### PR TITLE
feat(bench): LoCoMo runner + prompt-opt + mem0 adapter (validated)

### DIFF
--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""LoCoMo benchmark runner for taosmd.
+
+Ingests each LoCoMo conversation into a fresh VectorMemory, runs retrieval
+against every QA, generates answers via Ollama, and scores with F1, BLEU-1,
+and an LLM judge. Output mirrors the Mem0 paper convention.
+
+Per-conversation QAs run concurrently (see ``--concurrency``) to cut wall
+time; conversations themselves remain sequential so vmem instances do not
+fight over the tempdir / embedding model load. Concurrency requires the
+Ollama server to be configured with ``OLLAMA_NUM_PARALLEL`` at least as
+large as ``--concurrency`` or requests will serialise on the server side.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from taosmd.vector_memory import VectorMemory  # noqa: E402
+from taosmd.retrieval import retrieve  # noqa: E402
+
+CATEGORY_NAMES = {
+    1: "Single-hop (1)",
+    2: "Temporal  (2)",
+    3: "Multi-hop (3)",
+    4: "Open-dom  (4)",
+    5: "Adversarial(5)",
+}
+
+ANSWER_PROMPT = """You are answering a question using retrieved conversation memory.
+Use the context below. For date/time questions, always answer with explicit absolute dates (e.g., "7 May 2023" or "June 2023") — never relative references like "last Saturday", "this month", or "next month". Copy the exact date format used in the conversation.
+If the answer is not directly stated but can be reasonably inferred from the context, give your best inference. Only reply "I don't know" if the context is unrelated to the question.
+Keep your answer to 1-2 short sentences.
+
+Context:
+{context}
+
+Question: {question}
+Answer:"""
+
+JUDGE_PROMPT = """You are grading a predicted answer against a reference answer.
+Reply with a single token: YES if the predicted answer matches the reference
+(same facts, minor wording differences are fine), otherwise NO.
+
+Question: {question}
+Reference: {reference}
+Predicted: {predicted}
+
+Reply YES or NO only."""
+
+_PUNCT = re.compile(r"[^\w\s]")
+
+
+def _git_sha() -> str:
+    try:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=root, stderr=subprocess.DEVNULL
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _tokenize(s: str) -> list[str]:
+    return [t for t in _PUNCT.sub(" ", s.lower().strip()).split() if t]
+
+
+def _f1(pred: str, ref: str) -> float:
+    p, r = _tokenize(pred), _tokenize(ref)
+    if not p or not r:
+        return 0.0
+    r_counts: dict[str, int] = {}
+    for tok in r:
+        r_counts[tok] = r_counts.get(tok, 0) + 1
+    overlap = 0
+    for tok in p:
+        if r_counts.get(tok, 0) > 0:
+            overlap += 1
+            r_counts[tok] -= 1
+    if overlap == 0:
+        return 0.0
+    precision = overlap / len(p)
+    recall = overlap / len(r)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _bleu1(pred: str, ref: str) -> float:
+    try:
+        from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+        smoothie = SmoothingFunction().method1
+        return float(sentence_bleu(
+            [_tokenize(ref)], _tokenize(pred),
+            weights=(1, 0, 0, 0), smoothing_function=smoothie,
+        ))
+    except Exception:
+        p, r = _tokenize(pred), _tokenize(ref)
+        if not p or not r:
+            return 0.0
+        r_counts: dict[str, int] = {}
+        for tok in r:
+            r_counts[tok] = r_counts.get(tok, 0) + 1
+        matches = 0
+        for tok in p:
+            if r_counts.get(tok, 0) > 0:
+                matches += 1
+                r_counts[tok] -= 1
+        precision = matches / len(p)
+        bp = 1.0 if len(p) >= len(r) else pow(2.718281828, 1 - len(r) / max(len(p), 1))
+        return precision * bp
+
+
+async def _ollama_generate(client: httpx.AsyncClient, url: str, model: str,
+                           prompt: str, temperature: float = 0.2) -> str:
+    resp = await client.post(
+        f"{url}/api/generate",
+        json={"model": model, "prompt": prompt, "stream": False,
+              "options": {"temperature": temperature}},
+    )
+    resp.raise_for_status()
+    return (resp.json().get("response") or "").strip()
+
+
+async def _judge(client: httpx.AsyncClient, url: str, model: str,
+                 question: str, reference: str, predicted: str) -> float:
+    try:
+        reply = await _ollama_generate(
+            client, url, model,
+            JUDGE_PROMPT.format(question=question, reference=reference, predicted=predicted),
+            temperature=0.0,
+        )
+    except Exception:
+        return 0.0
+    head = reply.strip().upper().split()
+    return 1.0 if head and head[0].startswith("YES") else 0.0
+
+
+def _session_keys(conversation: dict) -> list[tuple[str, str]]:
+    pairs = []
+    for key in conversation.keys():
+        if not key.startswith("session_") or key.endswith("_date_time"):
+            continue
+        parts = key.split("_")
+        if len(parts) != 2 or not parts[1].isdigit():
+            continue
+        if not isinstance(conversation.get(key), list):
+            continue
+        pairs.append((key, conversation.get(f"{key}_date_time", "")))
+    pairs.sort(key=lambda kv: int(kv[0].split("_")[1]))
+    return pairs
+
+
+async def _ingest_conversation(vmem: VectorMemory, conv: dict) -> tuple[int, float]:
+    conversation = conv.get("conversation", conv)
+    t0 = time.time()
+    added = 0
+    for session_key, dt in _session_keys(conversation):
+        for turn in conversation.get(session_key) or []:
+            text = (turn.get("text") or "").strip()
+            if not text:
+                continue
+            speaker = turn.get("speaker", "")
+            await vmem.add(
+                f"[{speaker}] {text}",
+                metadata={
+                    "dia_id": turn.get("dia_id", ""),
+                    "session": session_key,
+                    "datetime": dt,
+                    "speaker": speaker,
+                },
+            )
+            added += 1
+    return added, time.time() - t0
+
+
+async def _retrieve(strategy: str, query: str, vmem: VectorMemory, top_k: int) -> list[dict]:
+    if strategy == "vector-only":
+        raw = await vmem.search(query, limit=top_k)
+        return [{"text": r["text"], "metadata": r.get("metadata", {}),
+                 "score": r.get("similarity", 0.0)} for r in raw]
+    # TODO: wire cross-encoder reranker for strategy="full"; for now reuse retrieve() with vector source only.
+    hits = await retrieve(query, strategy="thorough", sources={"vector": vmem},
+                          limit=top_k, agent_name="locomo_eval")
+    return [{"text": h.get("text", ""),
+             "metadata": h.get("metadata", {}).get("metadata", h.get("metadata", {})),
+             "score": h.get("rrf_score", h.get("source_score", 0.0))} for h in hits]
+
+
+def _build_context(hits: list[dict]) -> str:
+    lines = []
+    for hit in hits:
+        meta = hit.get("metadata", {}) or {}
+        dt = meta.get("datetime", "")
+        prefix = f"[{dt}] " if dt else ""
+        lines.append(f"{prefix}{hit.get('text', '')}")
+    return "\n".join(lines)
+
+
+def _evidence_hits(hits: list[dict], evidence: list[str]) -> int:
+    if not evidence:
+        return 0
+    retrieved = {(h.get("metadata", {}) or {}).get("dia_id") for h in hits}
+    retrieved.discard(None)
+    return sum(1 for e in evidence if e in retrieved)
+
+
+async def _process_qa(qa: dict, conv_id: str, vmem: VectorMemory, client: httpx.AsyncClient,
+                      ollama_url: str, model: str, top_k: int, strategy: str) -> dict | None:
+    if "answer" not in qa:
+        return None
+    question = qa["question"]
+    reference = str(qa["answer"])
+    category = int(qa.get("category", 0))
+    evidence = qa.get("evidence", []) or []
+
+    t0 = time.time()
+    hits = await _retrieve(strategy, question, vmem, top_k)
+    retrieval_ms = (time.time() - t0) * 1000.0
+
+    context = _build_context(hits)
+    t1 = time.time()
+    try:
+        predicted = await _ollama_generate(
+            client, ollama_url, model,
+            ANSWER_PROMPT.format(context=context, question=question),
+        )
+    except Exception as exc:
+        predicted = f"[generation_error: {exc}]"
+    gen_ms = (time.time() - t1) * 1000.0
+
+    judge = await _judge(client, ollama_url, model, question, reference, predicted)
+
+    return {
+        "conversation_id": conv_id,
+        "question": question,
+        "reference": reference,
+        "predicted": predicted,
+        "category": category,
+        "f1": round(_f1(predicted, reference), 4),
+        "bleu1": round(_bleu1(predicted, reference), 4),
+        "judge": round(judge, 4),
+        "retrieval_ms": round(retrieval_ms, 2),
+        "gen_ms": round(gen_ms, 2),
+        "evidence_hits": _evidence_hits(hits, evidence),
+        "evidence_total": len(evidence),
+    }
+
+
+def _summary(rows: list[dict]) -> dict:
+    if not rows:
+        return {"count": 0, "f1": 0.0, "bleu1": 0.0, "judge": 0.0, "retrieval_recall": 0.0}
+    n = len(rows)
+    hit_rows = [r for r in rows if r.get("evidence_total", 0) > 0]
+    recall = (sum(1 for r in hit_rows if r["evidence_hits"] > 0) / len(hit_rows)) if hit_rows else 0.0
+    return {
+        "count": n,
+        "f1": round(sum(r["f1"] for r in rows) / n, 4),
+        "bleu1": round(sum(r["bleu1"] for r in rows) / n, 4),
+        "judge": round(sum(r["judge"] for r in rows) / n, 4),
+        "retrieval_recall": round(recall, 4),
+    }
+
+
+def _aggregate(results: list[dict]) -> tuple[dict, dict]:
+    by_cat: dict[str, list[dict]] = {}
+    for r in results:
+        by_cat.setdefault(str(r["category"]), []).append(r)
+    return {cat: _summary(rows) for cat, rows in by_cat.items()}, _summary(results)
+
+
+def _print_summary(meta: dict, by_category: dict, overall: dict) -> None:
+    sep, dash = "=" * 57, "-" * 57
+    print(sep)
+    print(f"LoCoMo Benchmark \u2014 taosmd (commit {meta.get('git_sha', 'unknown')})")
+    print(sep)
+    print(f"Conversations: {meta['conversations']} | Questions: {meta['total_qa']} | "
+          f"Model: {meta['model']} | Strategy: {meta['strategy']} | Top-K: {meta['top_k']}")
+    print(dash)
+    print(f"{'Category':<16} {'Count':>5} {'F1':>7} {'BLEU-1':>8} {'Judge':>8} {'R@K':>8}")
+    print(dash)
+    for cat in sorted(by_category.keys(), key=int):
+        s = by_category[cat]
+        label = CATEGORY_NAMES.get(int(cat), f"Cat {cat}")
+        recall = "-" if int(cat) == 5 else f"{s['retrieval_recall']:.2f}"
+        print(f"{label:<16} {s['count']:>5} {s['f1']:>7.2f} {s['bleu1']:>8.2f} "
+              f"{s['judge']:>8.2f} {recall:>8}")
+    print(dash)
+    print(f"{'Overall':<16} {overall['count']:>5} {overall['f1']:>7.2f} "
+          f"{overall['bleu1']:>8.2f} {overall['judge']:>8.2f} "
+          f"{overall['retrieval_recall']:>8.2f}")
+    print(sep)
+
+
+async def run(args: argparse.Namespace) -> int:
+    dataset_path = Path(args.dataset).expanduser()
+    if not dataset_path.exists():
+        print(f"ERROR: dataset not found: {dataset_path}", file=sys.stderr)
+        return 2
+    conversations = json.loads(dataset_path.read_text())[: args.conversations]
+
+    if args.category == "all":
+        include_cats = {1, 2, 3, 4}
+        if args.include_adversarial:
+            include_cats.add(5)
+    else:
+        include_cats = {int(args.category)}
+
+    results: list[dict] = []
+    total_seen = 0
+    failed_qa = 0
+    concurrency = max(1, int(args.concurrency))
+    sem = asyncio.Semaphore(concurrency)
+    progress_lock = asyncio.Lock()
+
+    async def _guarded(qa: dict, conv_id: str, vmem: VectorMemory,
+                       client: httpx.AsyncClient) -> dict | None:
+        nonlocal total_seen, failed_qa
+        async with sem:
+            try:
+                outcome = await _process_qa(qa, conv_id, vmem, client, args.ollama_url,
+                                            args.model, args.top_k, args.strategy)
+            except Exception as e:
+                async with progress_lock:
+                    failed_qa += 1
+                    print(f"  qa failed: {e!r}", flush=True)
+                return None
+        if outcome is not None:
+            async with progress_lock:
+                total_seen += 1
+                if total_seen % 25 == 0:
+                    print(f"  progress: {total_seen} QAs processed", flush=True)
+        return outcome
+
+    async with httpx.AsyncClient(timeout=args.timeout) as client:
+        for conv in conversations:
+            conv_id = conv.get("sample_id", "unknown")
+            tmp = tempfile.mkdtemp(prefix=f"locomo_{conv_id}_")
+            vmem = VectorMemory(
+                db_path=os.path.join(tmp, "vmem.db"),
+                qmd_url=args.qmd_url,
+                embed_mode=args.embed_mode,
+                onnx_path=args.onnx_path,
+            )
+            await vmem.init(http_client=client)
+            added, ingest_s = await _ingest_conversation(vmem, conv)
+            print(f"[{conv_id}] ingested {added} turns in {ingest_s:.1f}s", flush=True)
+
+            # Pick eligible QAs up-front. --per-conv-limit caps QAs per
+            # conversation (for balanced sampling); --limit is the global cap.
+            eligible: list[dict] = []
+            for qa in conv.get("qa", []) or []:
+                cat = int(qa.get("category", 0))
+                if cat not in include_cats:
+                    continue
+                if args.per_conv_limit and len(eligible) >= args.per_conv_limit:
+                    break
+                if args.limit and (total_seen + len(eligible)) >= args.limit:
+                    break
+                eligible.append(qa)
+
+            if eligible:
+                tasks = [_guarded(qa, conv_id, vmem, client) for qa in eligible]
+                gathered = await asyncio.gather(*tasks, return_exceptions=True)
+                for outcome in gathered:
+                    if isinstance(outcome, Exception) or outcome is None:
+                        continue
+                    results.append(outcome)
+            await vmem.close()
+            if args.limit and total_seen >= args.limit:
+                break
+
+    by_category, overall = _aggregate(results)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    meta = {
+        "run_id": args.run_id or "",
+        "timestamp": timestamp,
+        "model": args.model,
+        "top_k": args.top_k,
+        "strategy": args.strategy,
+        "total_qa": len(results),
+        "categories_included": sorted(include_cats),
+        "conversations": min(args.conversations, len(conversations)),
+        "git_sha": _git_sha(),
+        "dataset": str(dataset_path),
+        "concurrency": concurrency,
+        "failed_qa": failed_qa,
+    }
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        tag = f"_{args.run_id}" if args.run_id else ""
+        out_path = Path(os.path.dirname(os.path.abspath(__file__))) / "results" / f"locomo_{timestamp}{tag}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(
+        {"meta": meta, "by_category": by_category, "overall": overall, "results": results},
+        indent=2,
+    ))
+
+    _print_summary(meta, by_category, overall)
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_DATASET = os.environ.get(
+    "LOCOMO_DATASET",
+    os.path.join(_REPO_ROOT, "data", "locomo", "data", "locomo10.json"),
+)
+_DEFAULT_ONNX = os.environ.get(
+    "TAOSMD_ONNX_PATH",
+    os.path.join(_REPO_ROOT, "models", "minilm-onnx"),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="LoCoMo benchmark runner for taosmd")
+    p.add_argument("--dataset", default=_DEFAULT_DATASET,
+                   help=f"LoCoMo dataset JSON. Env: LOCOMO_DATASET (default: {_DEFAULT_DATASET})")
+    p.add_argument("--limit", type=int, default=0, help="Cap total QAs across all conversations (0=all)")
+    p.add_argument("--per-conv-limit", type=int, default=0,
+                   help="Cap QAs per conversation for balanced sampling (0=all eligible)")
+    p.add_argument("--conversations", type=int, default=10)
+    p.add_argument("--category", default="all")
+    p.add_argument("--include-adversarial", action="store_true")
+    p.add_argument("--qmd-url", default="http://localhost:7832")
+    p.add_argument("--embed-mode", choices=["qmd", "local", "onnx"], default="onnx",
+                   help="Embedding backend. Default onnx (Fedora reference stack).")
+    p.add_argument("--onnx-path", default=_DEFAULT_ONNX,
+                   help=f"Path to MiniLM ONNX model directory. Env: TAOSMD_ONNX_PATH (default: {_DEFAULT_ONNX})")
+    p.add_argument("--ollama-url", default="http://localhost:11434")
+    p.add_argument("--model", default="qwen3:4b")
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
+    p.add_argument("--out", default=None)
+    p.add_argument("--run-id", default=None)
+    p.add_argument(
+        "--concurrency", type=int, default=3,
+        help=("Max parallel QAs per conversation. Requires OLLAMA_NUM_PARALLEL "
+              ">= N on the Ollama server. Default 3; use 1 for sequential."),
+    )
+    p.add_argument(
+        "--timeout", type=float, default=120.0,
+        help="HTTP timeout for Ollama calls in seconds. Default 120 (was 60 — "
+             "bumped after observing p95 latency of 52s under concurrency=3).",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run(_parse_args())))

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -20,18 +20,18 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from tinyagentos.temporal_knowledge_graph import TemporalKnowledgeGraph
-from tinyagentos.archive import ArchiveStore
-from tinyagentos.memory_extractor import extract_facts_from_text, process_conversation_turn
-from tinyagentos.context_assembler import ContextAssembler
-from tinyagentos.vector_memory import VectorMemory
+from taosmd.knowledge_graph import TemporalKnowledgeGraph
+from taosmd.archive import ArchiveStore
+from taosmd.memory_extractor import extract_facts_from_text, process_conversation_turn
+from taosmd.context_assembler import ContextAssembler
+from taosmd.vector_memory import VectorMemory
 
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "longmemeval_oracle.json")
 
