### PR TITLE
fix(catalog): complete agent_name scoping for crystallize stage (#22)

### DIFF
--- a/taosmd/catalog_pipeline.py
+++ b/taosmd/catalog_pipeline.py
@@ -237,11 +237,11 @@ class CatalogPipeline:
             kg = TemporalKnowledgeGraph(db_path=self._kg_db)
             await kg.init()
 
-            sessions_fresh = await self.catalog.lookup_date(date)
+            sessions_fresh = await self.catalog.lookup_date(date, agent_name=agent_name or None)
             for session in sessions_fresh:
                 sid = session["id"]
                 try:
-                    ctx = await self.catalog.get_session_context(sid)
+                    ctx = await self.catalog.get_session_context(sid, agent_name=agent_name or None)
                     if ctx is None:
                         continue
 

--- a/taosmd/session_catalog.py
+++ b/taosmd/session_catalog.py
@@ -160,6 +160,13 @@ class SessionCatalog:
                 self._conn.execute(_sql)
             except Exception:
                 pass  # column already exists
+        # agent_name column — safe no-op if already present
+        try:
+            self._conn.execute(
+                "ALTER TABLE sessions ADD COLUMN agent_name TEXT DEFAULT ''"
+            )
+        except Exception:
+            pass
         try:
             self._conn.execute(
                 'CREATE INDEX IF NOT EXISTS idx_sessions_path '
@@ -285,6 +292,10 @@ class SessionCatalog:
             summaries = [e.get("summary", "") for e in group if e.get("summary")]
             topic = summaries[0][:80] if summaries else "Activity session"
 
+            # Derive agent_name from first event that carries the field
+            agent_names = [e.get("agent_name", "") for e in group if e.get("agent_name")]
+            session_agent = agent_names[0] if agent_names else ""
+
             # Build split file path: data/sessions/YYYY/MM/DD/session-NNN-<cat>-<slug>.jsonl
             category = "other"
             slug = _slugify(topic)
@@ -308,8 +319,8 @@ class SessionCatalog:
                 """INSERT INTO sessions
                    (date, start_time, end_time, topic, description, category,
                     archive_file, line_start, line_end, split_file,
-                    turn_count, tier, partial, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    turn_count, tier, partial, created_at, agent_name)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     date,
                     start_ts,
@@ -325,6 +336,7 @@ class SessionCatalog:
                     1,
                     1 if partial else 0,
                     now,
+                    session_agent,
                 ),
             )
             session_id = cursor.lastrowid
@@ -371,12 +383,25 @@ class SessionCatalog:
     # Queries
     # ------------------------------------------------------------------
 
-    async def lookup_date(self, date: str) -> list[dict]:
-        """Get all sessions for a specific date, ordered by start time."""
-        rows = self._conn.execute(
-            "SELECT * FROM sessions WHERE date = ? ORDER BY start_time",
-            (date,),
-        ).fetchall()
+    async def lookup_date(self, date: str, *, agent_name: str | None = None) -> list[dict]:
+        """Get all sessions for a specific date, ordered by start time.
+
+        Args:
+            date: YYYY-MM-DD string.
+            agent_name: optional agent slug. When set, only sessions whose
+                ``agent_name`` column matches are returned. When None (default),
+                all sessions for the date are returned.
+        """
+        if agent_name:
+            rows = self._conn.execute(
+                "SELECT * FROM sessions WHERE date = ? AND agent_name = ? ORDER BY start_time",
+                (date, agent_name),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM sessions WHERE date = ? ORDER BY start_time",
+                (date,),
+            ).fetchall()
         return [self._format(dict(r)) for r in rows]
 
     async def lookup_range(self, start_date: str, end_date: str) -> list[dict]:

--- a/tests/test_catalog_pipeline.py
+++ b/tests/test_catalog_pipeline.py
@@ -136,3 +136,78 @@ class TestPipelineDetectBestTier:
         assert tier in (1, 2), f"Expected tier 1 or 2, got {tier}"
         if tier == 2:
             assert model is not None, "Tier 2 should have a model name"
+
+
+class TestCrystallizeAgentScoping:
+
+    def setup_method(self, method):
+        import tempfile
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmpdir.name)
+
+    def teardown_method(self, method):
+        self._tmpdir.cleanup()
+
+    def test_crystallize_stage_passes_agent_name_to_lookup_date(self):
+        """index_day(agent_name='alice') must call lookup_date with agent_name='alice'
+        in the crystallize stage, so bob's sessions are never touched."""
+        from unittest.mock import AsyncMock, patch
+
+        t = BASE_TS
+
+        alice_events = [
+            {
+                "timestamp": t,
+                "event_type": "conversation",
+                "agent_name": "alice",
+                "summary": "alice started coding",
+                "data": {},
+            },
+        ]
+        bob_events = [
+            {
+                "timestamp": t + 55 * 60,
+                "event_type": "conversation",
+                "agent_name": "bob",
+                "summary": "bob reviewing PR",
+                "data": {},
+            },
+        ]
+
+        _write_archive(self.tmp / "archive", alice_events + bob_events)
+
+        pipeline = _make_pipeline(self.tmp)
+
+        lookup_calls: list[dict] = []
+
+        async def run():
+            await pipeline.init()
+
+            # Record calls to lookup_date so we can assert on agent_name.
+            original_lookup = pipeline.catalog.lookup_date
+
+            async def recording_lookup(date, *, agent_name=None):
+                lookup_calls.append({"date": date, "agent_name": agent_name})
+                return await original_lookup(date, agent_name=agent_name)
+
+            pipeline.catalog.lookup_date = recording_lookup
+
+            # Patch detect_best_tier → tier 2, and run_if_enabled → True so
+            # the crystallize block is entered (alice is not a registered agent).
+            with patch.object(
+                pipeline, "detect_best_tier", new=AsyncMock(return_value=(2, "test-model"))
+            ), patch("taosmd.catalog_pipeline.run_if_enabled", return_value=True):
+                await pipeline.index_day("2025-04-13", agent_name="alice")
+
+            await pipeline.close()
+
+        _run(run())
+
+        # The crystallize stage must have called lookup_date with agent_name="alice".
+        # (Other stages also call lookup_date unscoped — only the crystallize fix
+        # is verified here.)
+        scoped_calls = [c for c in lookup_calls if c["agent_name"] == "alice"]
+        assert scoped_calls, (
+            f"Expected at least one lookup_date call with agent_name='alice' "
+            f"(crystallize stage); got calls: {lookup_calls}"
+        )

--- a/tests/test_session_catalog.py
+++ b/tests/test_session_catalog.py
@@ -394,3 +394,60 @@ class TestEnricher:
         assert topic == "legacy topic phrase"
         assert description == "legacy description sentence."
         assert category == "coding"
+
+    def test_lookup_date_respects_agent_name(self):
+        """lookup_date(date, agent_name='alice') returns only alice's sessions;
+        lookup_date(date) returns both (backward compat)."""
+        import tempfile
+        tmpdir = tempfile.TemporaryDirectory()
+        tmp = Path(tmpdir.name)
+
+        cat = _make_catalog(tmp)
+        _run(cat.init())
+
+        archive_dir = tmp / "archive"
+        t = BASE_TS
+
+        alice_events = [
+            {
+                "timestamp": t,
+                "event_type": "conversation",
+                "agent_name": "alice",
+                "summary": "alice started coding",
+                "data": {},
+            },
+        ]
+        bob_events = [
+            {
+                "timestamp": t + 55 * 60,
+                "event_type": "conversation",
+                "agent_name": "bob",
+                "summary": "bob reviewing PR",
+                "data": {},
+            },
+        ]
+
+        _write_archive(archive_dir, alice_events + bob_events)
+        cat.split_day("2025-04-13")
+
+        # Unscoped — both sessions returned
+        all_sessions = _run(cat.lookup_date("2025-04-13"))
+        assert len(all_sessions) == 2, f"Expected 2 sessions total, got {len(all_sessions)}"
+
+        # Scoped to alice — only alice's session
+        alice_sessions = _run(cat.lookup_date("2025-04-13", agent_name="alice"))
+        assert len(alice_sessions) == 1, (
+            f"Expected 1 alice session, got {len(alice_sessions)}"
+        )
+        assert alice_sessions[0]["agent_name"] == "alice", (
+            f"Expected agent_name='alice', got {alice_sessions[0].get('agent_name')!r}"
+        )
+
+        # Scoped to bob — only bob's session
+        bob_sessions = _run(cat.lookup_date("2025-04-13", agent_name="bob"))
+        assert len(bob_sessions) == 1, (
+            f"Expected 1 bob session, got {len(bob_sessions)}"
+        )
+
+        _run(cat.close())
+        tmpdir.cleanup()


### PR DESCRIPTION
Follow-up to #24 per Kilo's review observation on issue #22.

## Changes

**1. `lookup_date` extended with `agent_name` kwarg** (`session_catalog.py`)
Added `agent_name: str | None = None` (keyword-only) to `SessionCatalog.lookup_date`. When set, adds `WHERE agent_name = ?` to the SQL query. Backward-compatible: `None` preserves original behaviour.

To support the SQL filter, `agent_name` is now stored as a column in the `sessions` table (migration added to `init()` — safe no-op if already present) and populated from the first tagged event during `split_day`.

**2. Crystallize stage wired through** (`catalog_pipeline.py` lines 240 and 244)
`index_day`'s crystallize stage now passes `agent_name` to both `lookup_date` and `get_session_context`, completing the scoping contract PR #24 intended to establish.

**3. Tests**
- `test_lookup_date_respects_agent_name` — seeds alice + bob sessions on same date; asserts scoped and unscoped returns are correct.
- `test_crystallize_stage_passes_agent_name_to_lookup_date` — patches `detect_best_tier` to tier 2 and `run_if_enabled` to True so the crystallize block runs; records `lookup_date` calls and asserts the scoped call with `agent_name='alice'` is present.

Closes #22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session catalog now supports agent-scoped filtering, enabling better organization and retrieval of sessions in multi-agent environments.
  * Agent context is automatically tracked and propagated throughout the entire indexing pipeline, ensuring consistent and reliable session management across different agents while maintaining full backward compatibility for existing workflows and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->