### PR TITLE
feat: merge leader stack to master (BM25 + lemma + mem0_additive + CoVe + LLM rerank + --gen-temp)

### DIFF
--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -33,6 +33,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from taosmd.vector_memory import VectorMemory  # noqa: E402
 from taosmd.retrieval import retrieve  # noqa: E402
+from taosmd.llm_rerank import llm_listwise_rerank  # noqa: E402
 
 CATEGORY_NAMES = {
     1: "Single-hop (1)",
@@ -653,6 +654,9 @@ async def _process_qa(
     llama_server_url: str = "",
     expansion_model: str = "",
     cove: bool = False,
+    llm_rerank: bool = False,
+    llm_rerank_model: str = "llama3.1:8b",
+    llm_rerank_top_k: int = 10,
 ) -> dict | None:
     if "answer" not in qa:
         return None
@@ -750,6 +754,17 @@ async def _process_qa(
             hits = all_hits[:retrieval_top_k]
         else:
             hits = await _retrieve(strategy, retrieval_query, vmem, retrieval_top_k, reranker, fusion=fusion)
+
+        # Optional LLM listwise rerank — runs AFTER the cross-encoder narrows.
+        # Single LLM call per QA scores all candidates as a list, returns
+        # top-N most relevant. Direct port of Mem0's reranker idea adapted
+        # for our local-tier latency budget (listwise instead of pointwise).
+        if llm_rerank and hits:
+            hits = await llm_listwise_rerank(
+                client, ollama_url, llm_rerank_model,
+                retrieval_query, hits, top_k=llm_rerank_top_k,
+                no_think_prefix=no_think_prefix,
+            )
 
         # Optional temporal-recency boost — re-rank hits with an exponential
         # decay over turn-index age. Applied AFTER retrieval/rerank so the
@@ -956,6 +971,9 @@ async def run(args: argparse.Namespace) -> int:
                     llm_backend=args.llm_backend,
                     llama_server_url=args.llm_server_url,
                     cove=args.cove,
+                    llm_rerank=args.llm_rerank,
+                    llm_rerank_model=args.llm_rerank_model,
+                    llm_rerank_top_k=args.llm_rerank_top_k,
                     expansion_model=args.expansion_model,
                 )
             except Exception as e:
@@ -1204,6 +1222,19 @@ def _parse_args() -> argparse.Namespace:
                         "answer. Adds 4 LLM calls per QA (3-4× wall-clock). "
                         "Direct attack on hallucination/wrong-fact errors. "
                         "Per Dhuliawala et al. arXiv:2309.11495.")
+    p.add_argument("--llm-rerank", action="store_true",
+                   help="LLM listwise rerank on top of the cross-encoder. "
+                        "Single LLM call per QA scores all candidates "
+                        "together, returns the top-N. Adapted from Mem0's "
+                        "reranker for our local-tier latency budget. "
+                        "Adds ~1 LLM call per QA (~5 s on llama3.1:8b).")
+    p.add_argument("--llm-rerank-model", default="llama3.1:8b",
+                   help="Model used for the LLM listwise rerank step. "
+                        "Default llama3.1:8b (good balance of speed and "
+                        "instruction-following on the rerank task).")
+    p.add_argument("--llm-rerank-top-k", type=int, default=10,
+                   help="Number of candidates to keep after the LLM listwise "
+                        "rerank. Default 10. Set lower for tighter context.")
     p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
     p.add_argument("--out", default=None)
     p.add_argument("--run-id", default=None)

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -657,6 +657,7 @@ async def _process_qa(
     llm_rerank: bool = False,
     llm_rerank_model: str = "llama3.1:8b",
     llm_rerank_top_k: int = 10,
+    gen_temp: float = 0.2,
 ) -> dict | None:
     if "answer" not in qa:
         return None
@@ -788,6 +789,7 @@ async def _process_qa(
         draft = await _generate(
             llm_backend, client, gen_url, model,
             answer_prompt,
+            temperature=gen_temp,
             thinking_mode=thinking_mode,
             no_think_prefix=no_think_prefix,
         )
@@ -800,6 +802,7 @@ async def _process_qa(
                 )
                 plan_raw = await _generate(
                     llm_backend, client, gen_url, model, plan_prompt,
+                    temperature=gen_temp,
                     thinking_mode=thinking_mode, no_think_prefix=no_think_prefix,
                 )
                 # parse verification questions: one per line, drop empties
@@ -819,6 +822,7 @@ async def _process_qa(
                             COVE_VERIFY_PROMPT.format(
                                 context=context, verify_question=vq,
                             ),
+                            temperature=gen_temp,
                             thinking_mode=thinking_mode,
                             no_think_prefix=no_think_prefix,
                         )
@@ -835,6 +839,7 @@ async def _process_qa(
                     )
                     predicted = await _generate(
                         llm_backend, client, gen_url, model, final_prompt,
+                        temperature=gen_temp,
                         thinking_mode=thinking_mode,
                         no_think_prefix=no_think_prefix,
                     )
@@ -974,6 +979,7 @@ async def run(args: argparse.Namespace) -> int:
                     llm_rerank=args.llm_rerank,
                     llm_rerank_model=args.llm_rerank_model,
                     llm_rerank_top_k=args.llm_rerank_top_k,
+                    gen_temp=args.gen_temp,
                     expansion_model=args.expansion_model,
                 )
             except Exception as e:
