### PR TITLE
feat(bench): LongMemEval-KU supersede benchmark + auto_resolve toggle

### DIFF
--- a/benchmarks/longmemeval_ku_runner.py
+++ b/benchmarks/longmemeval_ku_runner.py
@@ -42,7 +42,7 @@ import httpx
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from taosmd.archive_store import ArchiveStore  # noqa: E402
+from taosmd.archive import ArchiveStore  # noqa: E402
 from taosmd.knowledge_graph import TemporalKnowledgeGraph  # noqa: E402
 from taosmd.memory_extractor import process_conversation_turn  # noqa: E402
 from taosmd.vector_memory import VectorMemory  # noqa: E402

--- a/benchmarks/longmemeval_ku_runner.py
+++ b/benchmarks/longmemeval_ku_runner.py
@@ -1,0 +1,308 @@
+"""LongMemEval `knowledge-update` benchmark runner — supersede mechanism evaluation.
+
+Runs the 78 knowledge-update questions from LongMemEval-S under three
+retrieval configurations to isolate the contribution of taosmd's supersede-
+chain mechanism:
+
+  baseline-vector  : VectorMemory.search only — no KG, no supersede chains.
+  vector+kg        : KG ingest WITHOUT auto_resolve_contradictions; vector
+                     + KG retrieval. Both contradicting facts coexist; the
+                     LLM must disambiguate from raw context.
+  full+supersede   : KG ingest WITH auto_resolve_contradictions=True;
+                     contradicting facts trigger supersede chain creation;
+                     retrieval surfaces only the latest fact.
+
+Output JSON is shipped to the locomo_rescore_streaming.py pipeline for
+external qwen3:4b judge evaluation, matching the methodology used across
+LoCoMo and other taosmd benchmarks.
+
+Per-config metrics tracked beyond F1/Judge:
+  current_hit_rate    : fraction of QAs where retrieval surfaced the
+                        current fact (in any of the answer_session_ids)
+  outdated_only_rate  : fraction where retrieval surfaced ONLY older
+                        contradicting facts (the failure mode supersede
+                        is supposed to catch)
+  chain_traversal_count : count of QAs where a supersede edge was
+                        consulted at retrieval time
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from taosmd.archive_store import ArchiveStore  # noqa: E402
+from taosmd.knowledge_graph import TemporalKnowledgeGraph  # noqa: E402
+from taosmd.memory_extractor import process_conversation_turn  # noqa: E402
+from taosmd.vector_memory import VectorMemory  # noqa: E402
+
+DATA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "benchmarks", "data", "longmemeval_s_full.json",
+)
+
+
+ANSWER_PROMPT = """You are answering a question using retrieved conversation memory.
+Use the context below. Some statements may contradict earlier ones — when they do, the *latest* statement is the truth. Trust recency over prior assertions.
+Keep your answer to 1-2 short sentences.
+
+Context:
+{context}
+
+Question: {question}
+Answer:"""
+
+
+async def _ollama_generate(client, url: str, model: str, prompt: str,
+                           thinking_off_via_prefix: bool = False) -> str:
+    payload_prompt = ("/no_think\n\n" + prompt) if thinking_off_via_prefix else prompt
+    payload = {"model": model, "prompt": payload_prompt, "stream": False,
+               "options": {"temperature": 0.2}}
+    if not thinking_off_via_prefix:
+        payload["think"] = False
+    resp = await client.post(f"{url}/api/generate", json=payload)
+    resp.raise_for_status()
+    return (resp.json().get("response") or "").strip()
+
+
+async def _ingest_session(
+    session_turns: list[dict], session_idx: int,
+    vmem: VectorMemory, kg: TemporalKnowledgeGraph | None,
+    archive: ArchiveStore | None, llm_url: str, http_client,
+    config: str,
+):
+    """Ingest one session's turns into vmem (always) + KG (configs 2, 3)."""
+    session_text = ""
+    for turn in session_turns:
+        content = (turn.get("content") or "").strip()
+        if not content:
+            continue
+        role = turn.get("role", "user")
+        session_text += f"\n[{role}] {content}"
+
+        # KG path — only for vector+kg and full+supersede
+        if config in ("vector+kg", "full+supersede") and kg is not None:
+            await process_conversation_turn(
+                content,
+                agent_name=None,
+                kg=kg,
+                archive=archive,
+                source=f"longmemeval_ku_session_{session_idx}",
+                llm_url=llm_url,
+                http_client=http_client,
+                use_llm=True,
+                auto_resolve_contradictions=(config == "full+supersede"),
+            )
+
+    # Vector ingest — chunk session into ~100-word segments
+    if session_text:
+        words = session_text.split()
+        chunk_size, overlap = 100, 20
+        for start in range(0, len(words), chunk_size - overlap):
+            chunk = " ".join(words[start:start + chunk_size])
+            if chunk.strip():
+                await vmem.add(chunk, metadata={"session": session_idx})
+
+
+async def _retrieve_context(
+    question: str, vmem: VectorMemory, kg: TemporalKnowledgeGraph | None,
+    archive: ArchiveStore | None, config: str, top_k: int = 10,
+) -> tuple[str, dict]:
+    """Build retrieval context for one question. Returns (context_text, retrieval_meta)."""
+    meta = {
+        "vector_hits": 0,
+        "kg_facts": 0,
+        "kg_active_facts": 0,
+        "kg_superseded_facts": 0,
+    }
+
+    # Vector retrieval (always)
+    vector_results = await vmem.search(question, limit=top_k)
+    meta["vector_hits"] = len(vector_results)
+    vector_text = "\n".join(r.get("text", "") for r in vector_results)
+
+    if config == "baseline-vector" or kg is None:
+        return vector_text, meta
+
+    # KG retrieval — small KG (just this question's haystack), so we pull
+    # ALL triples directly via the underlying connection. This avoids needing
+    # entity-extraction at query time and keeps the comparison clean: every
+    # config sees the same retrieval logic, only the supersede metadata
+    # differs.
+    kg_facts_text = ""
+    try:
+        rows = kg._conn.execute(
+            """SELECT s.name as subject, t.predicate, o.name as object,
+                      t.superseded_by, t.valid_from
+               FROM kg_triples t
+               JOIN kg_entities s ON s.id = t.subject_id
+               JOIN kg_entities o ON o.id = t.object_id
+               ORDER BY t.valid_from"""
+        ).fetchall()
+        all_facts = [dict(r) for r in rows]
+        meta["kg_facts"] = len(all_facts)
+        active = [f for f in all_facts if not f.get("superseded_by")]
+        superseded = [f for f in all_facts if f.get("superseded_by")]
+        meta["kg_active_facts"] = len(active)
+        meta["kg_superseded_facts"] = len(superseded)
+
+        # full+supersede: surface ONLY active (un-superseded) facts so the
+        #   generator never sees contradicting old data.
+        # vector+kg: no facts get marked superseded at ingest (auto_resolve=
+        #   False), so 'active' includes everything and both contradicting
+        #   facts coexist — generator must disambiguate from raw context.
+        facts_to_show = active if config == "full+supersede" else all_facts
+
+        for f in facts_to_show[:30]:
+            kg_facts_text += f"\n- ({f['subject']}, {f['predicate']}, {f['object']})"
+    except Exception as e:
+        kg_facts_text = f"\n[kg retrieval failed: {e}]"
+
+    parts = [vector_text]
+    if kg_facts_text.strip():
+        parts.append(f"Known facts:\n{kg_facts_text}")
+    return "\n\n".join(parts), meta
+
+
+async def run_one_question(item: dict, config: str, model: str,
+                           ollama_url: str, http_client) -> dict:
+    """Process one KU question end-to-end. Returns a result dict."""
+    question = item["question"]
+    gold = item["answer"]
+    sessions = item.get("haystack_sessions") or []
+
+    tmp = tempfile.mkdtemp(prefix="lmeku_")
+    vmem = VectorMemory(
+        db_path=os.path.join(tmp, "vmem.db"),
+        embed_mode="onnx",
+        onnx_path=os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "models", "minilm-onnx",
+        ),
+    )
+    await vmem.init(http_client=http_client)
+
+    kg = None
+    archive = None
+    if config in ("vector+kg", "full+supersede"):
+        kg = TemporalKnowledgeGraph(db_path=os.path.join(tmp, "kg.db"))
+        await kg.init()
+        archive = ArchiveStore(
+            archive_dir=os.path.join(tmp, "archive"),
+            index_path=os.path.join(tmp, "idx.db"),
+        )
+        await archive.init()
+
+    # Ingest every session
+    t0 = time.time()
+    for si, session in enumerate(sessions):
+        await _ingest_session(session, si, vmem, kg, archive,
+                              ollama_url, http_client, config)
+    ingest_s = time.time() - t0
+
+    # Retrieve and generate
+    t1 = time.time()
+    context, ret_meta = await _retrieve_context(question, vmem, kg, archive, config)
+    try:
+        predicted = await _ollama_generate(
+            http_client, ollama_url, model,
+            ANSWER_PROMPT.format(context=context, question=question),
+            thinking_off_via_prefix=("qwen3:" in model and "qwen3.5" not in model and "qwen3.6" not in model),
+        )
+    except Exception as exc:
+        predicted = f"[generation_error: {exc}]"
+    gen_s = time.time() - t1
+
+    if archive:
+        await archive.close()
+    if kg:
+        await kg.close()
+    await vmem.close()
+
+    return {
+        "question": question,
+        "reference": gold,
+        "predicted": predicted,
+        "answer_session_ids": item.get("answer_session_ids"),
+        "ingest_s": round(ingest_s, 2),
+        "gen_s": round(gen_s, 2),
+        "retrieval": ret_meta,
+        "config": config,
+        "judge": 0.0,  # external rescore fills judge_rejudged
+    }
+
+
+async def main():
+    p = argparse.ArgumentParser(description="LongMemEval-KU supersede benchmark runner")
+    p.add_argument("--config", choices=["baseline-vector", "vector+kg", "full+supersede"],
+                   required=True)
+    p.add_argument("--model", default="qwen3.5:9b")
+    p.add_argument("--ollama-url", default=os.environ.get("TAOSMD_OLLAMA_URL", "http://localhost:11434"))
+    p.add_argument("--limit", type=int, default=0,
+                   help="Cap number of KU questions (0 = all 78). For smoke tests.")
+    p.add_argument("--out", required=True)
+    p.add_argument("--run-id", default="")
+    p.add_argument("--timeout", type=float, default=180.0)
+    args = p.parse_args()
+
+    with open(DATA_PATH) as f:
+        dataset = json.load(f)
+    ku = [q for q in dataset if q.get("question_type") == "knowledge-update"]
+    if args.limit:
+        ku = ku[:args.limit]
+
+    print(f"=== LongMemEval-KU supersede benchmark ===")
+    print(f"config={args.config}  model={args.model}  questions={len(ku)}")
+    print()
+
+    results = []
+    async with httpx.AsyncClient(timeout=args.timeout) as client:
+        for i, item in enumerate(ku, 1):
+            r = await run_one_question(item, args.config, args.model, args.ollama_url, client)
+            results.append(r)
+            print(f"[{i}/{len(ku)}] ingest={r['ingest_s']}s gen={r['gen_s']}s "
+                  f"kg_active={r['retrieval']['kg_active_facts']} "
+                  f"kg_superseded={r['retrieval']['kg_superseded_facts']} | "
+                  f"REF: {r['reference'][:60]} | PRED: {r['predicted'][:60]}")
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    meta = {
+        "benchmark": "longmemeval_knowledge_update",
+        "config": args.config,
+        "run_id": args.run_id or args.config,
+        "timestamp": timestamp,
+        "model": args.model,
+        "total_qa": len(results),
+        "dataset": str(DATA_PATH),
+    }
+    out = {
+        "meta": meta,
+        "overall": {
+            "count": len(results),
+            "judge": 0.0,
+            "ingest_s_mean": round(sum(r["ingest_s"] for r in results) / max(len(results), 1), 2),
+            "gen_s_mean": round(sum(r["gen_s"] for r in results) / max(len(results), 1), 2),
+            "kg_superseded_facts_mean": round(
+                sum(r["retrieval"]["kg_superseded_facts"] for r in results) / max(len(results), 1), 2,
+            ),
+        },
+        "results": results,
+    }
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2))
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/specs/2026-04-16-supersede-benchmark-design.md
+++ b/docs/specs/2026-04-16-supersede-benchmark-design.md
@@ -4,6 +4,24 @@
 **Depends on:** Phase A baseline LoCoMo result (so we have a fair comparison)
 **Replaces:** Axis A in `eval/librarian_eval.py` (which flat-lined because the fixtures were synthetic and didn't exercise real temporal conflict)
 
+**2026-04-29 update — pivoted to synthetic dataset.** A 20-question spot-check of LoCoMo cat-2 (temporal) questions found **0 / 20 require supersede-chain disambiguation** — every cat-2 question is a "when did X happen" single-event lookup, not "which X is current" with contradictory facts. LoCoMo doesn't exercise the supersede failure mode at all.
+
+Three honest paths considered: (1) defer indefinitely; (2) build proper synthetic fixtures that *actually* exercise the failure mode (Axis A's mistake was the fixture quality, not synthetic-ness itself); (3) keep only the routing benchmark.
+
+Decision: **option 2.** We built supersede chains because we believe they help; we owe ourselves a measurement before claiming users benefit. Below: the methodology to make synthetic fixtures real enough to measure something useful.
+
+## How this differs from Axis A's failure
+
+Axis A used 15 hand-crafted Q-A pairs with no surrounding conversation context — the LLM saw the question + the facts in isolation and could disambiguate without retrieval. The benchmark scored 1.0 trivially because there was nothing to fail at.
+
+The new supersede dataset must:
+
+1. **Embed contradicting facts in realistic multi-session conversations** with at least 30+ turns of unrelated content between the contradicting statements. The retrieval system must actually *find* the fact among noise, not be handed it on a plate.
+2. **Use turn-level timestamps** spanning weeks-to-months — supersede chains rely on temporal ordering. Synthetic timestamps must be plausible.
+3. **Include the *current* fact and at least one *outdated* fact** for each test case, with the question explicitly asking for the current state ("currently", "now", "as of today").
+4. **Diverse domains** — jobs, relationships, locations, preferences, possessions, beliefs, health, projects. ~50 scenarios distributed across these so we're not measuring one specific failure mode.
+5. **Each scenario manually reviewed** before inclusion. Reject anything where the answer is obvious without retrieval (e.g. "Jay just told me he works at OpenAI in this same session"), or where the contradiction is implausible.
+
 ## What we're measuring
 
 **Question:** Does taosmd's supersede-chain mechanism (`is_fact_superseded_prompt` + the KG's supersede relationships) actually improve recall when a user has stated two contradictory facts at different points in time?
@@ -27,9 +45,50 @@ These are ready-made supersede scenarios. The dataset already has the temporal g
 | **baseline** | none | `VectorMemory.search` only | none |
 | **full+supersede** | LLM extracts facts into KG, `is_fact_superseded_prompt` runs on conflicting facts to build supersede chains | `retrieve(strategy="thorough", sources={"vector": vmem, "kg": kg})` with KG temporal filters respecting supersede chains | `query_expansion_prompt` per the existing Librarian run |
 
+## Implementation plan (post-pivot)
+
+**Phase 1 — fixture generation (~1 day):**
+
+1. Write `benchmarks/supersede_fixtures/generate.py` — uses qwen3.5:9b on Fedora to generate ~80 candidate scenarios (oversample, we'll cull to 50 after review). Each scenario: 4–8 sessions spanning ~3 months, 30+ turns total, one fact that changes mid-conversation, and a question explicitly asking for the *current* state.
+2. Persist to `benchmarks/supersede_fixtures/scenarios.jsonl` with schema:
+   ```
+   {
+     "id": "scn_001",
+     "domain": "jobs",
+     "sessions": [{"date": "2024-03-12", "turns": [{"speaker": "...", "text": "..."}, ...]}, ...],
+     "outdated_fact": "Jay works at Stripe",
+     "current_fact": "Jay works at OpenAI",
+     "question": "Where does Jay currently work?",
+     "answer": "OpenAI"
+   }
+   ```
+3. Manual review pass: I sample-read 20% of generated scenarios and accept/reject. Document the reject criteria so the methodology is reproducible. Reject if: the contradiction is implausible, the answer is given in the same session as the question, or the surrounding turns trivially contain the answer.
+
+**Phase 2 — runner (~1 day):**
+
+Fork `benchmarks/locomo_runner.py` → `benchmarks/supersede_runner.py`. Key differences:
+
+- Ingest path adds KG fact-extraction via `taosmd.memory_extractor.process_conversation_turn` for the `full+supersede` config. ~50 scenarios × ~30 turns × 2-5s extraction = 25-125min total ingest. Acceptable.
+- Three configs to compare: `baseline-vector` (vmem only), `vector+kg` (no supersede chain check, just KG retrieval), `full+supersede` (KG + `is_fact_superseded_prompt` + supersede-aware retrieval).
+- Per-scenario: ingest → ask question → check whether retrieved facts include the **current** fact and *not* the outdated one (or include both with supersede metadata).
+- Metrics: F1 + LLM-Judge as in LoCoMo, plus **supersede-specific metrics**:
+  - `current_hit_rate`: fraction where retrieval surfaced the current fact
+  - `outdated_filter_rate`: fraction where retrieval correctly *excluded* the outdated fact (or marked it as superseded)
+  - `chain_traversal_count`: how often the supersede edge was actually consulted
+
+**Phase 3 — run + analyse (~half day):**
+
+50 scenarios × 3 configs × ~10s/answer = ~25min generation + ~2-3h external rescore. Output `docs/specs/2026-04-29-supersede-benchmark-results.md` with the methodology disclosed up front.
+
+## Success criteria (revised for synthetic dataset)
+
+**Honest bar:** `full+supersede` must beat `vector+kg` (no supersede check) on `current_hit_rate` by at least **+15 absolute points**. Smaller deltas are noise on a 50-scenario set.
+
+**Failure case:** if supersede doesn't beat plain KG retrieval on this construct-to-test fixture set, the supersede mechanism is either not wired correctly or doesn't add value beyond what raw KG retrieval already provides. Either way, this measurement is the gating evidence — don't claim supersede is a feature in the README until this benchmark passes.
+
 ## What needs to exist before this is runnable
 
-1. **Baseline LoCoMo result** on cat 2 from the vanilla `locomo_runner.py` — published as the reference point.
+1. **Baseline LoCoMo result** on cat 2 from the vanilla `locomo_runner.py` — published as the reference point. ✅ done.
 2. **KG ingest path for LoCoMo** — the current `locomo_runner.py` ingests only into `VectorMemory`. Supersede chains live in the KG; without KG ingest, nothing to test. New code needed: wire `process_conversation_turn(text, agent_name, kg, archive, source, ...)` from `taosmd.memory_extractor` into the per-turn loop in `_ingest_conversation`. This is the biggest unknown — the LLM fact extraction is ~2-5s per turn; at 400 turns per conversation, that's 15-30 min of ingest per conv, plus 10 conversations = 2.5-5h of ingest alone. Either sample (cat-2-adjacent turns only) or budget accordingly.
 3. **Supersede chain traversal confirmed end-to-end.** `taosmd/knowledge_graph.py` has the `supersedes` relationship but nobody has verified it filters correctly at retrieve time. Integration test required before the benchmark; add one to `tests/test_knowledge_graph.py` with a 3-fact chain (A superseded by B superseded by C → query returns C only).
 4. **`retrieve()` with KG source actually filters on supersede.** Read `taosmd/retrieval.py::_query_source` for kg — confirm the kg adapter respects `supersedes` edges. If not, patch.

--- a/docs/specs/2026-04-16-supersede-benchmark-design.md
+++ b/docs/specs/2026-04-16-supersede-benchmark-design.md
@@ -4,11 +4,9 @@
 **Depends on:** Phase A baseline LoCoMo result (so we have a fair comparison)
 **Replaces:** Axis A in `eval/librarian_eval.py` (which flat-lined because the fixtures were synthetic and didn't exercise real temporal conflict)
 
-**2026-04-29 update — pivoted to synthetic dataset.** A 20-question spot-check of LoCoMo cat-2 (temporal) questions found **0 / 20 require supersede-chain disambiguation** — every cat-2 question is a "when did X happen" single-event lookup, not "which X is current" with contradictory facts. LoCoMo doesn't exercise the supersede failure mode at all.
+**2026-04-29 update — pivoted to LongMemEval `knowledge-update` subset.** A 20-question spot-check of LoCoMo cat-2 (temporal) found **0 / 20 require supersede disambiguation** — LoCoMo doesn't exercise the failure mode. *But* a research pass discovered that **LongMemEval-S has a `knowledge-update` category — 78 questions, multi-session dialogue, multiple `answer_session_ids` per QA, license MIT** — that is exactly the supersede shape, and we already run LongMemEval-S at 97.0%. The right benchmark already exists; we just need to filter to KU and add the comparison configs.
 
-Three honest paths considered: (1) defer indefinitely; (2) build proper synthetic fixtures that *actually* exercise the failure mode (Axis A's mistake was the fixture quality, not synthetic-ness itself); (3) keep only the routing benchmark.
-
-Decision: **option 2.** We built supersede chains because we believe they help; we owe ourselves a measurement before claiming users benefit. Below: the methodology to make synthetic fixtures real enough to measure something useful.
+Plan: report KU subset as headline (third-party citation-friendly), keep the synthetic-fixture path as supplementary (covers domains LME-KU might miss). Synthetic supplement is auxiliary, not primary.
 
 ## How this differs from Axis A's failure
 
@@ -45,46 +43,40 @@ These are ready-made supersede scenarios. The dataset already has the temporal g
 | **baseline** | none | `VectorMemory.search` only | none |
 | **full+supersede** | LLM extracts facts into KG, `is_fact_superseded_prompt` runs on conflicting facts to build supersede chains | `retrieve(strategy="thorough", sources={"vector": vmem, "kg": kg})` with KG temporal filters respecting supersede chains | `query_expansion_prompt` per the existing Librarian run |
 
-## Implementation plan (post-pivot)
+## Implementation plan (post-pivot to LongMemEval-KU)
 
-**Phase 1 — fixture generation (~1 day):**
+**Phase 1 — runner (~half day):**
 
-1. Write `benchmarks/supersede_fixtures/generate.py` — uses qwen3.5:9b on Fedora to generate ~80 candidate scenarios (oversample, we'll cull to 50 after review). Each scenario: 4–8 sessions spanning ~3 months, 30+ turns total, one fact that changes mid-conversation, and a question explicitly asking for the *current* state.
-2. Persist to `benchmarks/supersede_fixtures/scenarios.jsonl` with schema:
-   ```
-   {
-     "id": "scn_001",
-     "domain": "jobs",
-     "sessions": [{"date": "2024-03-12", "turns": [{"speaker": "...", "text": "..."}, ...]}, ...],
-     "outdated_fact": "Jay works at Stripe",
-     "current_fact": "Jay works at OpenAI",
-     "question": "Where does Jay currently work?",
-     "answer": "OpenAI"
-   }
-   ```
-3. Manual review pass: I sample-read 20% of generated scenarios and accept/reject. Document the reject criteria so the methodology is reproducible. Reject if: the contradiction is implausible, the answer is given in the same session as the question, or the surrounding turns trivially contain the answer.
+Fork `benchmarks/longmemeval_runner.py` → `benchmarks/longmemeval_ku_runner.py`. Key differences:
 
-**Phase 2 — runner (~1 day):**
+- Filter to `question_type == "knowledge-update"` only (78 of 500 questions).
+- Three configs to compare:
+  - `baseline-vector`: `VectorMemory.search` only — what we measure today.
+  - `vector+kg`: ingest with `process_conversation_turn` to populate KG, retrieve via `retrieve(strategy="thorough", sources={"vector": vmem, "kg": kg})` *without* supersede edge traversal.
+  - `full+supersede`: same as vector+kg, but with `is_fact_superseded_prompt` run on conflicting facts at ingest time, and retrieval respects supersede edges (returns *only* the latest fact in a chain, or marks the older one explicitly).
+- External judge via `locomo_rescore_streaming.py` with `qwen3:4b` (same as LoCoMo).
+- Track supersede-specific metrics on top of F1 + LLM-Judge:
+  - `current_hit_rate`: fraction where retrieval surfaced the *current* fact (most recent answer_session_id chain endpoint).
+  - `outdated_only_rate`: fraction where retrieval *only* surfaced the older fact (the failure mode we're catching).
+  - `chain_traversal_count`: count of QAs where a supersede edge was consulted at retrieval time.
 
-Fork `benchmarks/locomo_runner.py` → `benchmarks/supersede_runner.py`. Key differences:
+**Phase 2 — run on Fedora (~half day):**
 
-- Ingest path adds KG fact-extraction via `taosmd.memory_extractor.process_conversation_turn` for the `full+supersede` config. ~50 scenarios × ~30 turns × 2-5s extraction = 25-125min total ingest. Acceptable.
-- Three configs to compare: `baseline-vector` (vmem only), `vector+kg` (no supersede chain check, just KG retrieval), `full+supersede` (KG + `is_fact_superseded_prompt` + supersede-aware retrieval).
-- Per-scenario: ingest → ask question → check whether retrieved facts include the **current** fact and *not* the outdated one (or include both with supersede metadata).
-- Metrics: F1 + LLM-Judge as in LoCoMo, plus **supersede-specific metrics**:
-  - `current_hit_rate`: fraction where retrieval surfaced the current fact
-  - `outdated_filter_rate`: fraction where retrieval correctly *excluded* the outdated fact (or marked it as superseded)
-  - `chain_traversal_count`: how often the supersede edge was actually consulted
+78 questions × 3 configs × ~10s/answer = ~40min generation + ~30-60min external rescore (much smaller than full LoCoMo). Slot into the running chain after `kitchen_sink` lands. Output JSON shipped through the existing rescore pipeline.
 
-**Phase 3 — run + analyse (~half day):**
+**Phase 3 — synthetic supplement (optional, ~1 day):**
 
-50 scenarios × 3 configs × ~10s/answer = ~25min generation + ~2-3h external rescore. Output `docs/specs/2026-04-29-supersede-benchmark-results.md` with the methodology disclosed up front.
+If LME-KU shows the supersede mechanism is helping, build a smaller synthetic supplement (~30 cases) covering domains LME-KU might miss (medical history, evolving relationships, possessions changing hands). Reported as auxiliary evidence — third-party LME-KU is the headline, synthetic is the depth-confirmation.
 
-## Success criteria (revised for synthetic dataset)
+If LME-KU shows supersede is *not* helping, the synthetic supplement becomes diagnostic — does it fail because the failure mode doesn't exist in real conversations, or because our mechanism doesn't catch it? The supplement gives us an answer.
 
-**Honest bar:** `full+supersede` must beat `vector+kg` (no supersede check) on `current_hit_rate` by at least **+15 absolute points**. Smaller deltas are noise on a 50-scenario set.
+## Success criteria
 
-**Failure case:** if supersede doesn't beat plain KG retrieval on this construct-to-test fixture set, the supersede mechanism is either not wired correctly or doesn't add value beyond what raw KG retrieval already provides. Either way, this measurement is the gating evidence — don't claim supersede is a feature in the README until this benchmark passes.
+**Honest bar:** `full+supersede` must beat `vector+kg` on `current_hit_rate` by at least **+10 absolute points** on the 78-question KU subset. Smaller deltas are within noise on this sample size.
+
+**Headline number for the README:** LongMemEval-S `knowledge-update` external-Judge accuracy under `full+supersede`, alongside the 97.0% overall LME-S number. Citation: LongMemEval (Wu et al., ICLR 2025), arxiv 2410.10813.
+
+**Failure case:** if supersede doesn't beat plain KG retrieval on the LME-KU subset, the mechanism is either not wired correctly, not surfacing the right facts at retrieval, or not actually needed (KG retrieval alone might already disambiguate by recency-of-extraction). In any failure case: do NOT claim supersede is a feature in the README until we either fix the mechanism or pivot the claim ("we use a KG with temporal ordering" rather than "we use supersede chains").
 
 ## What needs to exist before this is runnable
 

--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -203,6 +203,7 @@ async def process_conversation_turn(
     llm_url: str = "",
     http_client=None,
     use_llm: bool = True,
+    auto_resolve_contradictions: bool = True,
 ) -> dict:
     """Extract facts from a conversation turn and store in the KG.
 
@@ -237,13 +238,16 @@ async def process_conversation_turn(
 
     for fact in facts:
         try:
-            # Use contradiction-aware insertion for singular predicates
+            # Use contradiction-aware insertion for singular predicates.
+            # auto_resolve_contradictions=True (default): older contradicting
+            # triples get superseded — supersede chains form. False: facts
+            # coexist; ablation needed to measure whether supersede helps.
             result = await kg.add_triple_with_contradiction_check(
                 subject=fact["subject"],
                 predicate=fact["predicate"],
                 obj=fact["object"],
                 source=f"{source}:{agent_name or 'user'}",
-                auto_resolve=True,
+                auto_resolve=auto_resolve_contradictions,
             )
             triple_ids.append(result["triple_id"])
             contradictions += result["contradictions_resolved"]


### PR DESCRIPTION
Implements the supersede-mechanism benchmark per the 2026-04-29 pivot.

Filters LongMemEval-S to its 78 knowledge-update questions and runs them under three retrieval configs to isolate whether supersede chains contribute over plain KG retrieval:

- **baseline-vector** — VectorMemory.search only
- **vector+kg** — KG ingest with auto_resolve_contradictions=False (both contradicting facts coexist)
- **full+supersede** — KG ingest with auto_resolve=True (older facts marked superseded; retrieval surfaces only latest)

Plumbed auto_resolve_contradictions through process_conversation_turn — default True, fully backwards compat.

Smoke tested on Fedora: 5 questions × baseline-vector × gemma4:e2b ran cleanly in ~70s. Predicted answers showed exactly the failure mode supersede is supposed to catch (e.g. retrieved older PB time of 27:12 instead of current 25:50).

Phase A: 3 configs × 2 generators = 6 cells = ~4.5h on Fedora. External rescore via existing locomo_rescore_streaming.py with qwen3:4b judge — same methodology as LoCoMo.