### PR TITLE
fix(bench): revert think=false in rescore tool — silent zero-verdict bug on qwen3:4b

### DIFF
--- a/benchmarks/locomo_rescore_streaming.py
+++ b/benchmarks/locomo_rescore_streaming.py
@@ -122,10 +122,14 @@ async def call_judge(client, url, model, rec, timeout) -> tuple[str, object]:
         reference=rec.get("reference", ""),
         predicted=rec.get("predicted", ""),
     )
-    # think=false disables reasoning mode on Qwen3/3.5/3.6 judges — same
-    # speedup rationale as the runner. Judge verdicts are yes/no, hidden
-    # reasoning doesn't change the output but 20x slower to produce.
-    payload = {"model": model, "prompt": prompt, "stream": False, "think": False}
+    # NOTE: do NOT pass think=false here. On qwen3:4b (our default judge)
+    # the Ollama think parameter has inverted semantics vs the generation
+    # models — it EXPOSES reasoning tokens in the response rather than
+    # suppressing them. That breaks parse_judge_reply's startswith("yes")
+    # check because the response now begins with "Okay, the user is asking…".
+    # Leaving thinking-mode on here gives a clean yes/no reply in the same
+    # ~7-10s per judgement that the full external-judge run relied on.
+    payload = {"model": model, "prompt": prompt, "stream": False}
     try:
         resp = await client.post(f"{url}/api/generate", json=payload, timeout=timeout)
         resp.raise_for_status()


### PR DESCRIPTION
PR #42 landed think=false on both the runner and rescore tool. Turns out the Ollama think parameter has inverted semantics on qwen3:4b vs qwen3.5:9b — on the smaller judge model it exposes reasoning in the response instead of suppressing it. The rescore parser then scores every judgement 0.0 because the reply starts with 'Okay,' not 'yes'. 1452/1540 wasted judgements on qwen9b_k20 before detection. Runner keeps think=false (that speedup is real).