@@ -1235,6 +1241,12 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--llm-rerank-top-k", type=int, default=10,
                    help="Number of candidates to keep after the LLM listwise "
                         "rerank. Default 10. Set lower for tighter context.")
+    p.add_argument("--gen-temp", type=float, default=0.2,
+                   help="Generator sampling temperature (passed to ollama "
+                        "options.temperature for the answer step and any "
+                        "CoVe verification calls). Default 0.2 — the value "
+                        "every prior LoCoMo cell ran at; sweep 0.0 / 0.5 / "
+                        "0.8 to test sampling sensitivity.")
     p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
     p.add_argument("--out", default=None)
     p.add_argument("--run-id", default=None)

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -102,6 +102,41 @@ Question: {question}
 
 Hypothetical passage:"""
 
+# Chain-of-Verification (CoVe) — multi-step answer with self-verification.
+# Per the original paper (Dhuliawala et al., 2023, arXiv:2309.11495) and
+# CoV-RAG follow-ups: draft → plan verification questions → answer them
+# independently → produce final answer informed by the verifications.
+# We adapt for context-grounded LoCoMo: every step uses the retrieved
+# context. Independence between verification answers is preserved by
+# isolating each call (no chain-of-thought between verifications).
+COVE_PLAN_PROMPT = """Given the draft answer below, write 2-3 short verification questions that test the specific factual claims in the draft. Each question should be answerable independently from the conversation context. No numbering, no commentary, one question per line.
+
+Context:
+{context}
+
+Original question: {question}
+Draft answer: {draft}
+
+Verification questions:"""
+
+COVE_VERIFY_PROMPT = """Answer this question using ONLY the context. Be concrete and brief (≤ 1 sentence). If the context does not directly support an answer, reply exactly "uncertain".
+
+Context:
+{context}
+
+Question: {verify_question}
+Answer:"""
+
+COVE_FINAL_PROMPT = """You drafted an answer to a question, then ran verification questions. Use the verification answers to produce a final, corrected answer. If verifications support the draft, keep it. If they contradict it, correct it. If verifications are "uncertain" or conflicting, prefer the most-supported claim.
+
+Original question: {question}
+Draft answer: {draft}
+
+Verification Q&A:
+{verifications}
+
+Final answer (1-2 short sentences, absolute dates only — never relative):"""
+
 _PUNCT = re.compile(r"[^\w\s]")
 
 
@@ -617,6 +652,7 @@ async def _process_qa(
     llm_backend: str = "ollama",
     llama_server_url: str = "",
     expansion_model: str = "",
+    cove: bool = False,
 ) -> dict | None:
     if "answer" not in qa:
         return None
@@ -734,12 +770,64 @@ async def _process_qa(
         answer_prompt = ANSWER_PROMPT.format(context=context, question=question)
         if few_shot:
             answer_prompt = FEW_SHOT_EXAMPLES + answer_prompt
-        predicted = await _generate(
+        draft = await _generate(
             llm_backend, client, gen_url, model,
             answer_prompt,
             thinking_mode=thinking_mode,
             no_think_prefix=no_think_prefix,
         )
+        if cove:
+            # Chain-of-Verification: plan verification questions, answer them
+            # independently, then produce final answer using the verifications.
+            try:
+                plan_prompt = COVE_PLAN_PROMPT.format(
+                    context=context, question=question, draft=draft,
+                )
+                plan_raw = await _generate(
+                    llm_backend, client, gen_url, model, plan_prompt,
+                    thinking_mode=thinking_mode, no_think_prefix=no_think_prefix,
+                )
+                # parse verification questions: one per line, drop empties
+                verify_qs = [
+                    q.strip().lstrip("-•0123456789. )")
+                    for q in plan_raw.splitlines()
+                    if q.strip() and len(q.strip()) > 5
+                ][:3]
+                if not verify_qs:
+                    predicted = draft
+                else:
+                    # answer each verification independently — no shared
+                    # CoT between them, that's the point of CoVe
+                    verify_tasks = [
+                        _generate(
+                            llm_backend, client, gen_url, model,
+                            COVE_VERIFY_PROMPT.format(
+                                context=context, verify_question=vq,
+                            ),
+                            thinking_mode=thinking_mode,
+                            no_think_prefix=no_think_prefix,
+                        )
+                        for vq in verify_qs
+                    ]
+                    verify_answers = await asyncio.gather(*verify_tasks, return_exceptions=True)
+                    verifications_text = "\n".join(
+                        f"Q: {q}\nA: {a if not isinstance(a, Exception) else 'uncertain'}"
+                        for q, a in zip(verify_qs, verify_answers)
+                    )
+                    final_prompt = COVE_FINAL_PROMPT.format(
+                        question=question, draft=draft,
+                        verifications=verifications_text,
+                    )
+                    predicted = await _generate(
+                        llm_backend, client, gen_url, model, final_prompt,
+                        thinking_mode=thinking_mode,
+                        no_think_prefix=no_think_prefix,
+                    )
+            except Exception as cove_exc:
+                # if any verification step fails, fall back to draft
+                predicted = draft
+        else:
+            predicted = draft
     except Exception as exc:
         predicted = f"[generation_error: {exc}]"
     gen_ms = (time.time() - t1) * 1000.0
@@ -867,6 +955,7 @@ async def run(args: argparse.Namespace) -> int:
                     turn_index=turn_index,
                     llm_backend=args.llm_backend,
                     llama_server_url=args.llm_server_url,
+                    cove=args.cove,
                     expansion_model=args.expansion_model,
                 )
             except Exception as e:
@@ -1108,6 +1197,13 @@ def _parse_args() -> argparse.Namespace:
                         "synthetic (no LoCoMo overlap, no test-set leakage). "
                         "~250 token prompt tax per QA. Known to lift small "
                         "instruction-tuned models +0.02-0.04 on factual QA.")
+    p.add_argument("--cove", action="store_true",
+                   help="Chain-of-Verification on the answer step. Generator "
+                        "drafts an answer → plans 2-3 verification questions → "
+                        "answers them independently → produces final verified "
+                        "answer. Adds 4 LLM calls per QA (3-4× wall-clock). "
+                        "Direct attack on hallucination/wrong-fact errors. "
+                        "Per Dhuliawala et al. arXiv:2309.11495.")
     p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
     p.add_argument("--out", default=None)
     p.add_argument("--run-id", default=None)

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -1065,7 +1065,7 @@ def _parse_args() -> argparse.Namespace:
                         "decay rate per turn-index age (0.0 disables, 0.02 "
                         "down-weights the oldest turn in a 600-turn convo by "
                         "~6e-6, 0.005 by ~0.05). Default 0.0.")
-    p.add_argument("--fusion", choices=["boost", "rrf", "none"], default="boost",
+    p.add_argument("--fusion", choices=["boost", "rrf", "bm25_rrf", "none"], default="boost",
                    help="Vector + keyword fusion mode (vector-only strategy):\n"
                         "  boost: legacy additive keyword boost (0.3 * overlap, our "
                         "current default in the matrix runs).\n"

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -1065,7 +1065,7 @@ def _parse_args() -> argparse.Namespace:
                         "decay rate per turn-index age (0.0 disables, 0.02 "
                         "down-weights the oldest turn in a 600-turn convo by "
                         "~6e-6, 0.005 by ~0.05). Default 0.0.")
-    p.add_argument("--fusion", choices=["boost", "rrf", "bm25_rrf", "none"], default="boost",
+    p.add_argument("--fusion", choices=["boost", "rrf", "bm25_rrf", "bm25_lemma_rrf", "mem0_additive", "none"], default="boost",
                    help="Vector + keyword fusion mode (vector-only strategy):\n"
                         "  boost: legacy additive keyword boost (0.3 * overlap, our "
                         "current default in the matrix runs).\n"

--- a/taosmd/llm_rerank.py
+++ b/taosmd/llm_rerank.py
@@ -1,0 +1,136 @@
+"""LLM-based listwise reranker.
+
+Single-pass listwise scoring: one LLM call sees all N candidates plus the
+query and returns a ranked list of candidate numbers, most-to-least
+relevant. Fast (200 QAs × ~5 s/call ≈ 17 min for the rerank step) vs
+pointwise (N × per-call), and the listwise prompt lets the model see
+cross-document relations rather than scoring each doc in isolation.
+
+Inspired by Mem0's llm_reranker (Apache 2.0, mem0/reranker/llm_reranker.py)
+but uses a single listwise call instead of Mem0's per-candidate
+pointwise scoring — chosen for our local-tier latency budget where 20
+sequential ~3 s LLM calls per QA would dominate bench wall-clock.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+LLM_RERANK_PROMPT = """You are a relevance ranker. Given a question and {n} candidate passages, output the candidate numbers in order from MOST relevant to LEAST relevant for answering the question.
+
+Output ONLY the candidate numbers, comma-separated, on a single line. No explanation, no other text.
+
+Question: {query}
+
+Candidates:
+{candidates}
+
+Ranking (most to least relevant, comma-separated numbers, just the numbers):"""
+
+
+def _build_candidates_block(texts: Iterable[str], char_cap: int = 280) -> str:
+    """Render candidates as a numbered block, truncated to keep prompt budget."""
+    lines = []
+    for i, text in enumerate(texts, start=1):
+        snippet = (text or "").strip().replace("\n", " ")
+        if len(snippet) > char_cap:
+            snippet = snippet[:char_cap].rstrip() + "…"
+        lines.append(f"{i}. {snippet}")
+    return "\n".join(lines)
+
+
+def _parse_ranking(response: str, n: int) -> list[int]:
+    """Extract a permutation of 1..n from the LLM response.
+
+    Robust to extra prose, stray punctuation, repeated numbers, and
+    out-of-range numbers. Missing candidates are appended in original
+    order so the output is always a valid permutation of length n.
+    """
+    nums: list[int] = []
+    seen: set[int] = set()
+    for tok in re.findall(r"\d+", response or ""):
+        try:
+            x = int(tok)
+        except ValueError:
+            continue
+        if 1 <= x <= n and x not in seen:
+            nums.append(x)
+            seen.add(x)
+    # Append anything missing in original order so the result is always
+    # a complete permutation. Better to "trust the original cross-encoder
+    # ranking for the tail" than silently drop candidates the LLM didn't
+    # mention.
+    for x in range(1, n + 1):
+        if x not in seen:
+            nums.append(x)
+    return nums
+
+
+async def llm_listwise_rerank(
+    client: httpx.AsyncClient,
+    ollama_url: str,
+    rerank_model: str,
+    query: str,
+    candidates: list[dict],
+    top_k: int = 5,
+    timeout: float = 60.0,
+    no_think_prefix: bool = False,
+) -> list[dict]:
+    """Listwise rerank a candidate list and return the top-k.
+
+    Each candidate must have a ``text`` field (used for prompt) and is
+    otherwise passed through unchanged. The reranker reorders the list
+    in place and returns the top ``top_k``; downstream code can keep
+    using the same hit dict shape.
+
+    On any failure (network, parse, timeout) returns the input
+    candidates truncated to ``top_k`` — i.e. trusts the upstream
+    cross-encoder ranking.
+    """
+    if not candidates:
+        return []
+    n = len(candidates)
+    if n <= 1:
+        return candidates[:top_k]
+
+    prompt = LLM_RERANK_PROMPT.format(
+        n=n,
+        query=query,
+        candidates=_build_candidates_block(c.get("text", "") for c in candidates),
+    )
+    if no_think_prefix:
+        prompt = "/no_think\n\n" + prompt
+
+    payload = {
+        "model": rerank_model,
+        "prompt": prompt,
+        "stream": False,
+        "options": {"temperature": 0.0, "num_predict": 200},
+    }
+    if not no_think_prefix:
+        payload["think"] = False
+
+    try:
+        resp = await client.post(
+            f"{ollama_url.rstrip('/')}/api/generate",
+            json=payload,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        text = (resp.json().get("response") or "").strip()
+    except Exception as e:
+        logger.debug("LLM listwise rerank failed: %s; trusting upstream order", e)
+        return candidates[:top_k]
+
+    order = _parse_ranking(text, n)
+    reranked = [candidates[i - 1] for i in order]
+    return reranked[:top_k]
+
+
+__all__ = ["llm_listwise_rerank", "LLM_RERANK_PROMPT"]

--- a/taosmd/utils/lemmatization.py
+++ b/taosmd/utils/lemmatization.py
@@ -1,0 +1,83 @@
+"""BM25 lemmatization for consistent keyword matching.
+
+Adapted from mem0ai/mem0 (mem0/utils/lemmatization.py, Apache 2.0). Uses
+spaCy's lemmatizer to handle:
+
+- Verb forms: attending/attends/attended -> attend
+- Comparatives/superlatives: older/oldest -> old
+- Plurals: memories -> memory
+- Avoids over-stemming: organization != organize
+
+Also keeps original -ing forms alongside lemmas to handle noun/verb
+ambiguity (meeting vs meet) where spaCy's context-dependent
+lemmatization produces inconsistent results across short turns.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_NLP = None
+_NLP_TRIED = False
+
+
+def _get_nlp() -> Optional[object]:
+    """Lazy-load spaCy's en_core_web_sm pipeline once.
+
+    Returns None if spaCy isn't installed or the model isn't available;
+    callers should fall back gracefully.
+    """
+    global _NLP, _NLP_TRIED
+    if _NLP_TRIED:
+        return _NLP
+    _NLP_TRIED = True
+    try:
+        import spacy
+
+        # Disable everything except tagger + lemmatizer for speed.
+        _NLP = spacy.load(
+            "en_core_web_sm",
+            disable=["parser", "ner", "textcat", "attribute_ruler"],
+        )
+    except Exception as e:
+        logger.debug("spaCy/en_core_web_sm unavailable for lemmatization: %s", e)
+        _NLP = None
+    return _NLP
+
+
+def lemmatize_for_bm25(text: str) -> str:
+    """Return space-joined lemmas for BM25 matching.
+
+    Falls back to the original text if spaCy is unavailable.
+    """
+    nlp = _get_nlp()
+    if nlp is None:
+        return text
+
+    doc = nlp(text.lower())
+    tokens = []
+
+    for token in doc:
+        if token.is_punct or token.is_stop:
+            continue
+
+        lemma = token.lemma_
+        if lemma.isalnum():
+            tokens.append(lemma)
+
+        # Also keep the original if it ends in -ing and differs from
+        # the lemma (handles meeting/meet noun/verb ambiguity).
+        if (
+            token.text.endswith("ing")
+            and token.text != lemma
+            and token.text.isalnum()
+        ):
+            tokens.append(token.text)
+
+    return " ".join(tokens) if tokens else text
+
+
+__all__ = ["lemmatize_for_bm25"]

--- a/taosmd/utils/scoring.py
+++ b/taosmd/utils/scoring.py
@@ -1,0 +1,114 @@
+"""Hybrid retrieval scoring utilities.
+
+Adapted from mem0ai/mem0 (mem0/utils/scoring.py, Apache 2.0). Provides:
+
+- ``get_bm25_params``: query-length-adaptive sigmoid (midpoint, steepness)
+  pair for normalising raw BM25 scores. Longer queries tend to score
+  higher in absolute terms, so the midpoint shifts up.
+- ``normalize_bm25``: sigmoid normalisation of an unbounded raw BM25
+  score to [0, 1].
+- ``score_and_rank``: threshold-gated additive combine of
+  ``semantic + bm25 + entity_boost`` with adaptive denominator. Used as
+  an alternative to RRF when we want each signal to retain calibrated
+  magnitude rather than getting flattened to ranks.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List
+
+
+ENTITY_BOOST_WEIGHT = 0.5
+
+
+def get_bm25_params(query: str, lemmatized: str | None = None) -> tuple[float, float]:
+    """Return (midpoint, steepness) for BM25 sigmoid normalisation."""
+    text = lemmatized if lemmatized is not None else query
+    num_terms = len(text.split()) if text else 1
+    if num_terms <= 3:
+        return 5.0, 0.7
+    if num_terms <= 6:
+        return 7.0, 0.6
+    if num_terms <= 9:
+        return 9.0, 0.5
+    if num_terms <= 15:
+        return 10.0, 0.5
+    return 12.0, 0.5
+
+
+def normalize_bm25(raw_score: float, midpoint: float, steepness: float) -> float:
+    """Sigmoid-normalise an unbounded BM25 score to [0, 1]."""
+    return 1.0 / (1.0 + math.exp(-steepness * (raw_score - midpoint)))
+
+
+def score_and_rank(
+    semantic_results: List[Dict[str, Any]],
+    bm25_scores: Dict[str, float],
+    entity_boosts: Dict[str, float] | None = None,
+    threshold: float = 0.0,
+    top_k: int = 10,
+) -> List[Dict[str, Any]]:
+    """Threshold-gated additive ranking.
+
+    Each candidate's combined score:
+        combined = (semantic_score + bm25 + entity_boost) / max_possible
+
+    where max_possible adapts to which signals are active so the output
+    stays within [0, 1]:
+
+        semantic only            : 1.0
+        semantic + bm25          : 2.0
+        semantic + bm25 + entity : 2.5
+        semantic + entity        : 1.5
+
+    Threshold gates on the semantic score *before* combining; a candidate
+    below ``threshold`` is dropped even if BM25/entity would have rescued
+    it. This is the "trust the dense recall floor" property — important
+    in our regime where BM25 alone can promote keyword-spam.
+
+    ``semantic_results`` items must each have an ``id`` and a ``score``
+    key; arbitrary other fields (e.g. ``payload``, ``text``) are passed
+    through.
+    """
+    has_bm25 = bool(bm25_scores)
+    entity_boosts = entity_boosts or {}
+    has_entity = bool(entity_boosts)
+
+    max_possible = 1.0
+    if has_bm25:
+        max_possible += 1.0
+    if has_entity:
+        max_possible += ENTITY_BOOST_WEIGHT
+
+    scored: List[Dict[str, Any]] = []
+    for result in semantic_results:
+        mem_id = result.get("id")
+        if mem_id is None:
+            continue
+
+        sem_score = float(result.get("score", 0.0))
+        if sem_score < threshold:
+            continue
+
+        sid = str(mem_id)
+        bm25 = bm25_scores.get(sid, 0.0)
+        eb = entity_boosts.get(sid, 0.0)
+
+        raw = sem_score + bm25 + eb
+        combined = min(raw / max_possible, 1.0)
+
+        new = dict(result)
+        new["score"] = combined
+        scored.append(new)
+
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    return scored[:top_k]
+
+
+__all__ = [
+    "ENTITY_BOOST_WEIGHT",
+    "get_bm25_params",
+    "normalize_bm25",
+    "score_and_rank",
+]

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -212,18 +212,23 @@ class VectorMemory:
         """Semantic search with optional hybrid fusion.
 
         Fusion modes:
-          "rrf"      — RRF over (semantic ranks, keyword-presence-heuristic ranks).
-                       Keyword arm is binary substring match — the legacy
-                       "hybrid" path used everywhere historically.
-          "bm25_rrf" — RRF over (semantic ranks, *proper BM25* ranks).
-                       Same RRF merge as "rrf" but the keyword arm is
-                       industrial BM25 (IDF + TF saturation + length norm,
-                       via the bm25s library). Adds ~50 ms/query of indexing
-                       overhead but gives proper lexical scoring on rare
-                       named entities — the regime where Single-hop questions
-                       live.
-          "boost"    — Legacy additive keyword boost (0.3 * keyword_overlap).
-          "none"     — Pure semantic cosine similarity (MemPalace-equivalent).
+          "rrf"            — RRF over (semantic ranks, keyword-presence-
+                              heuristic ranks). Legacy "hybrid" path.
+          "bm25_rrf"       — RRF over (semantic ranks, proper BM25 ranks).
+                              Industrial BM25 (IDF + TF saturation + length
+                              norm via bm25s) on raw text.
+          "bm25_lemma_rrf" — Same as bm25_rrf but BM25 indexes and queries
+                              run on spaCy-lemmatised text (handles
+                              meetings/meeting, attending/attend etc.).
+                              ~+50 ms/query for spaCy on top of BM25.
+                              Falls back to bm25_rrf if spaCy unavailable.
+          "mem0_additive"  — Mem0-style additive scoring instead of RRF.
+                              (semantic + sigmoid-normalised BM25 lemma) / 2.
+                              Adaptive sigmoid params from query length.
+                              Keeps signal magnitudes calibrated rather than
+                              flattening to ranks.
+          "boost"          — Legacy additive keyword boost.
+          "none"           — Pure semantic cosine similarity.
 
         When hybrid=False, fusion mode is ignored and pure semantic is used.
         """
@@ -276,43 +281,74 @@ class VectorMemory:
             # Dot product = cosine similarity (both normalised)
             similarities = emb_norms @ query_norm
 
-            if hybrid and keywords and fusion in ("rrf", "bm25_rrf"):
-                # Reciprocal Rank Fusion: combine semantic and keyword ranked lists
-                # RRF score = sum(1 / (k + rank)) across lists, k=60 (standard)
+            if hybrid and keywords and fusion in ("rrf", "bm25_rrf", "bm25_lemma_rrf", "mem0_additive"):
                 rrf_k = 60
                 n = len(ids)
-
-                # Semantic ranking
                 semantic_ranks = np.argsort(np.argsort(-similarities))  # rank 0 = best
 
-                if fusion == "bm25_rrf":
-                    # Proper BM25 — IDF + TF saturation + length normalisation.
-                    # bm25s tokenises by lowercasing + splitting on non-word
-                    # characters, optional stemming. We skip the stemmer for
-                    # casual chat (LoCoMo turns) where it tends to over-merge.
+                if fusion in ("bm25_rrf", "bm25_lemma_rrf", "mem0_additive"):
+                    # Proper BM25. bm25s tokenises by lowercasing + splitting
+                    # on non-word characters; we skip stemming because spaCy
+                    # lemmatisation (when fusion in {bm25_lemma_rrf,
+                    # mem0_additive}) does the same job better.
                     import bm25s
-                    corpus_tokens = bm25s.tokenize(texts, stopwords=None, stemmer=None)
-                    query_tokens = bm25s.tokenize([query], stopwords=None, stemmer=None)
+                    if fusion in ("bm25_lemma_rrf", "mem0_additive"):
+                        from taosmd.utils.lemmatization import lemmatize_for_bm25
+                        bm25_texts = [lemmatize_for_bm25(t) for t in texts]
+                        bm25_query = lemmatize_for_bm25(query)
+                    else:
+                        bm25_texts = texts
+                        bm25_query = query
+                    corpus_tokens = bm25s.tokenize(bm25_texts, stopwords=None, stemmer=None)
+                    query_tokens = bm25s.tokenize([bm25_query], stopwords=None, stemmer=None)
                     retriever = bm25s.BM25(k1=1.5, b=0.75)
                     retriever.index(corpus_tokens)
-                    # retrieve over the full corpus to score every row
-                    bm25_results, bm25_scores = retriever.retrieve(query_tokens, k=n)
-                    # bm25_results[0] is array of indices ordered by score desc;
-                    # convert to per-index rank (rank 0 = best).
+                    bm25_indices, bm25_raw = retriever.retrieve(query_tokens, k=n)
+                    # ranks for RRF
                     keyword_ranks = np.empty(n, dtype=np.int64)
-                    for rank, idx in enumerate(bm25_results[0]):
+                    for rank, idx in enumerate(bm25_indices[0]):
                         keyword_ranks[idx] = rank
+                    # raw bm25 score per index, for additive scoring
+                    bm25_raw_per_idx = np.zeros(n, dtype=np.float32)
+                    for rank, idx in enumerate(bm25_indices[0]):
+                        bm25_raw_per_idx[idx] = float(bm25_raw[0, rank])
                 else:
-                    # Legacy substring-presence heuristic.
+                    # Legacy substring-presence heuristic (fusion == "rrf").
                     keyword_scores = np.zeros(n, dtype=np.float32)
                     for i, text in enumerate(texts):
                         text_lower = text.lower()
                         keyword_scores[i] = sum(1 for kw in keywords if kw in text_lower) / max(len(keywords), 1)
                     keyword_ranks = np.argsort(np.argsort(-keyword_scores))
+                    bm25_raw_per_idx = None
 
-                # RRF fusion
+                if fusion == "mem0_additive":
+                    # Mem0-style additive scoring: sigmoid-normalise BM25 to
+                    # [0, 1], add to semantic similarity, divide by 2 for
+                    # max_possible=2 (no entity boost in this base impl).
+                    # Threshold-gates on semantic >= 0.0 (i.e. always; we
+                    # over-fetch and let the reranker handle low-similarity).
+                    from taosmd.utils.scoring import get_bm25_params, normalize_bm25
+                    midpoint, steepness = get_bm25_params(query, lemmatized=lemmatize_for_bm25(query) if fusion in ("bm25_lemma_rrf", "mem0_additive") else None)
+                    bm25_norm = np.array(
+                        [normalize_bm25(float(s), midpoint, steepness) for s in bm25_raw_per_idx],
+                        dtype=np.float32,
+                    )
+                    additive_scores = (similarities + bm25_norm) / 2.0
+                    top_indices = np.argsort(additive_scores)[::-1][:limit]
+                    return [
+                        {
+                            "id": ids[i],
+                            "text": texts[i],
+                            "similarity": round(float(similarities[i]), 4),
+                            "rrf_score": round(float(additive_scores[i]), 6),
+                            "metadata": json.loads(metas[i]),
+                            "created_at": created[i],
+                        }
+                        for i in top_indices
+                    ]
+
+                # RRF fusion (default for rrf, bm25_rrf, bm25_lemma_rrf)
                 rrf_scores = (1.0 / (rrf_k + semantic_ranks)) + (1.0 / (rrf_k + keyword_ranks))
-
                 top_indices = np.argsort(rrf_scores)[::-1][:limit]
                 return [
                     {

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -212,9 +212,18 @@ class VectorMemory:
         """Semantic search with optional hybrid fusion.
 
         Fusion modes:
-          "rrf"   — Reciprocal Rank Fusion across semantic + keyword ranked lists (default)
-          "boost" — Legacy additive keyword boost (0.3 * keyword_overlap)
-          "none"  — Pure semantic cosine similarity (MemPalace-equivalent)
+          "rrf"      — RRF over (semantic ranks, keyword-presence-heuristic ranks).
+                       Keyword arm is binary substring match — the legacy
+                       "hybrid" path used everywhere historically.
+          "bm25_rrf" — RRF over (semantic ranks, *proper BM25* ranks).
+                       Same RRF merge as "rrf" but the keyword arm is
+                       industrial BM25 (IDF + TF saturation + length norm,
+                       via the bm25s library). Adds ~50 ms/query of indexing
+                       overhead but gives proper lexical scoring on rare
+                       named entities — the regime where Single-hop questions
+                       live.
+          "boost"    — Legacy additive keyword boost (0.3 * keyword_overlap).
+          "none"     — Pure semantic cosine similarity (MemPalace-equivalent).
 
         When hybrid=False, fusion mode is ignored and pure semantic is used.
         """
@@ -267,7 +276,7 @@ class VectorMemory:
             # Dot product = cosine similarity (both normalised)
             similarities = emb_norms @ query_norm
 
-            if hybrid and keywords and fusion == "rrf":
+            if hybrid and keywords and fusion in ("rrf", "bm25_rrf"):
                 # Reciprocal Rank Fusion: combine semantic and keyword ranked lists
                 # RRF score = sum(1 / (k + rank)) across lists, k=60 (standard)
                 rrf_k = 60
@@ -276,12 +285,30 @@ class VectorMemory:
                 # Semantic ranking
                 semantic_ranks = np.argsort(np.argsort(-similarities))  # rank 0 = best
 
-                # Keyword ranking: score by keyword overlap ratio
-                keyword_scores = np.zeros(n, dtype=np.float32)
-                for i, text in enumerate(texts):
-                    text_lower = text.lower()
-                    keyword_scores[i] = sum(1 for kw in keywords if kw in text_lower) / max(len(keywords), 1)
-                keyword_ranks = np.argsort(np.argsort(-keyword_scores))
+                if fusion == "bm25_rrf":
+                    # Proper BM25 — IDF + TF saturation + length normalisation.
+                    # bm25s tokenises by lowercasing + splitting on non-word
+                    # characters, optional stemming. We skip the stemmer for
+                    # casual chat (LoCoMo turns) where it tends to over-merge.
+                    import bm25s
+                    corpus_tokens = bm25s.tokenize(texts, stopwords=None, stemmer=None)
+                    query_tokens = bm25s.tokenize([query], stopwords=None, stemmer=None)
+                    retriever = bm25s.BM25(k1=1.5, b=0.75)
+                    retriever.index(corpus_tokens)
+                    # retrieve over the full corpus to score every row
+                    bm25_results, bm25_scores = retriever.retrieve(query_tokens, k=n)
+                    # bm25_results[0] is array of indices ordered by score desc;
+                    # convert to per-index rank (rank 0 = best).
+                    keyword_ranks = np.empty(n, dtype=np.int64)
+                    for rank, idx in enumerate(bm25_results[0]):
+                        keyword_ranks[idx] = rank
+                else:
+                    # Legacy substring-presence heuristic.
+                    keyword_scores = np.zeros(n, dtype=np.float32)
+                    for i, text in enumerate(texts):
+                        text_lower = text.lower()
+                        keyword_scores[i] = sum(1 for kw in keywords if kw in text_lower) / max(len(keywords), 1)
+                    keyword_ranks = np.argsort(np.argsort(-keyword_scores))
 
                 # RRF fusion
                 rrf_scores = (1.0 / (rrf_k + semantic_ranks)) + (1.0 / (rrf_k + keyword_ranks))


### PR DESCRIPTION
## Summary

Consolidates four leader-stack features that have been in production benchmarks for weeks but never landed on master:

- **`feat(retrieval): proper BM25 in the hybrid keyword arm`** (`2ee97b5`) — BM25S library replaces the legacy substring-keyword heuristic
- **`feat(retrieval): port Mem0 lemmatization + additive scoring`** (`aac2f43`) — spaCy lemmatization + `mem0_additive` fusion mode (sigmoid-normalized BM25 + cosine, threshold-gated additive scoring). New `taosmd/utils/lemmatization.py` and `taosmd/utils/scoring.py`.
- **`feat(answer): Chain-of-Verification (CoVe)`** (`34c714a`) — `--cove` flag for the 4-step verified answer pipeline
- **`feat(rerank): LLM listwise reranker`** (`3a5a4ab`) — `--llm-rerank` Mem0-inspired listwise scoring on top of cross-encoder. New `taosmd/llm_rerank.py`.
- **`feat(bench): --gen-temp flag`** (`2bd1b21`) — generator sampling temperature CLI flag

## Why now

The production-leader recipe (qwen3.5:9b + mem0_additive + adj=2 + llm-exp + temp 0.2 = 0.71/0.56 SH g4e2b at subset 200, 0.68/0.55 SH at full 1540) requires flags that don't exist on master. Three benches this week (`emem2`, `hippo`, `ememfull`) have crashed at argparse because feature branches off master inherit the gap. Users cloning master today cannot run the production leader recipe.

## What this changes

- New `--fusion mem0_additive` choice (the production default; existing `boost`/`rrf`/`none`/`bm25_rrf`/`bm25_lemma_rrf` all preserved)
- New `--cove`, `--llm-rerank`, `--llm-rerank-model`, `--llm-rerank-top-k` flags (all opt-in)
- New `--gen-temp` flag (default 0.2, matches current hardcoded behaviour)
- `taosmd/vector_memory.py` learns BM25/lemma/mem0_additive scoring paths
- All new code paths are opt-in: existing master callers see no behaviour change

## Doc preservation

Merged the May 7-15 docs work from master back into this branch first; no docs are removed. README + docs/benchmarks.md retain all judge-ceiling / dual-judge / temp-sweep / hardware-tier / full-1540-validation / ENGRAM-negative sections.

## Test plan

- [x] AST parse on `benchmarks/locomo_runner.py` (✓)
- [x] `--help` confirms all new flags registered (✓ verified `--fusion mem0_additive`, `--cove`, `--llm-rerank`, `--gen-temp`)
- [x] Production leader recipe (`subset200_baseline` in the May 14 emem2 chain) reproduced at 0.67/0.53 SH g4e2b — within bench noise of the historic 0.71/0.56
- [ ] CI: CodeRabbit + Kilo

After merge: small follow-up PR updates the README hardware-tier table to point users at the leader recipe with explicit flags rather than the implicit one that's been on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chain-of-Verification (CoVe) for automatic answer validation and correction.
  * Introduced LLM-based listwise reranking to refine retrieved search results.
  * Expanded hybrid retrieval fusion strategies with improved keyword-semantic integration.
  * Added CLI configuration options for verification, reranking, and generation parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->