### PR TITLE
fix(readme): point agent-rules install path at the new in-package location

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ The cleanest way to install taosmd is to ask your agent to do it. Paste this mes
 > 2. Run the install script: `curl -fsSL https://raw.githubusercontent.com/jaylfc/taosmd/master/scripts/setup.sh | bash`. Report any errors and stop if it fails.
 > 3. Register yourself as an agent so you have your own isolated index. Pick a stable agent name (lowercase, no spaces) — the same name you'll use every time you call the librarian. If I have multiple agents in this framework, ask me what to name this one before registering.
 > 4. Verify the install: call `taosmd.search("hello", agent="<your-name>")` — it should return an empty result, not an error.
-> 5. Append the "Memory — taosmd" rules block from `docs/agent-rules.md` in the repo to my agent file (CLAUDE.md / system prompt / AGENTS.md — whatever your framework reads every turn). Replace `<your-agent-name>` with the name you registered as.
+> 5. Append the "Memory — taosmd" rules block to my agent file (CLAUDE.md / system prompt / AGENTS.md — whatever your framework reads every turn). Pull the block via `python -c "import taosmd; print(taosmd.agent_rules())"` — the file is shipped as package data at `taosmd/docs/agent-rules.md` so this works from both editable and wheel installs. Replace `<your-agent-name>` with the name you registered as.
 > 6. Confirm it's installed and tell me your agent name so I know how to refer to your memory.
 >
 > Don't summarise the repo or paraphrase the rules. Copy them verbatim — the wording is the contract.
 
-The agent will pull the repo, run the install, register itself, append the per-turn rules block to its own instruction file, and verify everything works. After that, every turn it runs it'll check the librarian when it's uncertain — see [docs/agent-rules.md](docs/agent-rules.md) for the rules block it installs.
+The agent will pull the repo, run the install, register itself, append the per-turn rules block to its own instruction file, and verify everything works. After that, every turn it runs it'll check the librarian when it's uncertain — see [taosmd/docs/agent-rules.md](taosmd/docs/agent-rules.md) for the rules block it installs (also available via `taosmd.agent_rules()`).
 
 **Multiple agents in one framework?** Same install message works. The agent will ask you to name it before registering, so each agent gets its own shelf. The taosmd service itself stays as one process; only the per-agent indexes are separate. See [docs/multi-agent.md](docs/multi-agent.md) for the full naming convention, cross-agent reads, migration scenarios, and a five-agent worked example.
 


### PR DESCRIPTION
PR #23 moved `docs/agent-rules.md` → `taosmd/docs/agent-rules.md` but the README still tells the install agent to read the old path — 404s on anyone following the install ritual right now. Update step 5 to use the `taosmd.agent_rules()` helper that PR #23 was designed for, plus fix the adjacent reference link. Pre-existing bug surfaced during a flat-repo audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified agent installation process with a programmatic method to fetch Memory rules via Python, replacing manual file copying.
  * Clarified rules location in the installed package and documented that rules are accessible through both file paths and a dedicated function call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->