### PR TITLE
feat(catalog): agent_name scoping in enrich_session (closes #22)

### DIFF
--- a/taosmd/catalog_pipeline.py
+++ b/taosmd/catalog_pipeline.py
@@ -205,6 +205,7 @@ class CatalogPipeline:
                             llm_url=self._llm_url,
                             model=model,
                             tier=tier,
+                            agent_name=agent_name,
                         )
                         enriched_count += 1
                     except Exception as exc:

--- a/taosmd/session_catalog.py
+++ b/taosmd/session_catalog.py
@@ -416,11 +416,20 @@ class SessionCatalog:
         self,
         session_id: int,
         max_lines: int = 100,
+        *,
+        agent_name: str | None = None,
     ) -> dict | None:
         """Get session metadata plus the raw event lines from its split file.
 
         Loads from the split file (fast) rather than seeking through the full
         day archive. Falls back to archive line-range if split file is missing.
+
+        Args:
+            session_id: primary key of the session to fetch.
+            max_lines:  maximum number of lines to return.
+            agent_name: optional agent slug. When set, only lines whose parsed
+                JSON ``agent_name`` field matches are included. When None
+                (default), all lines are returned unchanged.
         """
         row = self._conn.execute(
             "SELECT * FROM sessions WHERE id = ?", (session_id,)
@@ -431,13 +440,25 @@ class SessionCatalog:
         session = self._format(dict(row))
         lines: list[str] = []
 
+        def _accept_line(raw: str) -> bool:
+            """Return True if this raw JSONL line passes the agent_name filter."""
+            if agent_name is None:
+                return True
+            try:
+                event = json.loads(raw)
+                return event.get("agent_name") == agent_name
+            except (json.JSONDecodeError, AttributeError):
+                return False
+
         split_path = Path(row["split_file"]) if row["split_file"] else None
         if split_path and split_path.exists():
             with open(split_path, "r", encoding="utf-8") as f:
                 for line in f:
                     if len(lines) >= max_lines:
                         break
-                    lines.append(line.strip())
+                    stripped = line.strip()
+                    if _accept_line(stripped):
+                        lines.append(stripped)
         else:
             # Fallback: read from archive between line_start and line_end
             archive_path = Path(row["archive_file"])
@@ -455,7 +476,9 @@ class SessionCatalog:
                             break
                         if len(lines) >= max_lines:
                             break
-                        lines.append(line.strip())
+                        stripped = line.strip()
+                        if _accept_line(stripped):
+                            lines.append(stripped)
 
         session["archive_lines"] = lines
         session["lines_returned"] = len(lines)
@@ -513,6 +536,8 @@ class SessionCatalog:
         llm_url: str,
         model: str,
         tier: int = 2,
+        *,
+        agent_name: str | None = None,
     ) -> dict | None:
         """Enrich a catalog session with LLM-generated topic/description/category.
 
@@ -527,11 +552,14 @@ class SessionCatalog:
             llm_url:    base URL of the Ollama server (e.g. "http://localhost:11434").
             model:      model name to use for generation.
             tier:       tier to set on success (default 2 = LLM-enriched).
+            agent_name: optional agent slug to scope enrichment. When set, only
+                archive rows belonging to this agent are enriched. When None
+                (default), behaves as before — unscoped across all agents.
 
         Returns:
             Updated session dict, or None if session_id is not found.
         """
-        ctx = await self.get_session_context(session_id)
+        ctx = await self.get_session_context(session_id, agent_name=agent_name)
         if ctx is None:
             return None
 

--- a/tests/test_session_catalog.py
+++ b/tests/test_session_catalog.py
@@ -235,3 +235,100 @@ class TestEnricher:
         assert session_id in ids, (
             f"session_id {session_id} not found in FTS results: {ids}"
         )
