### PR TITLE
docs: retract subset-200 Single-hop pick after full-1540 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,16 +181,19 @@ The Librarian adds LLM-assisted query expansion on top of the vector + cross-enc
 
 LoCoMo-10 is a harder dataset than LongMemEval-S: 1540 QAs across multi-session conversations (50+ sessions, 400–700 turns), four categories, more pressure on the retrieval architecture. We run it on the smaller generators we actually target so the numbers reflect the hardware tier our users run on, not gpt-4o-mini.
 
-**0.557 ext rejudge** on the full 1540-QA test set under our strict default judge (`qwen3:4b`) — and **0.71 overall / 0.53 Single-hop** on the 200-QA subset under the lenient matched-with-paper-SOTA judge (`gemma4:e2b`). Same predictions, same recipe (qwen3.5:9b + `--retrieval-top-k 20 --adjacent-turns 2 --llm-query-expansion --fusion rrf`), only the judge differs. Both numbers are honest measurements of the same system; published numbers from Mem0/EMem/Zep use a lenient frontier judge (gpt-4o-mini), so 0.71 is the more apples-to-apples comparison number with their headlines. See [docs/benchmarks.md](docs/benchmarks.md#judge-sensitivity--what-we-are-really-measuring) for the full multi-judge analysis.
+**0.557 ext rejudge** on the full 1540-QA test set under our strict default judge (`qwen3:4b`) — and **0.68 overall / 0.55 Single-hop** on the **full 1540 QAs** under the lenient matched-with-paper-SOTA judge (`gemma4:e2b`). Same predictions, same recipe (qwen3.5:9b + `--retrieval-top-k 20 --adjacent-turns 2 --llm-query-expansion --fusion mem0_additive --gen-temp 0.2`), only the judge differs. Both numbers are honest measurements of the same system; published numbers from Mem0/EMem/Zep use a lenient frontier judge (gpt-4o-mini), so 0.68 is the more apples-to-apples comparison number with their headlines. See [docs/benchmarks.md](docs/benchmarks.md#judge-sensitivity--what-we-are-really-measuring) for the full multi-judge analysis.
 
-**Recommended generators at the 12 GB GPU tier** (200-QA subset, leader recipe, dual-judge scored, temperature-tuned):
+> **Subset 200 ≠ full 1540 for every recipe.** Earlier versions of this table reported subset-200 numbers for some rows. Validating those at full 1540 found the leader recipe (qwen+mem0+temp 0.2) generalises within −0.01 SH, but the previously-listed "Best Single-hop" pick (llama3.1:8b + RRF + temp 0.2) regressed by −0.16 SH at full scale and has been removed below. All ranks shown here are now validated at full 1540 before promotion; the asterisked rows are explicit about which scale they were measured at.
+
+**Recommended generators at the 12 GB GPU tier** (leader recipe, dual-judge scored, temperature-tuned):
 
 | Workload | Generator | Fusion | Temp | Overall (q3:4b / g4:e2b) | Single-hop (g4:e2b) | Notes |
 |---|---|---|---|---|---|---|
-| **Best overall** (default) | `qwen3.5:9b` Q4_K_M (5.3 GB) | `mem0_additive` | **0.2** | 0.54 / **0.71** | 0.56 | Best Multi-hop (0.77) under matched-judge. Production default. |
-| **Best factual recall** | `llama3.1:8b` (4.9 GB) | `rrf` | **0.2** | 0.54 / 0.67 | **0.65** | Wins Single-hop by +0.09 over qwen. **2.4× faster per QA**. RRF heuristic beats `mem0_additive` for *this* generator (-0.05 with mem0). |
-| Best mem0_additive Single-hop | `llama3.1:8b` | `mem0_additive` | **0.0** | 0.51 / 0.65 | 0.60 | Greedy decoding lifts llama Single-hop +0.13 vs temp 0.2. The biggest single-lever effect we've measured since the judge-strictness pivot. |
-| **Best temporal reasoning** | `mistral-small3.2` (~5 GB) | `rrf` | 0.2 | 0.56 / 0.70 | 0.53 | Wins Temporal (0.71). 2.8× slower than qwen — specialty pick only. |
+| **Best overall** (default) | `qwen3.5:9b` Q4_K_M (5.3 GB) | `mem0_additive` | **0.2** | 0.54 / **0.68** | **0.55** | **Validated at full 1540.** Wins Overall and Single-hop on full scale. Production default. |
+| Best mem0_additive Single-hop† | `llama3.1:8b` (4.9 GB) | `mem0_additive` | **0.0** | 0.51 / 0.65 | 0.60 | Subset 200. Greedy decoding lifted llama Single-hop +0.13 vs temp 0.2 in the temp sweep. Full-1540 validation pending. |
+| **Best temporal reasoning**† | `mistral-small3.2` (~5 GB) | `rrf` | 0.2 | 0.56 / 0.70 | 0.53 | Subset 200. Wins Temporal (0.71). 2.8× slower than qwen — specialty pick only. Full-1540 validation pending. |
+
+† Subset-200 measurement; the leader row is the only one currently validated at full 1540. The llama3.1:8b + RRF row from earlier versions of this table was removed after its full-1540 Single-hop measured at 0.49 (vs 0.65 on subset 200), failing the validation threshold.
 
 Other measured 12 GB-tier generators (Overall under gemma4:e2b judge, leader recipe): `gemma4:e4b` 0.60 / 0.65 (best at temp 0.5), `gemma4:e2b` 0.60 (best at temp 0.5), `granite4:tiny-h` 0.56, `phi4-reasoning` timeout.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -399,6 +399,24 @@ Updated 12 GB tier guidance (matched-judge methodology, gemma4:e2b):
 
 Measured on Fedora 12 GB 3060 host, May 8-9 2026. Bench script at `/home/jay/temp_sweep_bench.sh`; full summary at `/tmp/temp_sweep_bench_summary.tsv`. `--gen-temp` flag lives on branch `feat/gen-temp-flag` (commit `2bd1b21`) for reproduction.
 
+#### Subset 200 → full 1540 validation
+
+The May 7-9 temp-sweep cells were all measured at the 200-QA subset for chain throughput. On May 10-11 we re-ran the two cells that were headline picks in the README at full 1540 QAs so a public-facing ranking isn't sitting on subset noise.
+
+| Recipe | Subset 200 (g4e2b) Overall / SH | Full 1540 (g4e2b) Overall / SH | Δ Overall | Δ SH | Verdict |
+|---|---|---|---|---|---|
+| **qwen3.5:9b + mem0_additive + temp 0.2** (leader) | 0.71 / 0.56 | **0.68 / 0.55** | −0.03 | −0.01 | **Generalises.** Production default holds. |
+| llama3.1:8b + RRF + temp 0.2 (subset SH pick) | 0.67 / 0.65 | 0.64 / 0.49 | −0.03 | **−0.16** | **Regression.** Subset 200 over-represented Single-hop questions where llama+RRF won. Removed from README. |
+
+Methodology takeaways:
+
+- **Overall drift is uniformly small (−0.03)** across both recipes — subset 200 is a fair Overall sampler.
+- **Single-hop drift is recipe-dependent.** qwen+mem0 holds within noise (−0.01). llama+RRF collapses (−0.16). Subset 200 happened to over-represent the Single-hop questions where llama+RRF won at our recipe / generator pairing.
+- **Subset 200 is no longer sufficient for promoting a workload-specific recommendation** — particularly per-category picks. Subset → full validation is now required before any README claim that names a specific recipe as "best at X."
+- **Cell-3 (qwen+mem0) dual-judge complete:** qwen3:4b 0.54 / 0.28 SH, gemma4:e2b 0.68 / 0.55 SH. **Cell-4 (llama+RRF) qwen3:4b rescore is still running at the time of this update; only the gemma4:e2b half is reflected in the table above.** The qwen3:4b rescore for cell 4 will be added as a follow-up commit once it lands.
+
+Measured on Fedora 12 GB 3060 host, May 10-11 2026. Bench script at `/tmp/llama_rrf_gapfill_bench.sh`; full summary at `/tmp/llama_rrf_gapfill_summary.tsv` on the bench host.
+
 ### ENGRAM-style typed retrieval — does typed memory routing raise Single-hop?
 
 The third architectural lever we tested at this generator tier. Same setup as the prompt and embedder sweeps but varying the *retrieval routing*: instead of one undifferentiated vector store, classify each conversation turn into three typed memory stores at ingest, then fan out per-type top-k searches at retrieval and set-merge before the leader pipeline.


### PR DESCRIPTION
## Summary

- Full-1540 validation of the May 7-9 hardware-tier table revealed the llama3.1:8b + RRF + temp 0.2 \"Best Single-hop\" recipe regresses from **0.65 SH (subset 200)** to **0.49 SH (full 1540)** under gemma4:e2b — a -0.16 collapse.
- The leader recipe (qwen3.5:9b + mem0_additive + temp 0.2) generalises within noise (-0.01 SH), so production default holds with refreshed numbers (Overall 0.71 → 0.68).
- README row removed for llama+RRF; surviving subset-200 rows (llama+mem0+temp 0, mistral+rrf+0.2) carry explicit \"subset 200, full-1540 validation pending\" footnotes.
- New callout above the table makes the subset → full discipline explicit going forward.
- docs/benchmarks.md gains a \"Subset 200 → full 1540 validation\" subsection under the temp-sweep section with the side-by-side comparison and methodology takeaways.

## Status of the underlying bench

- **Cell 3 (qwen+mem0+0.2 full 1540)** — dual-judge complete: q34b 0.54 / 0.28 SH, g4e2b 0.68 / 0.55 SH.
- **Cell 4 (llama+RRF+0.2 full 1540)** — gemma4:e2b rescore complete (0.64 / 0.49 SH). qwen3:4b rescore still running at ~325/1540, ETA ~6h. q34b half will land as a follow-up commit on this branch.

The gemma4:e2b half alone is enough to flip the Single-hop ranking, so shipping the retraction now rather than waiting another ~6h.

## Test plan

- [x] AST + flag plumbing already validated when the bench script was queued
- [x] Numbers cross-checked against /tmp/llama_rrf_gapfill_summary.tsv on the bench host
- [ ] Add cell-4 qwen3:4b rescore numbers when they land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LoCoMo benchmark results with re-evaluation on expanded validation set
  * Revised generator recommendations for the 12 GB GPU tier based on latest performance findings
  * Added post-processing documentation explaining validation methodology and generalization analysis

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->