### PR TITLE
fix(prompts): align session_enrichment categories with SESSION_CATEGORIES

### DIFF
--- a/taosmd/prompts.py
+++ b/taosmd/prompts.py
@@ -177,8 +177,10 @@ Rules:
 - Topic is a noun phrase, not a sentence.
 - Description should quote a phrase from the log when possible. Do not
   paraphrase what was actually said.
-- Category is one of: question, decision, note, task, exchange, debug,
-  research, conversation. Pick "conversation" when nothing else fits.
+- Category is one of: coding, debugging, research, planning,
+  conversation, configuration, deployment, testing, documentation,
+  brainstorming, review, maintenance, other. Pick "other" when nothing
+  else fits.
 
 Quality bar:
 - Topic words appear in the log.


### PR DESCRIPTION
Follow-up to #26 (which bundled #3's refactor). Kilo's review on the now-closed #25 caught that `prompts.session_enrichment_prompt` listed 8 bespoke categories that didn't match `session_catalog.SESSION_CATEGORIES`:

- **Prompt listed**: question, decision, note, task, exchange, debug, research, conversation
- **Code expected**: coding, debugging, research, planning, conversation, configuration, deployment, testing, documentation, brainstorming, review, maintenance, other

Non-overlapping categories silently normalized to `"other"` via `if category not in SESSION_CATEGORIES: category = "other"`, degrading categorization on every enrichment.

Prompt now lists `SESSION_CATEGORIES` verbatim with `"other"` as the catch-all, matching the validation step.

## Why a separate PR
PR #25 originally carried this fix, but PR #26 squash-merged both #3 and #4 together (because #26's branch was based on feat/issue-3). That bundled #3's work onto master without this fix. #25's branch can no longer merge cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded category options for session enrichment to include coding, planning, configuration, deployment, testing, documentation, brainstorming, review, and maintenance.
  * Updated default fallback category behavior for improved categorization accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->