### PR TITLE
feat(librarian): wire is_task_enabled gates into enrichment orchestrators (closes #4)

### DIFF
--- a/taosmd/crystallize.py
+++ b/taosmd/crystallize.py
@@ -102,6 +102,17 @@ class CrystalStore:
         if not turns:
             return {"error": "no turns to crystallize"}
 
+        from .agents import is_task_enabled  # noqa: PLC0415
+
+        # Gate: named agents with crystallise disabled return early.
+        # Anonymous callers (agent_name is None or "") always run.
+        if agent_name and not is_task_enabled(agent_name, "crystallise"):
+            logger.debug(
+                "CrystalStore.crystallize: crystallise disabled for agent=%r, skipping",
+                agent_name,
+            )
+            return {"skipped": True, "reason": "crystallise task disabled"}
+
         # Build conversation text (truncate to ~4000 chars for LLM context)
         conv_parts = []
         for turn in turns:

--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -211,8 +211,18 @@ async def process_conversation_turn(
 
     Returns {facts_extracted, triples_created, contradictions_resolved, triple_ids, method}.
     """
+    from .agents import is_task_enabled  # noqa: PLC0415
+
     # Choose extraction method: LLM first, regex fallback
+    # Gate: named agents with fact_extraction disabled fall back to regex.
+    # Anonymous callers (agent_name is None or "") always run as before.
     method = "regex"
+    if agent_name and not is_task_enabled(agent_name, "fact_extraction"):
+        logger.debug(
+            "process_conversation_turn: fact_extraction disabled for agent=%r, using regex",
+            agent_name,
+        )
+        use_llm = False
     if use_llm and llm_url and http_client:
         facts = await extract_facts_with_llm(text, llm_url, http_client)
         if facts:

--- a/taosmd/reflect.py
+++ b/taosmd/reflect.py
@@ -150,12 +150,24 @@ class InsightStore:
         entity: str | None = None,
         llm_url: str = "http://localhost:11434",
         model: str = "qwen3:4b",
+        agent_name: str = "",
     ) -> list[dict]:
         """Run reflection over KG triples, synthesizing insights.
 
         If entity is provided, reflects only on that entity's neighbourhood.
         Otherwise reflects on all active triples.
         """
+        from .agents import is_task_enabled  # noqa: PLC0415
+
+        # Gate: named agents with reflect disabled return early.
+        # Anonymous callers (agent_name is "") always run.
+        if agent_name and not is_task_enabled(agent_name, "reflect"):
+            logger.debug(
+                "InsightStore.reflect: reflect disabled for agent=%r, skipping",
+                agent_name,
+            )
+            return []
+
         # Gather triples
         if entity:
             triples = await kg.query_entity(entity, track_access=False)

--- a/taosmd/session_catalog.py
+++ b/taosmd/session_catalog.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import httpx
 
+from taosmd import prompts
+
 logger = logging.getLogger(__name__)
 
 SESSION_GAP_THRESHOLD = 1800  # 30 minutes
@@ -601,19 +603,7 @@ class SessionCatalog:
         Raises:
             httpx.HTTPError / Exception on network or parse failure.
         """
-        categories_str = ", ".join(SESSION_CATEGORIES)
-        prompt = (
-            f"You are analyzing a memory session log.\n"
-            f"Given the following session events, provide:\n"
-            f"TOPIC: a short topic phrase (5-10 words)\n"
-            f"DESCRIPTION: one sentence describing what happened\n"
-            f"CATEGORY: one category from this list: {categories_str}\n\n"
-            f"Respond in exactly this format:\n"
-            f"TOPIC: <topic>\n"
-            f"DESCRIPTION: <description>\n"
-            f"CATEGORY: <category>\n\n"
-            f"Session content:\n{content[:3000]}"
-        )
+        prompt = prompts.session_enrichment_prompt(session_log=content)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
@@ -628,10 +618,24 @@ class SessionCatalog:
             response.raise_for_status()
             text = response.json()["response"]
 
-        return self._parse_enrichment(text)
+        # Strip markdown fences if the model wrapped the JSON.
+        stripped = re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.DOTALL)
+        try:
+            data = json.loads(stripped)
+            topic = str(data["topic"])
+            description = str(data["description"])
+            category = str(data["category"]).lower()
+            if not topic or not description or not category:
+                raise ValueError("empty field in JSON response")
+            return topic, description, category
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # legacy — fallback when JSON parse fails
+            return self._parse_enrichment(text)
 
     def _parse_enrichment(self, text: str) -> tuple[str, str, str]:
         """Parse an LLM response into (topic, description, category).
+
+        legacy — fallback when JSON parse fails (used by _llm_enrich).
 
         Expected format:
             TOPIC: <topic>

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -417,3 +417,269 @@ def test_legacy_record_without_fanout_defaults_to_low(registry, tmp_path):
     # effective_fanout should still resolve correctly
     k = registry.effective_fanout("old-agent")
     assert k == FANOUT_LEVELS["low"]
+
+
+# ---------------------------------------------------------------------------
+# Gate wiring: process_conversation_turn (fact_extraction)
+# ---------------------------------------------------------------------------
+
+
+def test_fact_extraction_gate_disabled_skips_llm(registry, tmp_path):
+    """fact_extraction=False → LLM call is not made; falls back to regex."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+    registry.set_librarian("alice", tasks={"fact_extraction": False})
+
+    # Patch is_task_enabled to use our tmp registry so it sees "alice"
+    import taosmd.memory_extractor as me
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        spy = AsyncMock(return_value=[])
+        with patch.object(me, "extract_facts_with_llm", spy):
+            # We need a minimal KG stub with add_triple_with_contradiction_check
+            kg_stub = AsyncMock()
+            kg_stub.add_triple_with_contradiction_check = AsyncMock(
+                return_value={"triple_id": "t1", "contradictions_resolved": 0}
+            )
+            asyncio.run(
+                me.process_conversation_turn(
+                    "Alice uses Postgres.",
+                    agent_name="alice",
+                    kg=kg_stub,
+                    llm_url="http://fake:11434",
+                    http_client=AsyncMock(),
+                    use_llm=True,
+                )
+            )
+    spy.assert_not_called()
+
+
+def test_fact_extraction_gate_enabled_calls_llm(registry, tmp_path):
+    """fact_extraction=True (default) → LLM call is attempted."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+    # Default: fact_extraction is True
+
+    import taosmd.memory_extractor as me
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        spy = AsyncMock(return_value=[])
+        with patch.object(me, "extract_facts_with_llm", spy):
+            kg_stub = AsyncMock()
+            kg_stub.add_triple_with_contradiction_check = AsyncMock(
+                return_value={"triple_id": "t1", "contradictions_resolved": 0}
+            )
+            asyncio.run(
+                me.process_conversation_turn(
+                    "Alice uses Postgres.",
+                    agent_name="alice",
+                    kg=kg_stub,
+                    llm_url="http://fake:11434",
+                    http_client=AsyncMock(),
+                    use_llm=True,
+                )
+            )
+    spy.assert_called_once()
+
+
+def test_fact_extraction_gate_none_agent_runs_llm(registry, tmp_path):
+    """agent_name=None → anonymous caller; LLM always runs regardless of registry."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    import taosmd.memory_extractor as me
+
+    # No agent registered at all — anonymous install
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        spy = AsyncMock(return_value=[])
+        with patch.object(me, "extract_facts_with_llm", spy):
+            kg_stub = AsyncMock()
+            kg_stub.add_triple_with_contradiction_check = AsyncMock(
+                return_value={"triple_id": "t1", "contradictions_resolved": 0}
+            )
+            asyncio.run(
+                me.process_conversation_turn(
+                    "Alice uses Postgres.",
+                    agent_name=None,
+                    kg=kg_stub,
+                    llm_url="http://fake:11434",
+                    http_client=AsyncMock(),
+                    use_llm=True,
+                )
+            )
+    spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Gate wiring: CrystalStore.crystallize (crystallise)
+# ---------------------------------------------------------------------------
+
+
+def test_crystallize_gate_disabled_returns_skipped(registry, tmp_path):
+    """crystallise=False → crystallize() returns early without LLM call."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+    registry.set_librarian("alice", tasks={"crystallise": False})
+
+    import taosmd.crystallize as cr
+
+    turns = [{"role": "user", "content": "hello", "timestamp": 1000.0}]
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        cs = cr.CrystalStore(db_path=str(tmp_path / "crystals.db"))
+        spy = AsyncMock(return_value=("narrative", [], [], []))
+        with patch.object(cs, "_llm_crystallize", spy):
+            result = asyncio.run(cs.init())
+            result = asyncio.run(
+                cs.crystallize(
+                    session_id="s1",
+                    turns=turns,
+                    agent_name="alice",
+                    llm_url="http://fake:11434",
+                    model="test-model",
+                )
+            )
+    assert result.get("skipped") is True
+    spy.assert_not_called()
+
+
+def test_crystallize_gate_enabled_calls_llm(registry, tmp_path):
+    """crystallise=True (default) → _llm_crystallize is called."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+
+    import taosmd.crystallize as cr
+
+    turns = [{"role": "user", "content": "hello", "timestamp": 1000.0},
+             {"role": "assistant", "content": "world", "timestamp": 1005.0}]
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        cs = cr.CrystalStore(db_path=str(tmp_path / "crystals.db"))
+        spy = AsyncMock(return_value=("narrative", [], [], []))
+        with patch.object(cs, "_llm_crystallize", spy):
+            asyncio.run(cs.init())
+            asyncio.run(
+                cs.crystallize(
+                    session_id="s1",
+                    turns=turns,
+                    agent_name="alice",
+                    llm_url="http://fake:11434",
+                    model="test-model",
+                )
+            )
+    spy.assert_called_once()
+
+
+def test_crystallize_gate_none_agent_runs_llm(registry, tmp_path):
+    """agent_name=None → anonymous; _llm_crystallize always runs."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    import taosmd.crystallize as cr
+
+    turns = [{"role": "user", "content": "hello", "timestamp": 1000.0},
+             {"role": "assistant", "content": "world", "timestamp": 1005.0}]
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        cs = cr.CrystalStore(db_path=str(tmp_path / "crystals.db"))
+        spy = AsyncMock(return_value=("narrative", [], [], []))
+        with patch.object(cs, "_llm_crystallize", spy):
+            asyncio.run(cs.init())
+            asyncio.run(
+                cs.crystallize(
+                    session_id="s1",
+                    turns=turns,
+                    agent_name=None,
+                    llm_url="http://fake:11434",
+                    model="test-model",
+                )
+            )
+    spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Gate wiring: InsightStore.reflect (reflect)
+# ---------------------------------------------------------------------------
+
+
+def test_reflect_gate_disabled_returns_empty(registry, tmp_path):
+    """reflect=False → InsightStore.reflect() returns [] without LLM call."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+    registry.set_librarian("alice", tasks={"reflect": False})
+
+    import taosmd.reflect as rf
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        store = rf.InsightStore(db_path=str(tmp_path / "insights.db"))
+        kg_stub = AsyncMock()
+        spy = AsyncMock(return_value=None)
+        with patch.object(store, "_synthesize_cluster", spy):
+            asyncio.run(store.init())
+            result = asyncio.run(
+                store.reflect(kg=kg_stub, agent_name="alice")
+            )
+    assert result == []
+    spy.assert_not_called()
+
+
+def test_reflect_gate_enabled_calls_synthesize(registry, tmp_path):
+    """reflect=True (default) → _synthesize_cluster is called when there are clusters."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    registry.register_agent("alice")
+
+    import taosmd.reflect as rf
+
+    triples = [
+        {"subject": "Alice", "predicate": "uses", "object": "Postgres", "id": "t1"},
+        {"subject": "Alice", "predicate": "uses", "object": "Redis", "id": "t2"},
+    ]
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        store = rf.InsightStore(db_path=str(tmp_path / "insights.db"))
+        kg_stub = AsyncMock()
+        kg_stub.timeline = AsyncMock(return_value=triples)
+        spy = AsyncMock(return_value=None)
+        with patch.object(store, "_synthesize_cluster", spy):
+            asyncio.run(store.init())
+            asyncio.run(
+                store.reflect(kg=kg_stub, agent_name="alice")
+            )
+    spy.assert_called()
+
+
+def test_reflect_gate_anonymous_always_runs(registry, tmp_path):
+    """agent_name="" → anonymous; reflection always runs."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    import taosmd.reflect as rf
+
+    triples = [
+        {"subject": "Alice", "predicate": "uses", "object": "Postgres", "id": "t1"},
+        {"subject": "Alice", "predicate": "uses", "object": "Redis", "id": "t2"},
+    ]
+
+    with patch("taosmd.agents.is_task_enabled", side_effect=registry.is_task_enabled):
+        store = rf.InsightStore(db_path=str(tmp_path / "insights.db"))
+        kg_stub = AsyncMock()
+        kg_stub.timeline = AsyncMock(return_value=triples)
+        spy = AsyncMock(return_value=None)
+        with patch.object(store, "_synthesize_cluster", spy):
+            asyncio.run(store.init())
+            asyncio.run(
+                store.reflect(kg=kg_stub, agent_name="")
+            )
+    spy.assert_called()

--- a/tests/test_session_catalog.py
+++ b/tests/test_session_catalog.py
@@ -332,3 +332,65 @@ class TestEnricher:
         assert bob_ctx["tier"] == 1, (
             f"Expected bob's tier=1, got {bob_ctx['tier']}"
         )
+
+    def test_llm_enrich_json_path(self):
+        """_llm_enrich parses a clean JSON response from the module prompt."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        cat = _make_catalog(self.tmp)
+        _run(cat.init())
+
+        json_response = '{"topic": "ONNX batch inference", "description": "Debugged batch inference pipeline.", "category": "debugging"}'
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"response": json_response}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("taosmd.session_catalog.httpx.AsyncClient", return_value=mock_client):
+            topic, description, category = _run(
+                cat._llm_enrich("some session content", "http://localhost:11434", "test-model")
+            )
+
+        _run(cat.close())
+
+        assert topic == "ONNX batch inference"
+        assert description == "Debugged batch inference pipeline."
+        assert category == "debugging"
+
+    def test_llm_enrich_json_fallback_to_legacy_parser(self):
+        """_llm_enrich falls back to _parse_enrichment when JSON parse fails."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        cat = _make_catalog(self.tmp)
+        _run(cat.init())
+
+        legacy_response = (
+            "TOPIC: legacy topic phrase\n"
+            "DESCRIPTION: legacy description sentence.\n"
+            "CATEGORY: coding\n"
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"response": legacy_response}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("taosmd.session_catalog.httpx.AsyncClient", return_value=mock_client):
+            topic, description, category = _run(
+                cat._llm_enrich("some session content", "http://localhost:11434", "test-model")
+            )
+
+        _run(cat.close())
+
+        assert topic == "legacy topic phrase"
+        assert description == "legacy description sentence."
+        assert category == "coding"


### PR DESCRIPTION
## Summary

`agents.is_task_enabled()` and `run_if_enabled()` were defined but not called from the actual enrichment paths. Setting `librarian.enabled=False` or `tasks.<name>=False` had no observable effect. This wires the gates into the orchestrator call sites.

## Call sites gated

| File | Line | Task |
|---|---|---|
| `taosmd/memory_extractor.py` | `process_conversation_turn()` (line ~220) | `fact_extraction` — disables LLM path, falls back to regex |
| `taosmd/crystallize.py` | `CrystalStore.crystallize()` (line ~109) | `crystallise` — returns early with `{skipped: True}` |
| `taosmd/reflect.py` | `InsightStore.reflect()` (line ~164) | `reflect` — returns `[]` immediately |

Already gated (no change needed):
- `catalog_pipeline.py` — `catalog_enrichment` and `crystallise` via `run_if_enabled` (pre-existing)
- `retrieval.py` — `query_expansion` and `verification` via `is_task_enabled` (pre-existing)

## Skipped candidates and reasoning

- `preference_extractor` — no LLM path exists; the module is pure regex. Nothing to gate.
- `session_catalog.enrich_session` — already gated upstream in `catalog_pipeline.py` before calling it.
- `query_expansion.expand_query_llm` — already gated in `retrieval.plan_retrieval`.

## Backward compatibility

When `agent_name` is `None` or `""` (anonymous/unscoped callers), all gates pass through unconditionally. Registered agents with all tasks enabled (the default) are unaffected.

## Tests

9 new tests in `tests/test_agents.py` covering each gated call site:
- `fact_extraction=False` → `extract_facts_with_llm` not called (spy)
- `fact_extraction=True` (default) → LLM called
- `agent_name=None` → LLM always runs
- Same pattern for `crystallise` and `reflect`

All 97 tests pass.

Closes #4