+
+    def test_enrich_session_respects_agent_name(self):
+        """enrich_session with agent_name='alice' must not touch bob's session.
+
+        Two sessions are created: one whose split file contains only alice's
+        events, one whose split file contains only bob's events.  Enrichment
+        called with agent_name='alice' should leave bob's session at tier=1
+        (LLM unreachable, so even alice's tier stays at 1 — but the key
+        assertion is that bob's context comes back empty, meaning the enrichment
+        path received no content for that session and left the tier unchanged).
+        """
+        import tempfile
+        tmpdir = tempfile.TemporaryDirectory()
+        tmp = Path(tmpdir.name)
+
+        cat = _make_catalog(tmp)
+        _run(cat.init())
+
+        # Write a single archive file with events tagged for two agents.
+        archive_dir = tmp / "archive"
+        t = BASE_TS
+
+        alice_events = [
+            {
+                "timestamp": t,
+                "event_type": "conversation",
+                "agent_name": "alice",
+                "summary": "alice started coding",
+                "data": {},
+            },
+            {
+                "timestamp": t + 5 * 60,
+                "event_type": "conversation",
+                "agent_name": "alice",
+                "summary": "alice finished coding",
+                "data": {},
+            },
+        ]
+        bob_events = [
+            {
+                "timestamp": t + 55 * 60,
+                "event_type": "conversation",
+                "agent_name": "bob",
+                "summary": "bob reviewing PR",
+                "data": {},
+            },
+            {
+                "timestamp": t + 60 * 60,
+                "event_type": "conversation",
+                "agent_name": "bob",
+                "summary": "bob merged PR",
+                "data": {},
+            },
+        ]
+
+        _write_archive(archive_dir, alice_events + bob_events)
+        cat.split_day("2025-04-13")
+
+        sessions = _run(cat.lookup_date("2025-04-13"))
+        assert len(sessions) == 2, f"Expected 2 sessions, got {len(sessions)}"
+
+        # Both sessions start at tier=1.
+        assert sessions[0]["tier"] == 1
+        assert sessions[1]["tier"] == 1
+
+        alice_session_id = sessions[0]["id"]
+        bob_session_id = sessions[1]["id"]
+
+        # Call enrich with agent_name="alice". LLM is unreachable so tier stays
+        # at 1 for alice's session, but the important invariant is that bob's
+        # get_session_context returns no matching lines — the agent filter works.
+        _run(
+            cat.enrich_session(
+                alice_session_id,
+                llm_url="http://localhost:99999",
+                model="test-model",
+                tier=2,
+                agent_name="alice",
+            )
+        )
+
+        # Fetch context for bob's session scoped to alice — should be empty.
+        bob_ctx = _run(
+            cat.get_session_context(bob_session_id, agent_name="alice")
+        )
+        _run(cat.close())
+        tmpdir.cleanup()
+
+        assert bob_ctx is not None, "get_session_context returned None for bob's session"
+        assert bob_ctx["archive_lines"] == [], (
+            f"Expected no alice lines in bob's session, got: {bob_ctx['archive_lines']}"
+        )
+
+        # Bob's tier must remain 1 — enrichment was never called for it.
+        assert bob_ctx["tier"] == 1, (
+            f"Expected bob's tier=1, got {bob_ctx['tier']}"
+        )


### PR DESCRIPTION
## Summary

- Adds `agent_name: str | None = None` as a keyword-only parameter to `SessionCatalog.enrich_session` and `SessionCatalog.get_session_context`.
- When `agent_name` is set, `get_session_context` filters JSONL lines by matching the `agent_name` field in each parsed event, scoping the archive content fed to the LLM.
- When `agent_name` is None (default), behaviour is completely unchanged — existing callers are unaffected.
- Wires `agent_name` through in `catalog_pipeline.py` so the job worker's `agent_name` payload flows into `enrich_session` automatically.

Closes #22.

## Acceptance criteria met

- [x] `enrich_session` accepts `agent_name` as keyword-only — no positional-arg breakage for existing callers
- [x] `get_session_context` filters event lines by `agent_name` when set; passes all lines when None
- [x] `catalog_pipeline.py` passes `agent_name` through to `enrich_session`
- [x] Docstring updated with agent_name description
- [x] New test `test_enrich_session_respects_agent_name` seeds alice and bob events, asserts bob's session returns zero alice-scoped lines
- [x] All 85 existing tests still pass (no regressions)
- [x] `archive.py` not modified