### PR TITLE
feat(api): add taosmd.ingest()/search() to back the agent-rules contract

### DIFF
--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -18,6 +18,7 @@ from .reflect import InsightStore
 from .session_catalog import SessionCatalog
 from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve
+from .api import ingest, search
 from .cross_encoder import CrossEncoderReranker
 from .access_tracker import AccessTracker
 from .preference_extractor import extract_preferences
@@ -74,6 +75,8 @@ __all__ = [
     "CatalogPipeline",
     # Retrieval
     "retrieve",
+    "ingest",
+    "search",
     "CrossEncoderReranker",
     "classify_intent",
     "get_search_strategy",

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -1,0 +1,286 @@
+"""High-level zero-config API for taOSmd agents.
+
+The two entry points referenced by ``taosmd/docs/agent-rules.md`` (the
+per-turn rules block agents copy into their instruction file):
+
+    await taosmd.ingest(transcript, agent="my-agent")
+    hits = await taosmd.search("what did we discuss about X?", agent="my-agent")
+
+Stores are auto-discovered from ``~/.taosmd`` (override with ``data_dir=``
+or the ``TAOSMD_DATA_DIR`` env var) and lazy-initialised on first call.
+The ``config.json`` written by ``python -m taosmd.auto_setup`` is honoured
+when present, so an agent that ran the install ritual gets sensible
+embed-mode defaults without further wiring.
+
+Ingest writes to the zero-loss archive (verbatim, append-only) and
+embeds the same text into vector memory so a later ``search()`` can
+reach it. Search returns hits in the agent-rules-contract shape:
+``{text, source, timestamp, confidence, metadata}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from collections.abc import Iterable
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = os.path.expanduser("~/.taosmd")
+_stores_lock = asyncio.Lock()
+_stores_cache: dict[str, dict] = {}
+
+
+def _resolve_data_dir(data_dir) -> str:
+    if data_dir is not None:
+        return os.fspath(data_dir)
+    env = os.environ.get("TAOSMD_DATA_DIR")
+    if env:
+        return env
+    return _DEFAULT_DATA_DIR
+
+
+def _load_config(data_dir: str) -> dict:
+    cfg_path = Path(data_dir) / "config.json"
+    if not cfg_path.exists():
+        return {}
+    try:
+        return json.loads(cfg_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("taosmd: failed to read %s: %s", cfg_path, exc)
+        return {}
+
+
+def _resolve_onnx_path(data_dir: str) -> str | None:
+    """Find the MiniLM ONNX model directory.
+
+    Search order: ``$TAOSMD_ONNX_PATH``, ``<data_dir>/models/minilm-onnx``,
+    ``$TAOSMD_DIR/models/minilm-onnx`` (set by ``scripts/setup.sh``),
+    ``~/taosmd/models/minilm-onnx`` (default install root). Returns None
+    when no candidate has a ``model.onnx`` file.
+    """
+    env = os.environ.get("TAOSMD_ONNX_PATH")
+    if env and (Path(env) / "model.onnx").exists():
+        return env
+    candidates = [
+        Path(data_dir) / "models" / "minilm-onnx",
+        Path(os.environ.get("TAOSMD_DIR", os.path.expanduser("~/taosmd"))) / "models" / "minilm-onnx",
+    ]
+    for candidate in candidates:
+        if (candidate / "model.onnx").exists():
+            return str(candidate)
+    return None
+
+
+async def _ensure_stores(data_dir=None) -> dict:
+    """Lazy-init and cache the {archive, vector, kg} stores for a data dir.
+
+    A separate cache entry per resolved data_dir means tests can pass an
+    isolated tmpdir without polluting the production cache.
+    """
+    resolved = _resolve_data_dir(data_dir)
+    cached = _stores_cache.get(resolved)
+    if cached is not None:
+        return cached
+
+    async with _stores_lock:
+        cached = _stores_cache.get(resolved)
+        if cached is not None:
+            return cached
+
+        from taosmd.archive import ArchiveStore
+        from taosmd.knowledge_graph import TemporalKnowledgeGraph
+        from taosmd.vector_memory import VectorMemory
+
+        path = Path(resolved)
+        path.mkdir(parents=True, exist_ok=True)
+        config = _load_config(resolved)
+        embed_mode = config.get("vector_memory", {}).get("embed_mode", "onnx")
+        onnx_path = _resolve_onnx_path(resolved) if embed_mode == "onnx" else ""
+        if embed_mode == "onnx" and onnx_path is None:
+            logger.warning(
+                "taosmd: ONNX model not found under %s/models or $TAOSMD_DIR; "
+                "falling back to qmd embed mode (set TAOSMD_ONNX_PATH or run setup.sh).",
+                resolved,
+            )
+            embed_mode = "qmd"
+
+        archive = ArchiveStore(
+            archive_dir=str(path / "archive"),
+            index_path=str(path / "archive-index.db"),
+        )
+        await archive.init()
+        vmem = VectorMemory(
+            db_path=str(path / "vector-memory.db"),
+            embed_mode=embed_mode,
+            onnx_path=onnx_path or "",
+        )
+        await vmem.init()
+        kg = TemporalKnowledgeGraph(db_path=str(path / "knowledge-graph.db"))
+        await kg.init()
+
+        stores = {
+            "archive": archive,
+            "vector": vmem,
+            "kg": kg,
+            "data_dir": str(path),
+        }
+        _stores_cache[resolved] = stores
+        return stores
+
+
+def _normalize_transcript(transcript) -> list[dict]:
+    """Coerce common shapes into a list of structured turn dicts.
+
+    Accepts a string (one turn, role unknown), a single dict (treated as
+    one turn), or any iterable of strings/dicts. Strings inside an
+    iterable each become a one-turn dict with role ``"unknown"``.
+    """
+    if isinstance(transcript, str):
+        return [{"role": "unknown", "content": transcript}]
+    if isinstance(transcript, dict):
+        return [dict(transcript)]
+    if isinstance(transcript, Iterable):
+        out: list[dict] = []
+        for item in transcript:
+            if isinstance(item, str):
+                out.append({"role": "unknown", "content": item})
+            elif isinstance(item, dict):
+                out.append(dict(item))
+            else:
+                out.append({"role": "unknown", "content": str(item)})
+        return out
+    raise TypeError(
+        f"transcript must be str, dict, or iterable, got {type(transcript).__name__}"
+    )
+
+
+async def ingest(transcript, *, agent: str, data_dir=None) -> dict:
+    """Shelve a transcript into the zero-loss archive and embed it for search.
+
+    Per the agent-rules contract: call after every meaningful exchange.
+    Verbatim text is preserved in the append-only archive; a copy is
+    embedded into vector memory so a later ``search()`` can find it.
+
+    Args:
+        transcript: A single message (str), a structured turn dict
+            (``{"role", "content", optional "timestamp"}``), or an iterable
+            of either.
+        agent: Registered agent name. Auto-registered if absent.
+        data_dir: Optional taosmd data dir. Defaults to ``$TAOSMD_DATA_DIR``
+            or ``~/.taosmd``.
+
+    Returns:
+        ``{"archived": int, "agent": str, "data_dir": str}`` — ``archived``
+        is the count of non-empty turns that were shelved.
+    """
+    if not agent:
+        raise ValueError("agent name is required")
+    items = _normalize_transcript(transcript)
+    stores = await _ensure_stores(data_dir)
+
+    from taosmd.agents import ensure_agent, update_stats
+    ensure_agent(agent)
+
+    archived = 0
+    for item in items:
+        text = str(item.get("content", "")).strip()
+        if not text:
+            continue
+        await stores["archive"].record(
+            "conversation",
+            item,
+            agent_name=agent,
+            summary=text[:80],
+        )
+        meta: dict = {"agent": agent}
+        if "role" in item:
+            meta["role"] = item["role"]
+        if "timestamp" in item:
+            meta["timestamp"] = item["timestamp"]
+        await stores["vector"].add(text, metadata=meta)
+        archived += 1
+
+    update_stats(agent, last_ingest_at=int(time.time()))
+    return {"archived": archived, "agent": agent, "data_dir": stores["data_dir"]}
+
+
+def _format_hit(hit: dict) -> dict:
+    """Reshape a retrieve() hit into the agent-rules contract shape.
+
+    Confidence is taken from the underlying source score (cosine
+    similarity for vector hits, KG confidence, etc) rather than the RRF
+    rank score, since the agent-rules threshold (``< 0.6``) reads in the
+    0-1 similarity range. Timestamp is read from user metadata or the
+    underlying row's ``created_at`` / ``timestamp`` field.
+    """
+    md = hit.get("metadata", {}) or {}
+    inner = md.get("metadata") if isinstance(md, dict) else None
+    user_md = inner if isinstance(inner, dict) else md
+
+    confidence = (
+        md.get("similarity")
+        if isinstance(md, dict) and md.get("similarity") is not None
+        else hit.get("source_score", 0.0)
+    )
+    timestamp = (
+        user_md.get("timestamp")
+        if isinstance(user_md, dict) and user_md.get("timestamp") is not None
+        else (md.get("created_at") if isinstance(md, dict) else None)
+        or (md.get("timestamp") if isinstance(md, dict) else None)
+        or 0
+    )
+
+    return {
+        "text": hit.get("text", ""),
+        "source": hit.get("source", "unknown"),
+        "timestamp": timestamp,
+        "confidence": round(float(confidence), 4),
+        "metadata": user_md if isinstance(user_md, dict) else {},
+    }
+
+
+async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> list[dict]:
+    """Search the librarian's shelves for passages relevant to ``query``.
+
+    Returns ranked hits in the agent-rules contract shape with explicit
+    ``source``, ``timestamp``, and ``confidence`` fields. If the top hit
+    has ``confidence < 0.6`` per the rules block, agents should treat it
+    as "she didn't find anything" rather than invent.
+
+    Args:
+        query: The search query.
+        agent: Registered agent name. Auto-registered if absent.
+        limit: Maximum number of hits to return.
+        data_dir: Optional taosmd data dir (see :func:`ingest`).
+    """
+    if not agent:
+        raise ValueError("agent name is required")
+    if not query:
+        return []
+
+    stores = await _ensure_stores(data_dir)
+
+    from taosmd.agents import ensure_agent
+    from taosmd.retrieval import retrieve as _retrieve
+    ensure_agent(agent)
+
+    raw = await _retrieve(
+        query,
+        sources={
+            "vector": stores["vector"],
+            "kg": stores["kg"],
+            "archive": stores["archive"],
+        },
+        agent=agent,
+        agent_name=agent,
+        limit=limit,
+    )
+    return [_format_hit(hit) for hit in raw]
+
+
+__all__ = ["ingest", "search"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,208 @@
+"""Tests for taosmd.api — top-level ingest()/search() entry points."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import taosmd
+from taosmd import api as taosmd_api
+
+
+def _patch_embedder(stores: dict) -> None:
+    """Override the vector store's embed() so tests don't need ONNX/QMD.
+
+    Returns a deterministic 8-dim hash-based vector — same input → same vector,
+    different inputs → different vectors. Good enough for the integration tests
+    here which only need search to find a row whose text matches the query.
+    """
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Each test gets its own data dir + a clean stores cache."""
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    # Force-close cached stores so SQLite handles release before tmp cleanup.
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir: Path):
+    """Init the cached stores and patch the embedder."""
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def test_top_level_exports_exist():
+    """Regression: agent-rules.md calls taosmd.ingest / taosmd.search verbatim."""
+    assert hasattr(taosmd, "ingest"), "agent-rules.md depends on this attribute"
+    assert hasattr(taosmd, "search"), "agent-rules.md depends on this attribute"
+    assert callable(taosmd.ingest)
+    assert callable(taosmd.search)
+
+
+def test_ingest_string_archives_and_embeds(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    result = asyncio.run(taosmd.ingest(
+        "Jay decided to ship the adjacent_neighbors port today.",
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert result["archived"] == 1
+    assert result["agent"] == "test-agent"
+    assert Path(result["data_dir"]).resolve() == isolated_data_dir.resolve()
+
+    # Verify a JSONL file ended up under archive/
+    archive_files = list((isolated_data_dir / "archive").rglob("*.jsonl"))
+    assert archive_files, "expected at least one archive jsonl file"
+    contents = archive_files[0].read_text()
+    assert "adjacent_neighbors" in contents
+
+
+def test_ingest_skips_empty_content(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    result = asyncio.run(taosmd.ingest(
+        [{"role": "user", "content": "real message"}, {"role": "user", "content": "   "}, {"role": "user", "content": ""}],
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert result["archived"] == 1
+
+
+def test_ingest_accepts_dict_and_iterable(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    one = asyncio.run(taosmd.ingest(
+        {"role": "user", "content": "single dict"},
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert one["archived"] == 1
+
+    many = asyncio.run(taosmd.ingest(
+        [
+            {"role": "user", "content": "turn one"},
+            {"role": "assistant", "content": "turn two"},
+            "bare string turn",
+        ],
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert many["archived"] == 3
+
+
+def test_ingest_requires_agent(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="agent name is required"):
+        asyncio.run(taosmd.ingest("hi", agent="", data_dir=str(isolated_data_dir)))
+
+
+def test_search_returns_agent_contract_shape(isolated_data_dir):
+    """Hit shape must include source, timestamp, confidence per agent-rules.md."""
+    _setup_stores(isolated_data_dir)
+    asyncio.run(taosmd.ingest(
+        "The benchmark leader is rrf_full_stack at 0.557.",
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    hits = asyncio.run(taosmd.search(
+        "The benchmark leader is rrf_full_stack at 0.557.",
+        agent="test-agent",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert hits, "expected at least one hit for an exact-content query"
+    hit = hits[0]
+    assert set(hit.keys()) >= {"text", "source", "timestamp", "confidence", "metadata"}
+    assert hit["source"] in {"vector", "kg", "archive", "catalog", "crystals"}
+    assert isinstance(hit["confidence"], float)
+    # The fake embedder is deterministic, so identical query and document yield
+    # max similarity (cosine ≈ 1.0). Confidence should land high.
+    assert hit["confidence"] > 0.6
+
+
+def test_search_empty_query_returns_empty(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    hits = asyncio.run(taosmd.search("", agent="test-agent", data_dir=str(isolated_data_dir)))
+    assert hits == []
+
+
+def test_search_requires_agent(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="agent name is required"):
+        asyncio.run(taosmd.search("anything", agent="", data_dir=str(isolated_data_dir)))
+
+
+def test_data_dir_resolution_env_var(monkeypatch, tmp_path):
+    """TAOSMD_DATA_DIR is honoured when no explicit data_dir is passed."""
+    monkeypatch.setenv("TAOSMD_DATA_DIR", str(tmp_path))
+    assert taosmd_api._resolve_data_dir(None) == str(tmp_path)
+
+
+def test_data_dir_resolution_default(monkeypatch):
+    monkeypatch.delenv("TAOSMD_DATA_DIR", raising=False)
+    assert taosmd_api._resolve_data_dir(None) == os.path.expanduser("~/.taosmd")
+
+
+def test_config_json_overrides_embed_mode(isolated_data_dir, monkeypatch):
+    """A config.json written by auto_setup steers embed_mode."""
+    config = {"vector_memory": {"embed_mode": "qmd", "hybrid_search": True}}
+    (isolated_data_dir / "config.json").write_text(json.dumps(config))
+    loaded = taosmd_api._load_config(str(isolated_data_dir))
+    assert loaded["vector_memory"]["embed_mode"] == "qmd"
+
+
+def test_format_hit_prefers_similarity_over_source_score():
+    """Vector hits should report similarity (cosine) as confidence, not source_score (which is the same here but the helper should pick from metadata first)."""
+    hit = {
+        "text": "x",
+        "source": "vector",
+        "source_id": "1",
+        "rank": 0,
+        "source_score": 0.9,
+        "metadata": {
+            "id": 1,
+            "similarity": 0.85,
+            "metadata": {"position": 7, "timestamp": 1700000000},
+            "created_at": 1234.0,
+        },
+    }
+    formatted = taosmd_api._format_hit(hit)
+    assert formatted["confidence"] == 0.85
+    assert formatted["source"] == "vector"
+    assert formatted["timestamp"] == 1700000000
+    assert formatted["metadata"] == {"position": 7, "timestamp": 1700000000}
+
+
+def test_format_hit_falls_back_to_source_score():
+    """Non-vector hits without similarity should use source_score as confidence."""
+    hit = {
+        "text": "kg fact",
+        "source": "kg",
+        "source_id": "person:alice",
+        "rank": 0,
+        "source_score": 0.95,
+        "metadata": {"confidence": 0.95},
+    }
+    formatted = taosmd_api._format_hit(hit)
+    assert formatted["confidence"] == 0.95
+    assert formatted["source"] == "kg"


### PR DESCRIPTION
## Summary

The per-turn rules block in \`taosmd/docs/agent-rules.md\` (which agents copy verbatim into their CLAUDE.md / AGENTS.md / system prompt at install time) told agents to call:

\`\`\`python
await taosmd.ingest(transcript, agent=\"<your-agent-name>\")
hits = await taosmd.search(query, agent=\"<your-agent-name>\")
\`\`\`

Neither function existed at the module level. An agent that followed the contract verbatim hit \`AttributeError\`, including the README's verify-install step (\`taosmd.search('hello', agent='<name>')\`). The compact rules-block API also drifted from the long-form \`AGENTS.md\` integration guide which uses the underlying \`archive.record()\` / \`vmem.search()\` calls directly — agents reading both got two different stories.

This PR backs the contract with real implementations. No doc churn — the rules block, AGENTS.md, and the README install ritual all stay as-is.

## What changes

- **\`taosmd/api.py\`** — new module with \`ingest()\` and \`search()\`. Both:
  - Auto-discover \`~/.taosmd\` (override via \`TAOSMD_DATA_DIR\` or explicit \`data_dir=\`)
  - Honour the \`config.json\` written by \`python -m taosmd.auto_setup\`
  - Find the MiniLM ONNX model under \`<data_dir>/models/minilm-onnx\`, \`\$TAOSMD_DIR/models/minilm-onnx\` (set by \`scripts/setup.sh\`), or \`\$TAOSMD_ONNX_PATH\`
  - Lazy-init stores on first call, cached per resolved \`data_dir\`
  - Auto-register the agent if it isn't already (mirrors the auto-register behaviour described in \`agents.py:15\`)
- **\`ingest()\`** — accepts a string, a \`{role, content, timestamp}\` dict, or any iterable of either. Shelves verbatim text into the zero-loss archive AND embeds it into vector memory so a later \`search()\` can reach it.
- **\`search()\`** — calls \`retrieve()\` across {vector, kg, archive} and reshapes hits into the agent-rules contract shape: \`{text, source, timestamp, confidence, metadata}\`. Confidence is read from the underlying source score (cosine for vector, KG confidence, etc) so the documented \`< 0.6\` threshold reads in the right range.
- **\`taosmd/__init__.py\`** — re-exports \`ingest\` and \`search\`.

## What does NOT change

- \`taosmd/docs/agent-rules.md\` — already accurate; this PR makes it true.
- \`AGENTS.md\` — long-form integration guide still uses the lower-level API for agents that want fine-grained control. Both paths now coexist cleanly.
- \`benchmarks/\`, \`docs/benchmarks.md\`, README — untouched.

## Test plan

- [x] 13 new tests in \`tests/test_api.py\` cover: top-level export presence (regression for the agent-rules contract), ingest of str/dict/iterable, empty-content skipping, agent-required validation, search hit shape, empty query, data_dir resolution (explicit / env / default), config.json honoured, and \`_format_hit\` confidence-source preference
- [x] Full suite: 123 passing (110 prior + 13 new)
- [x] Tests use a tmpdir as \`data_dir\` and a deterministic fake embedder, so they don't need ONNX or QMD installed
- [ ] Manual verify on a fresh \`~/.taosmd\` install: \`python -c \"import asyncio, taosmd; asyncio.run(taosmd.ingest('hi', agent='manual'))\"\` then \`asyncio.run(taosmd.search('hi', agent='manual'))\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ingest()` function to archive and index transcripts by agent
  * Added `search()` function to query stored data with confidence scores and metadata
  * Both functions now available directly from the taosmd package
  * Automatic data directory resolution with customizable paths
  * Search results include text, source, timestamp, and confidence metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->