-# Remote LLM for answer generation (Ollama on Fedora with RTX 3060)
-REMOTE_LLM_URL = "http://192.168.6.108:11434"
-REMOTE_LLM_MODEL = "qwen2.5:3b"
+# Remote LLM for answer generation (override via TAOSMD_OLLAMA_URL env var)
+REMOTE_LLM_URL = os.environ.get("TAOSMD_OLLAMA_URL", "http://localhost:11434")
+REMOTE_LLM_MODEL = os.environ.get("TAOSMD_OLLAMA_MODEL", "qwen2.5:3b")
 
 ANSWER_PROMPT = """Based on the following context from past conversations, answer the question.
 If the answer is not in the context, say "I don't know."
@@ -149,7 +149,14 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
         tmp = tempfile.mkdtemp()
         kg = TemporalKnowledgeGraph(db_path=os.path.join(tmp, "kg.db"))
         archive = ArchiveStore(archive_dir=os.path.join(tmp, "archive"), index_path=os.path.join(tmp, "idx.db"))
-        vmem = VectorMemory(db_path=os.path.join(tmp, "vectors.db"))
+        vmem = VectorMemory(
+            db_path=os.path.join(tmp, "vectors.db"),
+            embed_mode=os.environ.get("TAOSMD_EMBED_MODE", "onnx"),
+            onnx_path=os.environ.get(
+                "TAOSMD_ONNX_PATH",
+                os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "models", "minilm-onnx"),
+            ),
+        )
         await kg.init()
         await archive.init()
 

--- a/benchmarks/mem0_locomo_runner.py
+++ b/benchmarks/mem0_locomo_runner.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""LoCoMo runner using mem0 as the memory layer.
+
+Apples-to-apples comparison harness: same generator, prompt, judge, and
+dataset as benchmarks/locomo_runner.py, but retrieval happens via
+mem0.search() instead of taosmd's native retrieval. Runs require mem0ai
+installed (`pip install mem0ai`) and an Ollama endpoint with the requested
+model + nomic-embed-text embedder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Shared constants (duplicated from locomo_runner.py to keep this file
+# self-contained; both runners must stay in sync if the prompts change).
+# ---------------------------------------------------------------------------
+
+CATEGORY_NAMES = {
+    1: "Single-hop (1)",
+    2: "Temporal  (2)",
+    3: "Multi-hop (3)",
+    4: "Open-dom  (4)",
+    5: "Adversarial(5)",
+}
+
+ANSWER_PROMPT = """You are answering a question using retrieved conversation memory.
+Use the context below. For date/time questions, always answer with explicit absolute dates (e.g., "7 May 2023" or "June 2023") — never relative references like "last Saturday", "this month", or "next month". Copy the exact date format used in the conversation.
+If the answer is not directly stated but can be reasonably inferred from the context, give your best inference. Only reply "I don't know" if the context is unrelated to the question.
+Keep your answer to 1-2 short sentences.
+
+Context:
+{context}
+
+Question: {question}
+Answer:"""
+
+JUDGE_PROMPT = """You are grading a predicted answer against a reference answer.
+Reply with a single token: YES if the predicted answer matches the reference
+(same facts, minor wording differences are fine), otherwise NO.
+
+Question: {question}
+Reference: {reference}
+Predicted: {predicted}
+
+Reply YES or NO only."""
+
+_PUNCT = re.compile(r"[^\w\s]")
+
+
+# ---------------------------------------------------------------------------
+# Utilities (identical to locomo_runner.py)
+# ---------------------------------------------------------------------------
+
+def _git_sha() -> str:
+    try:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=root, stderr=subprocess.DEVNULL
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _tokenize(s: str) -> list[str]:
+    return [t for t in _PUNCT.sub(" ", s.lower().strip()).split() if t]
+
+
+def _f1(pred: str, ref: str) -> float:
+    p, r = _tokenize(pred), _tokenize(ref)
+    if not p or not r:
+        return 0.0
+    r_counts: dict[str, int] = {}
+    for tok in r:
+        r_counts[tok] = r_counts.get(tok, 0) + 1
+    overlap = 0
+    for tok in p:
+        if r_counts.get(tok, 0) > 0:
+            overlap += 1
+            r_counts[tok] -= 1
+    if overlap == 0:
+        return 0.0
+    precision = overlap / len(p)
+    recall = overlap / len(r)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _bleu1(pred: str, ref: str) -> float:
+    try:
+        from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+        smoothie = SmoothingFunction().method1
+        return float(sentence_bleu(
+            [_tokenize(ref)], _tokenize(pred),
+            weights=(1, 0, 0, 0), smoothing_function=smoothie,
+        ))
+    except Exception:
+        p, r = _tokenize(pred), _tokenize(ref)
+        if not p or not r:
+            return 0.0
+        r_counts: dict[str, int] = {}
+        for tok in r:
+            r_counts[tok] = r_counts.get(tok, 0) + 1
+        matches = 0
+        for tok in p:
+            if r_counts.get(tok, 0) > 0:
+                matches += 1
+                r_counts[tok] -= 1
+        precision = matches / len(p)
+        bp = 1.0 if len(p) >= len(r) else pow(2.718281828, 1 - len(r) / max(len(p), 1))
+        return precision * bp
+
+
+async def _ollama_generate(client: httpx.AsyncClient, url: str, model: str,
+                           prompt: str, temperature: float = 0.2) -> str:
+    resp = await client.post(
+        f"{url}/api/generate",
+        json={"model": model, "prompt": prompt, "stream": False,
+              "options": {"temperature": temperature}},
+    )
+    resp.raise_for_status()
+    return (resp.json().get("response") or "").strip()
+
+
+async def _judge(client: httpx.AsyncClient, url: str, model: str,
+                 question: str, reference: str, predicted: str) -> float:
+    try:
+        reply = await _ollama_generate(
+            client, url, model,
+            JUDGE_PROMPT.format(question=question, reference=reference, predicted=predicted),
+            temperature=0.0,
+        )
+    except Exception:
+        return 0.0
+    head = reply.strip().upper().split()
+    return 1.0 if head and head[0].startswith("YES") else 0.0
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo data helpers (verbatim from locomo_runner.py)
+# ---------------------------------------------------------------------------
+
+def _session_keys(conversation: dict) -> list[tuple[str, str]]:
+    pairs = []
+    for key in conversation.keys():
+        if not key.startswith("session_") or key.endswith("_date_time"):
+            continue
+        parts = key.split("_")
+        if len(parts) != 2 or not parts[1].isdigit():
+            continue
+        if not isinstance(conversation.get(key), list):
+            continue
+        pairs.append((key, conversation.get(f"{key}_date_time", "")))
+    pairs.sort(key=lambda kv: int(kv[0].split("_")[1]))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Scoring / aggregate (identical to locomo_runner.py)
+# ---------------------------------------------------------------------------
+
+def _summary(rows: list[dict]) -> dict:
+    if not rows:
+        return {"count": 0, "f1": 0.0, "bleu1": 0.0, "judge": 0.0, "retrieval_recall": 0.0}
+    n = len(rows)
+    hit_rows = [r for r in rows if r.get("evidence_total", 0) > 0]
+    recall = (sum(1 for r in hit_rows if r["evidence_hits"] > 0) / len(hit_rows)) if hit_rows else 0.0
+    return {
+        "count": n,
+        "f1": round(sum(r["f1"] for r in rows) / n, 4),
+        "bleu1": round(sum(r["bleu1"] for r in rows) / n, 4),
+        "judge": round(sum(r["judge"] for r in rows) / n, 4),
+        "retrieval_recall": round(recall, 4),
+    }
+
+
+def _aggregate(results: list[dict]) -> tuple[dict, dict]:
+    by_cat: dict[str, list[dict]] = {}
+    for r in results:
+        by_cat.setdefault(str(r["category"]), []).append(r)
+    return {cat: _summary(rows) for cat, rows in by_cat.items()}, _summary(results)
+
+
+def _print_summary(meta: dict, by_category: dict, overall: dict) -> None:
+    sep, dash = "=" * 57, "-" * 57
+    print(sep)
+    print(f"LoCoMo Benchmark \u2014 mem0 (commit {meta.get('git_sha', 'unknown')})")
+    print(sep)
+    print(f"Conversations: {meta['conversations']} | Questions: {meta['total_qa']} | "
+          f"Model: {meta['model']} | Top-K: {meta['top_k']}")
+    print(dash)
+    print(f"{'Category':<16} {'Count':>5} {'F1':>7} {'BLEU-1':>8} {'Judge':>8} {'R@K':>8}")
+    print(dash)
+    for cat in sorted(by_category.keys(), key=int):
+        s = by_category[cat]
+        label = CATEGORY_NAMES.get(int(cat), f"Cat {cat}")
+        recall = "-" if int(cat) == 5 else f"{s['retrieval_recall']:.2f}"
+        print(f"{label:<16} {s['count']:>5} {s['f1']:>7.2f} {s['bleu1']:>8.2f} "
+              f"{s['judge']:>8.2f} {recall:>8}")
+    print(dash)
+    print(f"{'Overall':<16} {overall['count']:>5} {overall['f1']:>7.2f} "
+          f"{overall['bleu1']:>8.2f} {overall['judge']:>8.2f} "
+          f"{overall['retrieval_recall']:>8.2f}")
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
+# mem0 integration
+# ---------------------------------------------------------------------------
+
+def _build_mem0_config(args: argparse.Namespace) -> dict:
+    return {
+        "llm": {
+            "provider": "ollama",
+            "config": {
+                "model": args.model,
+                "ollama_base_url": args.ollama_url,
+                "temperature": 0.2,
+            },
+        },
+        "embedder": {
+            "provider": "ollama",
+            "config": {
+                "model": "nomic-embed-text",
+                "ollama_base_url": args.ollama_url,
+            },
+        },
+        "vector_store": {
+            "provider": "chroma",
+            "config": {
+                "collection_name": f"locomo_{args.run_id}",
+                "path": f"/tmp/mem0_{args.run_id}_chroma",
+            },
+        },
+    }
+
+
+def _ingest_conversation_mem0(memory, conv: dict, conv_id: str) -> tuple[int, float]:
+    """Add all turns from a LoCoMo conversation into mem0.
+
+    mem0.add() is synchronous, so this is a plain function called from the
+    async runner via run_in_executor to avoid blocking the event loop.
+    """
+    conversation = conv.get("conversation", conv)
+    messages: list[dict] = []
+    for session_key, dt in _session_keys(conversation):
+        for turn in conversation.get(session_key) or []:
+            text = (turn.get("text") or "").strip()
+            if not text:
+                continue
+            speaker = turn.get("speaker", "")
+            role = "assistant" if speaker.lower() in ("ai", "assistant", "bot") else "user"
+            prefix = f"[{dt}] " if dt else ""
+            messages.append({"role": role, "content": f"{prefix}[{speaker}] {text}"})
+
+    t0 = time.time()
+    if messages:
+        memory.add(messages, user_id=conv_id)
+    elapsed = time.time() - t0
+    return len(messages), elapsed
+
+
+def _mem0_search(memory, question: str, conv_id: str, top_k: int) -> list[str]:
+    """Synchronous wrapper; returns a list of memory text strings."""
+    results = memory.search(question, user_id=conv_id, limit=top_k)
+    # mem0 returns a list of dicts with a "memory" key (the stored fact) and "score".
+    return [r["memory"] for r in results if r.get("memory")]
+
+
+# ---------------------------------------------------------------------------
+# Per-QA processing
+# ---------------------------------------------------------------------------
+
+async def _process_qa_mem0(
+    qa: dict,
+    conv_id: str,
+    memory,
+    client: httpx.AsyncClient,
+    ollama_url: str,
+    model: str,
+    top_k: int,
+    loop: asyncio.AbstractEventLoop,
+) -> dict | None:
+    if "answer" not in qa:
+        return None
+    question = qa["question"]
+    reference = str(qa["answer"])
+    category = int(qa.get("category", 0))
+    evidence = qa.get("evidence", []) or []
+
+    t0 = time.time()
+    try:
+        # mem0.search is synchronous; offload to thread pool to avoid blocking.
+        context_chunks = await loop.run_in_executor(
+            None, _mem0_search, memory, question, conv_id, top_k
+        )
+    except Exception as exc:
+        return {
+            "conversation_id": conv_id,
+            "question": question,
+            "reference": reference,
+            "predicted": "",
+            "category": category,
+            "f1": 0.0,
+            "bleu1": 0.0,
+            "judge": 0.0,
+            "retrieval_ms": 0.0,
+            "gen_ms": 0.0,
+            # evidence_hits/evidence_total not computable without dia_id metadata from
+            # mem0's stored facts (mem0 doesn't preserve per-turn dia_ids). Set to 0.
+            # TODO: if mem0 exposes metadata round-trip, wire dia_id here.
+            "evidence_hits": 0,
+            "evidence_total": len(evidence),
+            "error": str(exc),
+        }
+    retrieval_ms = (time.time() - t0) * 1000.0
+
+    context = "\n---\n".join(context_chunks) if context_chunks else ""
+
+    t1 = time.time()
+    try:
+        predicted = await _ollama_generate(
+            client, ollama_url, model,
+            ANSWER_PROMPT.format(context=context, question=question),
+        )
+    except Exception as exc:
+        predicted = ""
+        gen_ms = (time.time() - t1) * 1000.0
+        return {
+            "conversation_id": conv_id,
+            "question": question,
+            "reference": reference,
+            "predicted": predicted,
+            "category": category,
+            "f1": 0.0,
+            "bleu1": 0.0,
+            "judge": 0.0,
+            "retrieval_ms": round(retrieval_ms, 2),
+            "gen_ms": round(gen_ms, 2),
+            "evidence_hits": 0,
+            "evidence_total": len(evidence),
+            "error": str(exc),
+        }
+    gen_ms = (time.time() - t1) * 1000.0
+
+    judge = await _judge(client, ollama_url, model, question, reference, predicted)
+
+    return {
+        "conversation_id": conv_id,
+        "question": question,
+        "reference": reference,
+        "predicted": predicted,
+        "category": category,
+        "f1": round(_f1(predicted, reference), 4),
+        "bleu1": round(_bleu1(predicted, reference), 4),
+        "judge": round(judge, 4),
+        "retrieval_ms": round(retrieval_ms, 2),
+        "gen_ms": round(gen_ms, 2),
+        # mem0 stored facts don't carry original dia_id metadata, so we cannot
+        # match against the LoCoMo gold evidence list. Set evidence_hits to 0.
+        # TODO: wire dia_id if mem0 adds metadata pass-through in a future release.
+        "evidence_hits": 0,
+        "evidence_total": len(evidence),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main run loop
+# ---------------------------------------------------------------------------
+
+async def run(args: argparse.Namespace) -> int:
+    try:
+        from mem0 import Memory  # noqa: PLC0415
+    except ImportError:
+        print("ERROR: mem0ai is not installed. Run: pip install mem0ai", file=sys.stderr)
+        return 1
+
+    dataset_path = Path(args.dataset).expanduser()
+    if not dataset_path.exists():
+        print(f"ERROR: dataset not found: {dataset_path}", file=sys.stderr)
+        return 2
+    conversations = json.loads(dataset_path.read_text())[: args.conversations]
+
+    if args.category == "all":
+        include_cats = {1, 2, 3, 4}
+        if args.include_adversarial:
+            include_cats.add(5)
+    else:
+        include_cats = {int(args.category)}
+
+    config = _build_mem0_config(args)
+    memory = Memory.from_config(config)
+
+    results: list[dict] = []
+    total_seen = 0
+    failed_qa = 0
+    concurrency = max(1, int(args.concurrency))
+    sem = asyncio.Semaphore(concurrency)
+    progress_lock = asyncio.Lock()
+    loop = asyncio.get_event_loop()
+
+    async def _guarded(qa: dict, conv_id: str) -> dict | None:
+        nonlocal total_seen, failed_qa
+        async with sem:
+            try:
+                outcome = await _process_qa_mem0(
+                    qa, conv_id, memory, client, args.ollama_url,
+                    args.model, args.top_k, loop,
+                )
+            except Exception as e:
+                async with progress_lock:
+                    failed_qa += 1
+                    print(f"  qa failed: {e!r}", flush=True)
+                return None
+        if outcome is not None:
+            async with progress_lock:
+                total_seen += 1
+                if total_seen % 25 == 0:
+                    print(f"  progress: {total_seen} QAs processed", flush=True)
+        return outcome
+
+    async with httpx.AsyncClient(timeout=args.timeout) as client:
+        for conv in conversations:
+            conv_id = conv.get("sample_id", "unknown")
+
+            # Ingest phase: synchronous mem0.add — offload to thread pool.
+            added, ingest_s = await loop.run_in_executor(
+                None, _ingest_conversation_mem0, memory, conv, conv_id
+            )
+            print(f"[{conv_id}] ingested {added} turns to mem0 in {ingest_s:.1f}s", flush=True)
+
+            eligible: list[dict] = []
+            for qa in conv.get("qa", []) or []:
+                cat = int(qa.get("category", 0))
+                if cat not in include_cats:
+                    continue
+                if args.per_conv_limit and len(eligible) >= args.per_conv_limit:
+                    break
+                if args.limit and (total_seen + len(eligible)) >= args.limit:
+                    break
+                eligible.append(qa)
+
+            if eligible:
+                tasks = [_guarded(qa, conv_id) for qa in eligible]
+                gathered = await asyncio.gather(*tasks, return_exceptions=True)
+                for outcome in gathered:
+                    if isinstance(outcome, Exception) or outcome is None:
+                        continue
+                    results.append(outcome)
+
+            if args.limit and total_seen >= args.limit:
+                break
+
+    by_category, overall = _aggregate(results)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    meta = {
+        "run_id": args.run_id or "",
+        "timestamp": timestamp,
+        "model": args.model,
+        "memory_backend": "mem0",
+        "top_k": args.top_k,
+        "total_qa": len(results),
+        "categories_included": sorted(include_cats),
+        "conversations": min(args.conversations, len(conversations)),
+        "git_sha": _git_sha(),
+        "dataset": str(dataset_path),
+        "concurrency": concurrency,
+        "failed_qa": failed_qa,
+    }
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        tag = f"_{args.run_id}" if args.run_id else ""
+        out_path = (
+            Path(os.path.dirname(os.path.abspath(__file__)))
+            / "results"
+            / f"locomo_{timestamp}{tag}_full_mem0_e2b.json"
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(
+        {"meta": meta, "by_category": by_category, "overall": overall, "results": results},
+        indent=2,
+    ))
+
+    _print_summary(meta, by_category, overall)
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_MEM0_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_MEM0_DEFAULT_DATASET = os.environ.get(
+    "LOCOMO_DATASET",
+    os.path.join(_MEM0_REPO_ROOT, "data", "locomo", "data", "locomo10.json"),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="LoCoMo benchmark runner using mem0 as the memory layer"
+    )
+    p.add_argument("--dataset", default=_MEM0_DEFAULT_DATASET,
+                   help=f"LoCoMo dataset JSON. Env: LOCOMO_DATASET (default: {_MEM0_DEFAULT_DATASET})")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Cap total QAs across all conversations (0=all)")
+    p.add_argument("--per-conv-limit", type=int, default=0,
+                   help="Cap QAs per conversation for balanced sampling (0=all eligible)")
+    p.add_argument("--conversations", type=int, default=10)
+    p.add_argument("--category", default="all")
+    p.add_argument("--include-adversarial", action="store_true")
+    p.add_argument(
+        "--ollama-url",
+        default=os.environ.get("TAOSMD_OLLAMA_URL", "http://localhost:11434"),
+        help="Ollama base URL. Env: TAOSMD_OLLAMA_URL (default http://localhost:11434)",
+    )
+    p.add_argument("--model", default="gemma4:e2b")
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--out", default=None)
+    p.add_argument("--run-id", default=None)
+    p.add_argument(
+        "--concurrency", type=int, default=3,
+        help=("Max parallel QAs per conversation. Requires OLLAMA_NUM_PARALLEL "
+              ">= N on the Ollama server. Default 3; use 1 for sequential."),
+    )
+    p.add_argument(
+        "--timeout", type=float, default=120.0,
+        help="HTTP timeout for Ollama calls in seconds. Default 120.",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run(_parse_args())))

--- a/benchmarks/mempalace_locomo_runner.py
+++ b/benchmarks/mempalace_locomo_runner.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""MemPalace LoCoMo adapter.
+
+Same generator, prompt, judge, and dataset as benchmarks/locomo_runner.py and
+benchmarks/mem0_locomo_runner.py — only the retrieval layer changes. Requires
+`pip install mempalace`.
+
+Per-conversation palace strategy: each LoCoMo conversation gets its own palace
+directory at /tmp/mempalace_{run_id}_{conv_id}/ so search() naturally scopes to
+that conversation without wing/room filters. This avoids the need for a shared
+palace with wing= scoping and makes it trivial to delete per-conv state
+afterwards if desired.
+
+Ingest strategy: if a Python ingest API is available (MemoryStack or similar in
+mempalace.layers), we use it. If no clean Python ingest API is found, we write
+each conversation's turns to a temporary text file and invoke `mempalace mine
+<path>` via subprocess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Shared constants (duplicated from locomo_runner.py / mem0_locomo_runner.py to
+# keep this file self-contained; all three runners must stay in sync if prompts
+# change).
+# ---------------------------------------------------------------------------
+
+CATEGORY_NAMES = {
+    1: "Single-hop (1)",
+    2: "Temporal  (2)",
+    3: "Multi-hop (3)",
+    4: "Open-dom  (4)",
+    5: "Adversarial(5)",
+}
+
+ANSWER_PROMPT = """You are answering a question using retrieved conversation memory.
+Use the context below. For date/time questions, always answer with explicit absolute dates (e.g., "7 May 2023" or "June 2023") — never relative references like "last Saturday", "this month", or "next month". Copy the exact date format used in the conversation.
+If the answer is not directly stated but can be reasonably inferred from the context, give your best inference. Only reply "I don't know" if the context is unrelated to the question.
+Keep your answer to 1-2 short sentences.
+
+Context:
+{context}
+
+Question: {question}
+Answer:"""
+
+JUDGE_PROMPT = """You are grading a predicted answer against a reference answer.
+Reply with a single token: YES if the predicted answer matches the reference
+(same facts, minor wording differences are fine), otherwise NO.
+
+Question: {question}
+Reference: {reference}
+Predicted: {predicted}
+
+Reply YES or NO only."""
+
+_PUNCT = re.compile(r"[^\w\s]")
+
+# MemPalace doesn't round-trip LoCoMo dia_id metadata, so retrieval recall
+# cannot be computed. Both fields are reported as None throughout.
+_EVIDENCE_UNAVAILABLE: dict = {"evidence_hits": None, "evidence_total": None}
+
+
+# ---------------------------------------------------------------------------
+# Utilities (identical to locomo_runner.py and mem0_locomo_runner.py)
+# ---------------------------------------------------------------------------
+
+def _git_sha() -> str:
+    try:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=root, stderr=subprocess.DEVNULL
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _tokenize(s: str) -> list[str]:
+    return [t for t in _PUNCT.sub(" ", s.lower().strip()).split() if t]
+
+
+def _f1(pred: str, ref: str) -> float:
+    p, r = _tokenize(pred), _tokenize(ref)
+    if not p or not r:
+        return 0.0
+    r_counts: dict[str, int] = {}
+    for tok in r:
+        r_counts[tok] = r_counts.get(tok, 0) + 1
+    overlap = 0
+    for tok in p:
+        if r_counts.get(tok, 0) > 0:
+            overlap += 1
+            r_counts[tok] -= 1
+    if overlap == 0:
+        return 0.0
+    precision = overlap / len(p)
+    recall = overlap / len(r)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _bleu1(pred: str, ref: str) -> float:
+    try:
+        from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+        smoothie = SmoothingFunction().method1
+        return float(sentence_bleu(
+            [_tokenize(ref)], _tokenize(pred),
+            weights=(1, 0, 0, 0), smoothing_function=smoothie,
+        ))
+    except Exception:
+        p, r = _tokenize(pred), _tokenize(ref)
+        if not p or not r:
+            return 0.0
+        r_counts: dict[str, int] = {}
+        for tok in r:
+            r_counts[tok] = r_counts.get(tok, 0) + 1
+        matches = 0
+        for tok in p:
+            if r_counts.get(tok, 0) > 0:
+                matches += 1
+                r_counts[tok] -= 1
+        precision = matches / len(p)
+        bp = 1.0 if len(p) >= len(r) else pow(2.718281828, 1 - len(r) / max(len(p), 1))
+        return precision * bp
+
+
+async def _ollama_generate(client: httpx.AsyncClient, url: str, model: str,
+                           prompt: str, temperature: float = 0.2) -> str:
+    resp = await client.post(
+        f"{url}/api/generate",
+        json={"model": model, "prompt": prompt, "stream": False,
+              "options": {"temperature": temperature}},
+    )
+    resp.raise_for_status()
+    return (resp.json().get("response") or "").strip()
+
+
+async def _judge(client: httpx.AsyncClient, url: str, model: str,
+                 question: str, reference: str, predicted: str) -> float | None:
+    """Returns 1.0/0.0 on success, None on transport failure."""
+    try:
+        reply = await _ollama_generate(
+            client, url, model,
+            JUDGE_PROMPT.format(question=question, reference=reference, predicted=predicted),
+            temperature=0.0,
+        )
+    except Exception:
+        return None
+    head = reply.strip().upper().split()
+    return 1.0 if head and head[0].startswith("YES") else 0.0
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo data helpers (verbatim from locomo_runner.py)
+# ---------------------------------------------------------------------------
+
+def _session_keys(conversation: dict) -> list[tuple[str, str]]:
+    pairs = []
+    for key in conversation.keys():
+        if not key.startswith("session_") or key.endswith("_date_time"):
+            continue
+        parts = key.split("_")
+        if len(parts) != 2 or not parts[1].isdigit():
+            continue
+        if not isinstance(conversation.get(key), list):
+            continue
+        pairs.append((key, conversation.get(f"{key}_date_time", "")))
+    pairs.sort(key=lambda kv: int(kv[0].split("_")[1]))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Scoring / aggregate (same as mem0_locomo_runner.py, None-aware per PR #33)
+# ---------------------------------------------------------------------------
+
+def _summary(rows: list[dict]) -> dict:
+    if not rows:
+        return {"count": 0, "f1": 0.0, "bleu1": 0.0, "judge": 0.0, "retrieval_recall": 0.0}
+    n = len(rows)
+    # Filter None values so infra failures don't depress averages.
+    f1_vals = [r["f1"] for r in rows if r.get("f1") is not None]
+    bleu_vals = [r["bleu1"] for r in rows if r.get("bleu1") is not None]
+    judge_vals = [r["judge"] for r in rows if r.get("judge") is not None]
+    # MemPalace doesn't carry dia_id so retrieval_recall is always 0.0 here.
+    hit_rows = [r for r in rows if r.get("evidence_total") is not None and r["evidence_total"] > 0]
+    recall = (
+        sum(1 for r in hit_rows if r["evidence_hits"] is not None and r["evidence_hits"] > 0)
+        / len(hit_rows)
+    ) if hit_rows else 0.0
+    return {
+        "count": n,
+        "f1": round(sum(f1_vals) / len(f1_vals), 4) if f1_vals else 0.0,
+        "bleu1": round(sum(bleu_vals) / len(bleu_vals), 4) if bleu_vals else 0.0,
+        "judge": round(sum(judge_vals) / len(judge_vals), 4) if judge_vals else 0.0,
+        "retrieval_recall": round(recall, 4),
+    }
+
+
+def _aggregate(results: list[dict]) -> tuple[dict, dict]:
+    by_cat: dict[str, list[dict]] = {}
+    for r in results:
+        by_cat.setdefault(str(r["category"]), []).append(r)
+    return {cat: _summary(rows) for cat, rows in by_cat.items()}, _summary(results)
+
+
+def _print_summary(meta: dict, by_category: dict, overall: dict) -> None:
+    sep, dash = "=" * 57, "-" * 57
+    print(sep)
+    print(f"LoCoMo Benchmark \u2014 MemPalace (commit {meta.get('git_sha', 'unknown')})")
+    print(sep)
+    print(f"Conversations: {meta['conversations']} | Questions: {meta['total_qa']} | "
+          f"Model: {meta['model']} | Top-K: {meta['top_k']}")
+    print(dash)
+    print(f"{'Category':<16} {'Count':>5} {'F1':>7} {'BLEU-1':>8} {'Judge':>8} {'R@K':>8}")
+    print(dash)
+    for cat in sorted(by_category.keys(), key=int):
+        s = by_category[cat]
+        label = CATEGORY_NAMES.get(int(cat), f"Cat {cat}")
+        recall = "-" if int(cat) == 5 else f"{s['retrieval_recall']:.2f}"
+        print(f"{label:<16} {s['count']:>5} {s['f1']:>7.2f} {s['bleu1']:>8.2f} "
+              f"{s['judge']:>8.2f} {recall:>8}")
+    print(dash)
+    print(f"{'Overall':<16} {overall['count']:>5} {overall['f1']:>7.2f} "
+          f"{overall['bleu1']:>8.2f} {overall['judge']:>8.2f} "
+          f"{overall['retrieval_recall']:>8.2f}")
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
+# MemPalace ingest
+# ---------------------------------------------------------------------------
+
+def _palace_path(run_id: str, conv_id: str) -> str:
+    """Each conversation gets its own palace under /tmp/."""
+    safe_run = run_id.replace("/", "_") if run_id else "bench"
+    safe_conv = str(conv_id).replace("/", "_")
+    return f"/tmp/mempalace_{safe_run}_{safe_conv}"
+
+
+def _build_turn_text(dt: str, speaker: str, text: str) -> str:
+    prefix = f"[{dt}] " if dt else ""
+    return f"{prefix}[{speaker}] {text}"
+
+
+def _ingest_conversation_mempalace(conv: dict, conv_id: str, palace: str) -> tuple[int, float]:
+    """Write conversation turns to a temp file and ingest via `mempalace mine`.
+
+    We first attempt programmatic ingest via mempalace.layers.MemoryStack if it
+    exists. If that class is absent or raises, we fall back to the CLI path.
+
+    Returns (turn_count, elapsed_seconds).
+    """
+    conversation = conv.get("conversation", conv)
+    lines: list[str] = []
+    for session_key, dt in _session_keys(conversation):
+        for turn in conversation.get(session_key) or []:
+            text = (turn.get("text") or "").strip()
+            if not text:
+                continue
+            speaker = turn.get("speaker", "")
+            lines.append(_build_turn_text(dt, speaker, text))
+
+    if not lines:
+        return 0, 0.0
+
+    t0 = time.time()
+
+    # --- Attempt 1: programmatic API via mempalace.layers.MemoryStack ----------
+    try:
+        from mempalace.layers import MemoryStack  # type: ignore
+        stack = MemoryStack(palace_path=palace)
+        for line in lines:
+            stack.add(line)
+        elapsed = time.time() - t0
+        return len(lines), elapsed
+    except (ImportError, AttributeError):
+        pass  # Fall through to CLI path.
+    except Exception:
+        pass  # Also fall through — CLI is the canonical ingest path.
+
+    # --- Attempt 2: CLI `mempalace mine <path>` --------------------------------
+    # Write turns to a temp .txt file inside the palace directory so the crawler
+    # picks them up.
+    Path(palace).mkdir(parents=True, exist_ok=True)
+    stage_file = os.path.join(palace, "_locomo_stage.txt")
+    with open(stage_file, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+    result = subprocess.run(
+        ["mempalace", "mine", palace],
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.time() - t0
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"mempalace mine failed (rc={result.returncode}): {result.stderr.strip()}"
+        )
+    return len(lines), elapsed
+
+
+def _mempalace_search(palace: str, question: str, top_k: int) -> list[str]:
+    """Synchronous wrapper around search_memories(); returns list of text strings."""
+    from mempalace.searcher import search_memories  # type: ignore
+    out = search_memories(
+        query=question,
+        palace_path=palace,
+        n_results=top_k,
+    )
+    results = out.get("results", []) if isinstance(out, dict) else out
+    return [r["text"] for r in results if r.get("text")]
+
+
+# ---------------------------------------------------------------------------
+# Per-QA processing
+# ---------------------------------------------------------------------------
+
+async def _process_qa(
+    qa: dict,
+    conv_id: str,
+    palace: str,
+    client: httpx.AsyncClient,
+    ollama_url: str,
+    model: str,
+    top_k: int,
+    loop: asyncio.AbstractEventLoop,
+) -> dict | None:
+    if "answer" not in qa:
+        return None
+    question = qa["question"]
+    reference = str(qa["answer"])
+    category = int(qa.get("category", 0))
+
+    t0 = time.time()
+    try:
+        context_chunks = await loop.run_in_executor(
+            None, _mempalace_search, palace, question, top_k
+        )
+    except Exception as exc:
+        return {
+            "conversation_id": conv_id,
+            "question": question,
+            "reference": reference,
+            "predicted": "",
+            "category": category,
+            "f1": None,
+            "bleu1": None,
+            "judge": None,
+            "retrieval_ms": 0.0,
+            "gen_ms": 0.0,
+            **_EVIDENCE_UNAVAILABLE,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    retrieval_ms = (time.time() - t0) * 1000.0
+
+    context = "\n---\n".join(context_chunks) if context_chunks else ""
+
+    t1 = time.time()
+    generation_error: str | None = None
+    try:
+        predicted = await _ollama_generate(
+            client, ollama_url, model,
+            ANSWER_PROMPT.format(context=context, question=question),
+        )
+    except Exception as exc:
+        predicted = ""
+        generation_error = f"{type(exc).__name__}: {exc}"
+    gen_ms = (time.time() - t1) * 1000.0
+
+    if generation_error is None:
+        judge = await _judge(client, ollama_url, model, question, reference, predicted)
+        f1_val = round(_f1(predicted, reference), 4)
+        bleu_val = round(_bleu1(predicted, reference), 4)
+        judge_val = round(judge, 4) if judge is not None else None
+    else:
+        f1_val = None
+        bleu_val = None
+        judge_val = None
+
+    row: dict = {
+        "conversation_id": conv_id,
+        "question": question,
+        "reference": reference,
+        "predicted": predicted,
+        "category": category,
+        "f1": f1_val,
+        "bleu1": bleu_val,
+        "judge": judge_val,
+        "retrieval_ms": round(retrieval_ms, 2),
+        "gen_ms": round(gen_ms, 2),
+        **_EVIDENCE_UNAVAILABLE,
+    }
+    if generation_error is not None:
+        row["error"] = generation_error
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Main run loop
+# ---------------------------------------------------------------------------
+
+async def run(args: argparse.Namespace) -> int:
+    try:
+        from mempalace.searcher import search_memories  # noqa: F401
+    except ImportError:
+        print(
+            "ERROR: mempalace is not installed. Run: pip install mempalace",
+            file=sys.stderr,
+        )
+        return 1
+
+    dataset_path = Path(args.dataset).expanduser()
+    if not dataset_path.exists():
+        print(f"ERROR: dataset not found: {dataset_path}", file=sys.stderr)
+        return 2
+    conversations = json.loads(dataset_path.read_text())[: args.conversations]
+
+    if args.category == "all":
+        include_cats = {1, 2, 3, 4}
+        if args.include_adversarial:
+            include_cats.add(5)
+    else:
+        include_cats = {int(args.category)}
+
+    run_id = args.run_id or datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+    results: list[dict] = []
+    total_seen = 0
+    failed_qa = 0
+    concurrency = max(1, int(args.concurrency))
+    sem = asyncio.Semaphore(concurrency)
+    progress_lock = asyncio.Lock()
+    loop = asyncio.get_event_loop()
+
+    async def _guarded(qa: dict, conv_id: str, palace: str) -> dict | None:
+        nonlocal total_seen, failed_qa
+        async with sem:
+            try:
+                outcome = await _process_qa(
+                    qa, conv_id, palace, client, args.ollama_url,
+                    args.model, args.top_k, loop,
+                )
+            except Exception as e:
+                async with progress_lock:
+                    failed_qa += 1
+                    print(f"  qa failed: {e!r}", flush=True)
+                return None
+        if outcome is not None:
+            async with progress_lock:
+                total_seen += 1
+                if total_seen % 25 == 0:
+                    print(f"  progress: {total_seen} QAs processed", flush=True)
+        return outcome
+
+    async with httpx.AsyncClient(timeout=args.timeout) as client:
+        for conv in conversations:
+            conv_id = conv.get("sample_id", "unknown")
+            palace = _palace_path(run_id, conv_id)
+
+            # Ingest phase: synchronous; offload to thread pool.
+            try:
+                added, ingest_s = await loop.run_in_executor(
+                    None, _ingest_conversation_mempalace, conv, conv_id, palace
+                )
+            except Exception as exc:
+                print(f"[{conv_id}] ingest failed: {exc!r} — skipping conversation", flush=True)
+                continue
+            print(
+                f"[{conv_id}] ingested {added} turns to mempalace in {ingest_s:.1f}s",
+                flush=True,
+            )
+
+            eligible: list[dict] = []
+            for qa in conv.get("qa", []) or []:
+                cat = int(qa.get("category", 0))
+                if cat not in include_cats:
+                    continue
+                if args.per_conv_limit and len(eligible) >= args.per_conv_limit:
+                    break
+                if args.limit and (total_seen + len(eligible)) >= args.limit:
+                    break
+                eligible.append(qa)
+
+            if eligible:
+                tasks = [_guarded(qa, conv_id, palace) for qa in eligible]
+                gathered = await asyncio.gather(*tasks, return_exceptions=True)
+                for outcome in gathered:
+                    if isinstance(outcome, Exception) or outcome is None:
+                        continue
+                    results.append(outcome)
+
+            if args.limit and total_seen >= args.limit:
+                break
+
+    by_category, overall = _aggregate(results)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    meta = {
+        "run_id": args.run_id or "",
+        "timestamp": timestamp,
+        "model": args.model,
+        "memory_backend": "mempalace",
+        "top_k": args.top_k,
+        "total_qa": len(results),
+        "categories_included": sorted(include_cats),
+        "conversations": min(args.conversations, len(conversations)),
+        "git_sha": _git_sha(),
+        "dataset": str(dataset_path),
+        "concurrency": concurrency,
+        "failed_qa": failed_qa,
+    }
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        tag = f"_{args.run_id}" if args.run_id else ""
+        out_path = (
+            Path(os.path.dirname(os.path.abspath(__file__)))
+            / "results"
+            / f"locomo_{timestamp}{tag}_full_mempalace_e2b.json"
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(
+        {"meta": meta, "by_category": by_category, "overall": overall, "results": results},
+        indent=2,
+    ))
+
+    _print_summary(meta, by_category, overall)
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_DATASET = os.environ.get(
+    "LOCOMO_DATASET",
+    os.path.join(_REPO_ROOT, "data", "locomo", "data", "locomo10.json"),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="LoCoMo benchmark runner using MemPalace as the memory layer"
+    )
+    p.add_argument("--dataset", default=_DEFAULT_DATASET,
+                   help=f"LoCoMo dataset JSON. Env: LOCOMO_DATASET (default: {_DEFAULT_DATASET})")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Cap total QAs across all conversations (0=all)")
+    p.add_argument("--per-conv-limit", type=int, default=0,
+                   help="Cap QAs per conversation for balanced sampling (0=all eligible)")
+    p.add_argument("--conversations", type=int, default=10)
+    p.add_argument("--category", default="all")
+    p.add_argument("--include-adversarial", action="store_true")
+    p.add_argument(
+        "--ollama-url",
+        default=os.environ.get("TAOSMD_OLLAMA_URL", "http://localhost:11434"),
+        help="Ollama base URL. Env: TAOSMD_OLLAMA_URL (default http://localhost:11434)",
+    )
+    p.add_argument("--model", default="gemma4:e2b")
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--out", default=None)
+    p.add_argument("--run-id", default=None)
+    p.add_argument(
+        "--concurrency", type=int, default=3,
+        help=("Max parallel QAs per conversation. Requires OLLAMA_NUM_PARALLEL "
+              ">= N on the Ollama server. Default 3; use 1 for sequential."),
+    )
+    p.add_argument(
+        "--timeout", type=float, default=120.0,
+        help="HTTP timeout for Ollama calls in seconds. Default 120.",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run(_parse_args())))

--- a/docs/specs/2026-04-16-routing-benchmark-design.md
+++ b/docs/specs/2026-04-16-routing-benchmark-design.md
@@ -1,0 +1,101 @@
+# Routing benchmark — design spec
+
+**Workstream:** Phase C #2 in `docs/specs/2026-04-16-taosmd-next-steps.md`
+**Depends on:** Phase A baseline LoCoMo result + supersede benchmark (sharing infrastructure)
+**Replaces:** Axis B in `eval/librarian_eval.py` (which trivially scored 1.0 because the fixture was a 15-item pool with one obviously-correct answer — no real routing signal)
+
+## What we're measuring
+
+**Question:** Does the Librarian's intent classifier (`query_route_prompt` + friends) correctly route a question to the memory layer that best serves it? And does routing-aware retrieval beat flat "query all layers" retrieval?
+
+**The concrete hypothesis:** different question types want different memory layers.
+- **Single-hop (cat 1)** — single factual span. Vector search over raw turns wins.
+- **Multi-hop (cat 3)** — chain facts across sessions. KG traversal (subject → predicate → object chains) beats flat vector.
+- **Temporal (cat 2)** — "when did X". Session catalog (timeline-indexed) + supersede chains beat flat vector.
+- **Open-domain (cat 4)** — world knowledge + dialogue. Crystals (session digests) + Reference Desk (cross-session insights) add value that raw vector misses.
+
+If the Librarian's router correctly matches question type → layer, we should see per-category improvements that add up to a better overall score than flat thorough mode. If it doesn't, there's either a bug in the router or the layers aren't differentiated enough for routing to matter.
+
+## Why LoCoMo is the right dataset for this
+
+LoCoMo hands us ground-truth category labels on every QA. We don't have to build synthetic routing fixtures (which is what Axis B tried to do and failed). We run the same 1,540-question set three ways and compare.
+
+## The three configurations
+
+| Config | Description |
+|--------|-------------|
+| **baseline (vector-only)** | `VectorMemory.search(query, limit=10)` only. No routing. Same as Phase A baseline. |
+| **flat-thorough** | `retrieve(strategy="thorough", sources={all 5 layers}, limit=10)` — queries every layer, fuses via RRF. No router; everyone gets the same treatment. |
+| **router-directed** | Classify intent first (`classify_intent` + `query_route_prompt`), then `retrieve(strategy="custom", memory_layers=[...routed layers...])` with the router's choice. |
+
+We want to know:
+- Is flat-thorough better than vector-only? (Expected: yes on multi-hop + open-domain; wash on single-hop.)
+- Is router-directed better than flat-thorough? (Expected: yes on token cost, maybe wash on quality. The routing value is **cost**, not recall.)
+- Where does router-directed lose to flat-thorough? (Expected: when the router miscategorises.)
+
+## What needs to exist before this is runnable
+
+1. **Phase A baseline** — published LoCoMo vector-only numbers.
+2. **Full retrieval stack on Fedora** — archive, catalog, crystals, KG all populated during ingest. The supersede benchmark spec calls out the ingest-cost concern; this benchmark inherits it. Cache the populated stores between runs.
+3. **`classify_intent` end-to-end on LoCoMo questions.** Currently `taosmd/intent_classifier.py::classify_intent` returns `{"intent": str, "layers": list[str]}` (verify). Need an integration test: feed 20 LoCoMo questions, assert classification is sensible. This is the single biggest risk — the classifier was trained/tuned on assumed agent-session phrasing, not LoCoMo's third-person narrative phrasing ("When did Melanie paint a sunrise?"). Validate early.
+4. **Layer-level metrics.** For router-directed, we need to log per-layer retrieval hit rates. Add `record["layers_queried"]: list[str]` and `record["layer_sources"]: dict[str, int]` (count of retrieved items from each layer).
+
+## File to create
+
+`benchmarks/routing_benchmark.py` — variant of `locomo_runner.py`. Key additions:
+
+- Accept `--config` = `vector-only` | `flat-thorough` | `router-directed`.
+- When `--config=router-directed`, call `classify_intent(query)` first and pass `memory_layers=result["layers"]` to `retrieve()`.
+- Track per-QA: `category`, `routed_layers`, `layer_source_counts`, `f1`, `bleu1`, `judge`, `tokens_used`.
+- Aggregate: per-category scorecard × 3 configs. Also per-category token cost.
+
+## Scorecard shape (what we publish)
+
+```
+Category       vector-only              flat-thorough            router-directed
+               F1    Judge  tokens      F1    Judge  tokens      F1    Judge  tokens
+single-hop     0.xx  0.xx   N           0.xx  0.xx   N           0.xx  0.xx   N
+temporal       0.xx  0.xx   N           0.xx  0.xx   N           0.xx  0.xx   N
+multi-hop      0.xx  0.xx   N           0.xx  0.xx   N           0.xx  0.xx   N
+open-domain    0.xx  0.xx   N           0.xx  0.xx   N           0.xx  0.xx   N
+------
+overall        0.xx  0.xx   N           0.xx  0.xx   N           0.xx  0.xx   N
+
+Router accuracy (vs expected layer for each category):
+  single-hop → vector          [N/M correct]
+  temporal  → catalog+kg       [N/M correct]
+  multi-hop → kg               [N/M correct]
+  open-domain → crystals       [N/M correct]
+```
+
+The router-accuracy block is the most interesting part. It's what tells you whether the routing logic matches our hypothesis about which layer serves which question type.
+
+## Success criteria
+
+**Honest bar:**
+- `flat-thorough` ≥ `vector-only` by ≥2 F1 points overall. (Validates that non-vector layers pull weight.)
+- `router-directed` tokens ≤ 0.6× `flat-thorough` tokens. (Routing's value is cost savings.)
+- `router-directed` F1 within 1 point of `flat-thorough` F1. (Router doesn't sacrifice quality for speed.)
+
+**Dream bar:** `router-directed` beats `flat-thorough` on quality too (router chose better layers than fusion).
+
+**Failure case A:** `flat-thorough` is worse than `vector-only`. Means fusion is hurting (KG/catalog/archive adding noise, not signal). Investigate per-layer hit rates; likely fix is to improve the adapters or change RRF weights.
+
+**Failure case B:** Router routes to the wrong layer. Measure with the router-accuracy block; fix is prompt engineering or replacing the classifier.
+
+**Failure case C:** Layers are all empty because LoCoMo ingest didn't populate them. Ingest side-effect problem — fix the ingest wiring.
+
+## Open questions
+
+1. **What's "the right layer" for each LoCoMo category?** The hypothesis table above is our best guess. Should we first run `flat-thorough` with per-layer attribution, look at which layer actually contributed the winning fact per category, and only then build the router against empirical routing? That would be more honest than assuming our architecture-level intuition is correct.
+2. **Is the intent classifier a prompt or a heuristic?** `taosmd/intent_classifier.py` — audit before building. If it's a hand-written heuristic, the evaluation measures heuristic quality. If it's an LLM prompt, the evaluation measures prompt quality. They need different follow-up actions.
+3. **Do we run all three configs on all 1,540 QAs, or sample?** Full run with 3 configs at concurrency=3 is ~3-4h on Fedora (reusing populated stores). Doable overnight.
+
+## Rough timeline
+
+- 3h — audit intent_classifier.py, run 20-QA classification sanity check
+- 4h — build runner (mostly parallel to locomo_runner.py)
+- 6-8h — first full run (3 configs)
+- 3h — analyse, write up scorecard
+
+Total: ~2 working days + overnight run. Start after supersede benchmark lands so we can share the populated stores.

--- a/docs/specs/2026-04-16-supersede-benchmark-design.md
+++ b/docs/specs/2026-04-16-supersede-benchmark-design.md
@@ -1,0 +1,69 @@
+# Supersede-chain benchmark — design spec
+
+**Workstream:** Phase C #1 in `docs/specs/2026-04-16-taosmd-next-steps.md`
+**Depends on:** Phase A baseline LoCoMo result (so we have a fair comparison)
+**Replaces:** Axis A in `eval/librarian_eval.py` (which flat-lined because the fixtures were synthetic and didn't exercise real temporal conflict)
+
+## What we're measuring
+
+**Question:** Does taosmd's supersede-chain mechanism (`is_fact_superseded_prompt` + the KG's supersede relationships) actually improve recall when a user has stated two contradictory facts at different points in time?
+
+**Failure mode we want to catch:** An agent that naively embeds both "I use Flask" (March) and "I'm on FastAPI now" (last week) and retrieves both at query time, leaving the LLM to guess which is current. The correct answer is *always the newer one* — the question is whether the system surfaces it without relying on the LLM's post-hoc disambiguation.
+
+## Why LoCoMo category 2 is the right dataset
+
+LoCoMo category 2 = **temporal reasoning**. 321 QAs across the 10 conversations, roughly 32 per conversation. Questions like:
+
+- "When did Caroline go to the LGBTQ support group?" → "7 May 2023"
+- "When did Melanie paint a sunrise?" → "2022"
+- "What year did Jay switch from Flask to FastAPI?" → requires detecting the switch event
+
+These are ready-made supersede scenarios. The dataset already has the temporal ground truth — we just need to compare system responses.
+
+## The two configurations
+
+| Config | KG ingest | Retrieval | Query expansion |
+|--------|-----------|-----------|-----------------|
+| **baseline** | none | `VectorMemory.search` only | none |
+| **full+supersede** | LLM extracts facts into KG, `is_fact_superseded_prompt` runs on conflicting facts to build supersede chains | `retrieve(strategy="thorough", sources={"vector": vmem, "kg": kg})` with KG temporal filters respecting supersede chains | `query_expansion_prompt` per the existing Librarian run |
+
+## What needs to exist before this is runnable
+
+1. **Baseline LoCoMo result** on cat 2 from the vanilla `locomo_runner.py` — published as the reference point.
+2. **KG ingest path for LoCoMo** — the current `locomo_runner.py` ingests only into `VectorMemory`. Supersede chains live in the KG; without KG ingest, nothing to test. New code needed: wire `process_conversation_turn(text, agent_name, kg, archive, source, ...)` from `taosmd.memory_extractor` into the per-turn loop in `_ingest_conversation`. This is the biggest unknown — the LLM fact extraction is ~2-5s per turn; at 400 turns per conversation, that's 15-30 min of ingest per conv, plus 10 conversations = 2.5-5h of ingest alone. Either sample (cat-2-adjacent turns only) or budget accordingly.
+3. **Supersede chain traversal confirmed end-to-end.** `taosmd/knowledge_graph.py` has the `supersedes` relationship but nobody has verified it filters correctly at retrieve time. Integration test required before the benchmark; add one to `tests/test_knowledge_graph.py` with a 3-fact chain (A superseded by B superseded by C → query returns C only).
+4. **`retrieve()` with KG source actually filters on supersede.** Read `taosmd/retrieval.py::_query_source` for kg — confirm the kg adapter respects `supersedes` edges. If not, patch.
+
+## File to create
+
+`benchmarks/supersede_benchmark.py` — derived from `locomo_runner.py`. Key changes:
+
+- Hardcode `include_cats = {2}` (temporal only).
+- Replace the `VectorMemory.search` path with `retrieve(...)` when `--config=full+supersede`.
+- Add `kg = KnowledgeGraph(...)` and `archive = ArchiveStore(...)` to the per-conversation setup.
+- Swap the ingest loop for `process_conversation_turn(...)` calls (slower but does fact extraction).
+- For each QA, retrieve via `retrieve(sources={"vector": vmem, "kg": kg, "archive": archive})`.
+- Report F1, BLEU-1, Judge as in LoCoMo runner. Add one extra metric: **supersede_hit_rate** = fraction of QAs where the retrieved facts include at least one kg record with a non-null `superseded_at` chain endpoint. This measures *whether* supersede edges were surfaced at all, not just whether the answer was right.
+
+## Success criteria
+
+**Honest bar:** `full+supersede` delivers **at least +5 F1 points** on cat 2 over `baseline`, at a per-QA token cost **≤3000** (tighter than the general Librarian budget because this is a deeper pipeline).
+
+**Dream bar:** +10 F1 points. That would be publishable as a standalone finding.
+
+**Failure case:** if `full+supersede` is the same as or worse than baseline, the supersede-chain mechanism is either (a) not surfacing relevant facts at retrieval, (b) surfacing them but the LLM answer still gets confused, or (c) the cat-2 questions don't actually require supersede disambiguation (many are "when did X happen" about a single event, which doesn't need supersede). Each failure mode has a different fix; don't ship the "it didn't work" conclusion without investigating which.
+
+## Open questions
+
+1. **Is LoCoMo cat 2 actually supersede-shaped?** Spot-check 20 random cat 2 QAs. Are they "when did X" (single event, no supersede needed) or "which X is current" (requires supersede)? If the former dominates, this benchmark measures temporal *retrieval*, not supersede *resolution*. Still valuable but rename the workstream.
+2. **Should the baseline include Librarian query expansion?** If yes, we're measuring supersede in isolation. If no, we're measuring supersede + expansion jointly. Pick one and say so.
+3. **Ingest cost budget.** 5h of LLM fact extraction per benchmark run is steep. Options: (a) batch fact extraction offline and cache the KG, (b) use a smaller extraction model, (c) subsample conversations. Decide before building.
+
+## Rough timeline
+
+- 2h — spot-check cat 2 questions to confirm supersede-shape
+- 4h — build the runner (most of the code is a fork of `locomo_runner.py`)
+- 8h+ — first full run on Fedora (dominated by ingest)
+- 2h — analyse, publish or iterate
+
+Total: ~2 working days of deep focus + machine time. Do not start before baseline LoCoMo result is in.

--- a/docs/specs/2026-04-16-taosmd-next-steps.md
+++ b/docs/specs/2026-04-16-taosmd-next-steps.md
@@ -1,0 +1,98 @@
+# taosmd Next Steps — April 2026
+
+## Context
+
+A /last30days sweep across Reddit, HN, and GitHub (Apr 2026) surfaced a shifted competitive landscape:
+
+- **Genesys** (r/AI_Agents, Apr 14): claims 89.9% on **LoCoMo**, +22 pts above Mem0, open-sourced. Uses "causal graph instead of flat vector storage."
+- **Mem0** is at 53K stars; **Letta** at 22K; **MemPalace** launched with 35.7K stars in 6 days.
+- **Benchmark controversies**: Zep published a formal rebuttal to Mem0's paper (Mem0 reported Zep at 65.99% LoCoMo, Zep's reproduction says 75.14%). Separately `dial481/locomo-audit` retested Zep's 84% self-claim and got 58.44%.
+- **Emerging critique** (Signet, r/AI_Agents): *"most agent memory systems are still just query-time retrieval — it breaks when relevant context is implicit."*
+- **Red-team threat lists** now include "memory poisoning" alongside prompt injection.
+
+**taosmd's position:** 97.0% on LongMemEval-S (SOTA on that benchmark) but **no published LoCoMo score**. LongMemEval is the minority benchmark; LoCoMo is the lingua franca.
+
+## The four workstreams
+
+### 1. Benchmark rigor (LoCoMo adoption + infrastructure cleanup)
+
+**Why this ships first:** without a LoCoMo number, taosmd is invisible to the comparison tables everyone else is in.
+
+**Methodology to match (from Mem0 paper `arxiv:2504.19413` and `snap-research/locomo`):**
+- Dataset: `github.com/snap-research/locomo` → `data/locomo10.json` (10 conversations, 1,986 QAs, avg 300 turns / 9K tokens / 19 sessions per conversation)
+- Categories: 1 single-hop, 2 temporal, 3 multi-hop, 4 open-domain, 5 adversarial
+- Metrics: F1, BLEU-1, LLM-as-Judge (J). Per-category breakdown required.
+- Standard practice: skip or separately report category 5 (adversarial).
+- Ingest protocol: ingest full conversation (all sessions in order with timestamps), then ask QA questions, score answers against ground truth.
+
+**Tasks:**
+1. **Build `benchmarks/locomo_runner.py`** — ingest LoCoMo conversations via `index_day()`, ask QAs via `retrieve()` + LLM answer generation, score F1/BLEU-1/LLM-J per category.
+2. **Run on Fedora** with the existing reference stack (MiniLM + cross-encoder + qwen3:4b for answer generation).
+3. **Publish scores** to README in the same table shape Mem0/Zep/Letta use.
+4. **Rewrite `benchmarks/longmemeval_runner.py`** — currently imports from dead `tinyagentos` monorepo (memory note confirms). Port to taosmd public API.
+5. **Fix token cost metric in `eval/librarian_eval.py`** — replace `infx` ratio (divide-by-zero vs zero baseline) with absolute threshold `≤2000 tokens/query`.
+
+**Success:** taosmd reports a full LoCoMo scorecard (F1/BLEU/J × 4 categories), and we know whether the librarian stack is competitive with Genesys's 89.9%.
+
+### 2. Librarian mechanisms (validate the unvalidated)
+
+**Why:** 16 prompts exist in `taosmd/prompts.py`, only 1 (query expansion) has a benchmark proving it earns its LLM cost.
+
+**Tasks:**
+1. **Supersede chain benchmark** — LoCoMo category 2 (temporal) is tailor-made for this. Test whether `is_fact_superseded_prompt` + supersede chains beats naive vector retrieval on temporal questions. This directly addresses Axis A's flat-scoring issue from the previous eval cycle.
+2. **Routing benchmark** — LoCoMo has four category types (single/multi/temporal/open-domain). Test whether intent classifier (via `query_route_prompt`) correctly routes to different memory layers. This reclaims the Axis B concept in a real-world setting.
+3. **Taxonomy confirmation** — verify `taxonomy_propose_prompt` + 3-use confirmation actually converges on sensible categories over a LoCoMo run. Report confirmed-taxonomy count after ingest.
+
+**Success:** a second benchmark table showing per-Librarian-task contribution (ablation): vector-only, +routing, +supersede, +taxonomy, full Librarian.
+
+### 3. Retrieval/architecture (positioning + hardening)
+
+**Tasks:**
+1. **Reframe README Librarian section around Signet's critique.** Current README leads with the library metaphor; add a concrete "why not just RAG" frame: *"query-time retrieval breaks when the relevant context is implicit — the Librarian layer is how we fix that."* Cite the public critique without naming Signet directly (they're a competitor).
+2. **Causal/temporal graph framing.** taosmd has `KnowledgeGraph` (Card Catalogue) with supersede chains — that's the same category as Genesys's "causal graph." Surface this in the architecture diagram section, not just as implementation detail.
+3. **Memory poisoning positioning.** `retrieve(verify=True)` already exists plus archive-first immutability. Add a short "Security" section to README calling out: archive-first transcripts are append-only (no poisoning vector), `verify` flag optionally validates retrieved facts against the archive before returning, extracted facts live in supersede chains (never silently overwritten).
+
+**Success:** README reads like it's engaging with the 2026 memory-systems conversation, not the 2024 one.
+
+### 4. Ecosystem/visibility
+
+**Tasks:**
+1. **Imran Ahmad AMA (Apr 24, r/LLMeng)** — prep a thoughtful memory/planning question that references taosmd organically. He wrote "30 Agents Every AI Engineer Must Build"; his interest in memory architecture is the right hook.
+2. **Publish a methodology post** riding the Zep/Mem0 controversy — not attacking them, but showing taosmd's bench protocol (reproducible, open fixtures, dev-branch-first, single seed). "Receipts-heavy honesty" travels; Zep's rebuttal proved it.
+3. **Target-market subreddits**: r/LocalLLaMA, r/AI_Agents, r/LangChain. Don't post until (1) LoCoMo numbers are published and (2) README is reframed.
+
+**Success:** organic first-100-stars via substance rather than celebrity launch.
+
+## Execution order
+
+**Phase A — unblocks everything (today/tomorrow):**
+- `benchmarks/locomo_runner.py` built and running on Fedora
+- First LoCoMo result in hand (even if imperfect)
+
+**Phase B — publish + reframe (while results come in):**
+- README LoCoMo table + Librarian critique reframe + Security section
+- Fix token cost metric
+- Rewrite `longmemeval_runner.py`
+
+**Phase C — deepen the moat (next):**
+- Supersede-chain benchmark (LoCoMo category 2 ablation)
+- Routing benchmark (LoCoMo category 1 vs 2 vs 3 vs 4 ablation)
+- Taxonomy convergence report
+
+**Phase D — visibility:**
+- AMA participation
+- Methodology post
+- Subreddit posts with published numbers
+
+## Risks & guardrails
+
+- **Don't fudge LoCoMo scores.** Publish whatever comes back, in the same honesty tradition that makes the Zep/Mem0 controversy look bad for Zep. Include `run_seed`, commit SHA, and raw answer log.
+- **Category 5 (adversarial) handling.** Mem0 skips; we should report separately with a note — standard practice.
+- **Don't overpromise timelines.** This spec covers four workstreams. Phase A ships this week; everything else gets its own checkpoint.
+- **Memory poisoning framing.** Don't imply taosmd is bulletproof — framing is "archive-first + verify gives you a primitive to build against poisoning," not "we solved it."
+
+## Open questions
+
+1. **Answer-generation LLM for LoCoMo.** Mem0 paper used GPT-4o-mini. Our reference stack is qwen3:4b (local). Cheaper/private but may score lower. Do we also run one GPT-4.1 pass for an apples-to-apples number? Decide after Phase A baseline.
+2. **Category 5 policy.** Report it, skip it, or report separately with "unanswerable accuracy" as its own metric?
+3. **Librarian task ablation cost.** Full matrix (5 configs × 4 categories × 1,986 QAs × LLM answer generation) is expensive. Budget-cap via sampling or run full matrix once?

--- a/docs/specs/2026-04-24-ama-question-draft.md
+++ b/docs/specs/2026-04-24-ama-question-draft.md
@@ -1,0 +1,43 @@
+# AMA question for Imran Ahmad — r/LLMeng, Apr 24 2026
+
+**Target:** Imran Ahmad, author of *30 Agents Every AI Engineer Must Build* (follow-up to his *50 Algorithms* book). AMA scheduled for Apr 24 on r/LLMeng.
+
+**Goal:** surface a substantive memory/planning architecture question that references taosmd organically without being promotional. Good AMA questions make the host want to answer them and make bystanders click through to whatever the asker is working on.
+
+## The question (primary)
+
+> In *30 Agents* you treat memory mostly as a retrieval problem — embed, store, fetch. But the failure mode practitioners keep running into is different: the agent *has* the fact, stored it, but the user's wording doesn't overlap with how it was said six weeks ago. Query-time retrieval misses it. Cross-encoder reranking can't save you because the fact never made it into the candidate pool.
+>
+> How are you thinking about the layer between "user asks a question" and "vector search runs"? Specifically: is that layer reactive (query expansion / rewriting) or proactive (structuring the memory at write-time — supersede chains, intent tags, implicit-topic indexing)? And do you see it as an LLM concern or a symbolic/structural one?
+>
+> For context: we've been measuring this on long-horizon sessions and a lightweight LLM query-expansion pass before retrieval lifts recall by ~15% on vocabulary-gap questions (the ones where the user asks "what code editor do I use" but the turn said "Neovim lua config done"). The cross-encoder adds nothing on those — it's the pre-retrieval step doing the work. Curious whether your book lands in the same spot.
+
+## Why this question works
+
+- **Framed as a question, not a pitch.** No "check out our project" — just a real technical puzzle.
+- **Shows work.** The "+15% on vocabulary-gap" sentence proves we've measured it, not just theorised. Bystanders who care will find taosmd without us linking it.
+- **Opens a door for him.** Asking about write-time vs read-time is a live debate in the field. He'll have opinions.
+- **Ends with curiosity, not conclusion.** "Curious whether your book lands in the same spot" invites him to correct, contrast, or agree — all good outcomes.
+
+## Fallback question (if primary is too long / already answered)
+
+> What's the memory pattern from *30 Agents* that surprised you most when you wrote the code? The gap between "the pattern makes sense on the page" and "the pattern fails in production" is usually where the interesting lessons are.
+
+## Posting logistics
+
+- Post in the first 30 minutes of the AMA window — higher visibility, less chance it gets buried.
+- Reddit username should be unambiguously human (not a brand account).
+- Don't link to taosmd anywhere in the question or in follow-ups. If someone asks what we're building, reply once with `github.com/jaylfc/taosmd` and a one-line description, no more.
+- If he engages, ask *one* follow-up. Don't thread into a demo.
+
+## Red flags to avoid
+
+- Don't mention Mem0, Zep, or Letta by name — it reads as trying to pick a fight.
+- Don't quote his book unless citing a specific technique (vague references sound like we haven't read it).
+- Don't post the question and then edit it — Reddit timestamps edits and it looks needy.
+
+## After the AMA
+
+- Screenshot the exchange if it goes well.
+- If he mentions taosmd, don't boost it immediately — let it sit naturally.
+- If it flops, no post-mortem needed. Move on to the methodology post.

--- a/docs/specs/2026-04-methodology-post-draft.md
+++ b/docs/specs/2026-04-methodology-post-draft.md
@@ -1,0 +1,76 @@
+# Methodology transparency post — draft
+
+**Status:** DRAFT. Hold until LoCoMo numbers are in and validated. Target posting: r/LocalLLaMA, r/AI_Agents, HN. Possibly a blog post on the taosmd GitHub readme.
+
+**Framing principle:** do not attack Zep, Mem0, or anyone else. The post rides the *existence* of the benchmark controversy, not either side of it. The argument is about protocol, not personalities.
+
+---
+
+## Title options (pick one)
+
+1. **"Publishing a memory-system benchmark is easy. Making it reproducible isn't. Here's what we did."**
+2. **"taosmd on LoCoMo: [X]% F1, every number reproducible from a single commit"**
+3. **"How to benchmark an agent memory system without cooking the numbers"** (spicier, higher click-through, more likely to get flamed)
+
+---
+
+## Post body (target 600-800 words)
+
+### The lede
+
+The agent-memory benchmark space had a rough month. Mem0 published a LoCoMo comparison. Zep published a rebuttal claiming Mem0 misconfigured their system and the real score was ~10 points higher. An independent audit (`dial481/locomo-audit`) then retested Zep's own 84% self-claim and reported 58.44%.
+
+All three parties probably believe their numbers. That's the problem.
+
+When a field's benchmark numbers can't be cross-checked by anyone outside the authoring team, the numbers stop being evidence. They become marketing. The lesson isn't "who was right" — it's that agent memory benchmarks need protocols, not just scoreboards.
+
+### What we did when we measured taosmd on LoCoMo
+
+taosmd hits **[X]% F1, [Y]% LLM-judge** on LoCoMo's standard categories (single-hop, multi-hop, temporal, open-domain). But the scorecard is not the interesting part. The interesting part is what sits underneath it:
+
+**1. The benchmark commit is tagged.** Every published number names the exact git SHA it was produced by. Roll back to that SHA, run the command in the README, get the same number (modulo LLM non-determinism, which we document).
+
+**2. The run command is a single line.** `python3 benchmarks/locomo_runner.py --run-id <tag>`. No hidden config, no private ingest preprocessor. The runner is [387 lines](https://github.com/jaylfc/taosmd/blob/master/benchmarks/locomo_runner.py) of argparse + retrieval + scoring. Read it in five minutes.
+
+**3. The seed is fixed and printed.** Every aggregation uses a seeded RNG. If your run produces different numbers from ours, we want to know which seed and commit.
+
+**4. The adversarial category (LoCoMo cat 5) is reported separately, not folded into the overall.** Mem0's paper skips it. Some systems fold "unanswerable" questions into the average in a way that inflates or deflates headline numbers. We report overall *and* per-category *and* adversarial as its own line. You decide what matters.
+
+**5. The raw answer log is committed with the results.** Every predicted answer, every ground truth, every F1/BLEU/Judge triple — in the repo, under `benchmarks/results/locomo_<timestamp>.json`. If you disagree with a judge call, read the answer and argue.
+
+**6. The LLM judge is documented and reproducible.** Judge = `qwen3:4b` at `temperature=0.0`. Same prompt every time. Not hidden behind an API contract with a provider that might change weights next month.
+
+**7. When our numbers disagree with someone else's claim about us, the burden's on us to rerun, not to rebut.** If you benchmark taosmd and get a different number, file an issue with the command you ran and we'll find the discrepancy. This is how Zep's 84% should have been caught — not after publication, but during.
+
+### The benchmark we'd rather win
+
+We're also publishing a benchmark we haven't solved yet: **staleness detection** — the case where a user said "I use Flask" three months ago and "I'm on FastAPI now" last week, and retrieval surfaces both. Vector search returns the stale one; supersede chains should beat it. We have the mechanism (taosmd's `is_fact_superseded_prompt` + supersede chains in the KG) but the ablation benchmark is still coming. We'd rather show the number that surprises us than the number that flatters us.
+
+### Why this matters beyond taosmd
+
+If the agent-memory field runs on unreproducible scorecards, the winner will be the system with the best PR, not the best algorithm. The Zep/Mem0 argument isn't healthy. It's a symptom of infrastructure that lets both sides be plausible at once.
+
+A minimum viable standard for anyone publishing an agent-memory benchmark in 2026:
+
+- Single-command run script, public.
+- Tagged commit SHA per number.
+- Raw answer log committed with the result.
+- LLM judge identified by name + version + temperature.
+- Adversarial categories reported separately.
+- Third-party reproduction welcomed, not litigated.
+
+We're doing this. We'd rather have a [78]% number everyone can reproduce than a [91]% number nobody can.
+
+---
+
+## After publishing
+
+- Monitor for third-party runs — make the issue tracker welcoming, not defensive.
+- If someone posts a different number, thank them publicly, investigate, and fix the discrepancy visibly. This is the whole point.
+- Don't engage in the Zep/Mem0 argument directly. The post is the engagement.
+
+## What NOT to say
+
+- Don't name-check Mem0, Zep, or Letta. Referring to "the benchmark controversy" is enough context for anyone who follows the field, and keeps us out of the fight.
+- Don't claim taosmd is "more honest." Claim the *protocol* is more honest. Protocols are arguable; character attacks aren't.
+- Don't promise new features in the same post. This is about the numbers and the methodology, not the roadmap.

--- a/eval/librarian_eval.py
+++ b/eval/librarian_eval.py
@@ -623,14 +623,24 @@ def _print_summary(reports: dict[str, EvalReport]) -> None:
         baseline = reports["full-pipeline"].composite_score
         librarian = reports["full+librarian"].composite_score
         gain = (librarian - baseline) / baseline * 100 if baseline > 0 else 0
-        bt = reports["full-pipeline"].tokens_total
         lt = reports["full+librarian"].tokens_total
-        token_mult = lt / bt if bt > 0 else float("inf")
-        target_met = gain >= 15.0 and token_mult <= 3.0
+        lib = reports["full+librarian"]
+        # eval_axis_c emits n_sessions, not n — using the wrong field here
+        # undercounts n_queries and inflates tokens_per_query.
+        n_queries = max(
+            lib.axis_a.get("n", 0)
+            + lib.axis_b.get("n", 0)
+            + lib.axis_c.get("n_sessions", lib.axis_c.get("n", 0)),
+            1,
+        )
+        tokens_per_query = lt / n_queries
+        TOKEN_BUDGET = 2000
+        cost_ok = tokens_per_query <= TOKEN_BUDGET
+        target_met = gain >= 15.0 and cost_ok
         print(
             f"\nLibrarian gain over full-pipeline: {gain:+.1f}%  "
-            f"token cost: {token_mult:.1f}x  "
-            f"target met ({'YES' if target_met else 'NO'}: ≥15% gain at ≤3x tokens)"
+            f"tokens/query: {tokens_per_query:.0f} (budget ≤{TOKEN_BUDGET})  "
+            f"target met ({'YES' if target_met else 'NO'}: ≥15% gain at ≤{TOKEN_BUDGET} tokens/query)"
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,10 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio"]
 local = ["sentence-transformers"]
+benchmarks = ["mem0ai>=0.1.0"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]
-
-[tool.setuptools.package-data]
-taosmd = ["docs/*.md"]
 
 [project.scripts]
 taosmd = "taosmd.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio"]
 local = ["sentence-transformers"]
-benchmarks = ["mem0ai>=0.1.0"]
+benchmarks = ["mem0ai>=0.1.0", "mempalace"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]


### PR DESCRIPTION
## Summary

Comprehensive LoCoMo benchmark PR — lands all the work that produced our published LongMemEval 97% and the new LoCoMo numbers. Supersedes the closed #25 (content subsumed into #26's unintentional bundle).

## What lands

**Benchmark infrastructure** (~2000 LOC):
- `benchmarks/locomo_runner.py` — full LoCoMo runner (ONNX embeds + Ollama answer/judge, F1/BLEU/Judge/R@K per category, `--concurrency`, `--per-conv-limit`, `--timeout`, `--model` flags, live progress markers)
- `benchmarks/longmemeval_runner.py` — ported off dead tinyagentos imports, now uses `TAOSMD_OLLAMA_URL`/`TAOSMD_OLLAMA_MODEL` env vars (no hardcoded IPs)
- `benchmarks/mem0_locomo_runner.py` — apples-to-apples adapter routing retrieval through `mem0.search()` with the same generator/prompt/judge (for the upcoming memory-architecture comparison)
- `benchmarks/locomo_rescore.py` — already merged via #29, included here only by branch history
- `eval/librarian_eval.py` — fixed divide-by-zero token ratio (replaced with absolute per-query budget)

**Prompt tweaks** (the +0.03 Overall Judge improvement, validated Apr 18–19):
- `benchmarks/locomo_runner.py` `ANSWER_PROMPT` — adds absolute-date instruction + softened IDK instruction
- Measured impact under external qwen3:4b judge:
  - Temporal: 0.36 → **0.41** (+0.05)
  - Multi-hop: 0.21 → **0.24** (+0.03)
  - Single-hop + Open-dom: unchanged (prompt targeted temporal/multi-hop specifically — clean signal)

**Methodology docs**:
- `docs/specs/2026-04-16-taosmd-next-steps.md` — four-workstream roadmap
- `docs/specs/2026-04-16-supersede-benchmark-design.md`
- `docs/specs/2026-04-16-routing-benchmark-design.md`
- `docs/specs/2026-04-24-ama-question-draft.md` — Imran Ahmad AMA on r/LLMeng
- `docs/specs/2026-04-methodology-post-draft.md` — publishable protocol-transparency post

**README framing** (updated on prior commits on this branch):
- Reframed Librarian section around "query-time RAG breaks on implicit context" critique
- Added Security & Integrity section on memory poisoning

## Validated results

LoCoMo full scorecard under `qwen3:4b` external judge (100% coverage, 0 errors):

| Category | e2b | e4b | e2b+prompt-opt |
|---|---|---|---|
| Single-hop | 0.17 | 0.15 | 0.16 |
| Temporal | 0.36 | 0.31 | **0.41** |
| Multi-hop | 0.21 | 0.14 | **0.24** |
| Open-dom | 0.51 | 0.51 | 0.51 |
| **Overall** | 0.40 | 0.38 | **0.41** |
| F1 | 0.162 | 0.152 | **0.175** |

## Test plan
- [x] All three models benchmarked against the full 1540-QA LoCoMo set
- [x] External judge (qwen3:4b) re-judged all three runs — 100% coverage, 0 errors
- [x] Prompt-opt improvement localized to targeted categories as designed
- [x] Existing test suite green (`pytest tests/ -q --ignore=tests/integration`)
- [ ] Post-merge: delete `feat/locomo-benchmark` and `feat/locomo-prompt-opt`
- [ ] Post-merge: Fedora `git fetch --prune && git checkout master` before next benchmark run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LoCoMo benchmark runners for evaluating retrieval and QA generation performance
  * Made benchmark LLM and embedding configuration configurable via environment variables

* **Documentation**
  * Added benchmark design specifications for routing and temporal reasoning evaluation scenarios

* **Chores**
  * Updated evaluation metrics to use absolute token-per-query budget instead of relative comparison
<!-- end of auto-generated comment: release notes by coderabbit.ai -->