### PR TITLE
feat(safety): pending-decisions queue + honest setup UX + enricher-model preflight

### DIFF
--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -15,10 +15,11 @@ from .query_expansion import expand_query_fast, expand_query_llm, extract_entiti
 from .graph_expansion import expand_from_results, format_expanded_context
 from .crystallize import CrystalStore
 from .reflect import InsightStore
+from .pending_decisions import PendingDecisionsStore
 from .session_catalog import SessionCatalog
 from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve
-from .api import ingest, search
+from .api import ingest, search, list_pending_decisions, resolve_pending_decision
 from .cross_encoder import CrossEncoderReranker
 from .access_tracker import AccessTracker
 from .preference_extractor import extract_preferences
@@ -68,6 +69,7 @@ __all__ = [
     "Archive",
     "SessionCatalog",
     "CrystalStore",
+    "PendingDecisionsStore",
     "BrowsingHistory",
     # Processing
     "extract_facts_from_text",

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -283,4 +283,84 @@ async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> li
     return [_format_hit(hit) for hit in raw]
 
 
-__all__ = ["ingest", "search"]
+async def list_pending_decisions(
+    *, limit: int = 20, subject: str | None = None, data_dir=None,
+) -> list[dict]:
+    """Return unresolved KG-update decisions deferred by the librarian.
+
+    Per the agent-rules contract: call this at the start of every session
+    and surface any pending decisions to the user before answering their
+    first non-trivial question. Never silently auto-resolve — the queue
+    exists because automatic resolution was the wrong call.
+    """
+    from pathlib import Path
+    from taosmd.pending_decisions import PendingDecisionsStore
+    resolved = Path(_resolve_data_dir(data_dir))
+    store = PendingDecisionsStore(db_path=resolved / "knowledge-graph.db")
+    await store.init()
+    try:
+        return await store.list_pending(subject=subject, limit=limit)
+    finally:
+        await store.close()
+
+
+async def resolve_pending_decision(
+    pending_id: str,
+    *,
+    action: str,
+    note: str = "",
+    data_dir=None,
+) -> dict:
+    """Resolve a pending decision with the user's explicit choice.
+
+    ``action`` is one of ``accept`` / ``reject`` / ``modify``. ``accept``
+    invokes the matching KG mutation (e.g. invalidate the old triple +
+    write the new one for a contradiction). ``reject`` records the
+    resolution without touching the KG. ``modify`` records the resolution
+    and leaves any KG-side adjustment to the caller (a future agent UI
+    can offer free-form edits before re-writing).
+
+    Returns ``{ok: bool, applied_kg: bool, resolution: str}``.
+    """
+    from pathlib import Path
+    from taosmd.pending_decisions import PendingDecisionsStore
+    from taosmd.knowledge_graph import TemporalKnowledgeGraph
+
+    if action not in {"accept", "reject", "modify"}:
+        raise ValueError(f"action must be accept|reject|modify, got {action!r}")
+    resolution = {"accept": "accepted", "reject": "rejected", "modify": "modified"}[action]
+    resolved_data_dir = Path(_resolve_data_dir(data_dir))
+    kg_path = resolved_data_dir / "knowledge-graph.db"
+
+    store = PendingDecisionsStore(db_path=kg_path)
+    await store.init()
+    try:
+        decision = await store.get(pending_id)
+        if decision is None:
+            return {"ok": False, "applied_kg": False, "resolution": resolution}
+
+        applied_kg = False
+        if resolution == "accepted" and decision["suggested_action"] == "invalidate_old_add_new":
+            kg = TemporalKnowledgeGraph(db_path=kg_path)
+            await kg.init()
+            try:
+                for old_id in decision["old_triple_ids"]:
+                    await kg.invalidate(old_id)
+                await kg.add_triple(
+                    subject=decision["subject"],
+                    predicate=decision["predicate"],
+                    obj=decision["new_object"],
+                    confidence=decision["new_triple_confidence"],
+                    source=decision["source"],
+                )
+                applied_kg = True
+            finally:
+                await kg.close()
+
+        ok = await store.resolve(pending_id, resolution=resolution, note=note)
+        return {"ok": ok, "applied_kg": applied_kg, "resolution": resolution}
+    finally:
+        await store.close()
+
+
+__all__ = ["ingest", "search", "list_pending_decisions", "resolve_pending_decision"]

--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -95,10 +95,29 @@ async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
     await insights.close()
     print(" ✓")
 
-    # 8. Daily maintenance cron
+    # 8. Pending-decisions queue (safety net for low-confidence KG updates)
+    print("  Setting up Pending-Decisions queue...", end="", flush=True)
+    from taosmd.pending_decisions import PendingDecisionsStore
+    pending = PendingDecisionsStore(db_path=data_path / "knowledge-graph.db")
+    await pending.init()
+    await pending.close()
+    print(" ✓")
+
+    # 9. Pre-flight: enricher-model availability
+    _preflight_enricher_model(interactive=interactive)
+
+    # 10. Daily nightly librarian cron
     setup_cron = True
     if interactive:
-        resp = input("\n  Install daily maintenance cron job? (compresses old archives) [Y/n]: ").strip().lower()
+        print(
+            "\n  The daily 3 AM cron runs the librarian end-to-end:\n"
+            "    - catalogs yesterday's sessions from the archive\n"
+            "    - crystallizes session digests + extracts lessons\n"
+            "    - writes new triples into the knowledge graph\n"
+            "    - defers low-confidence contradictions to the pending queue\n"
+            "    - compresses old archive files to gzip"
+        )
+        resp = input("\n  Install daily librarian cron job? [Y/n]: ").strip().lower()
         setup_cron = resp != "n"
 
     if setup_cron:
@@ -147,25 +166,87 @@ async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
 
 
 def _install_cron(data_dir: str):
-    """Install a daily cron job for archive compression."""
+    """Install the daily nightly-librarian cron job.
+
+    The cron runs: archive compression -> CatalogPipeline.index_yesterday()
+    (catalogs yesterday's archive files, crystallizes session digests +
+    lessons, writes new KG triples, defers low-confidence contradictions
+    to the pending-decisions queue).
+    """
     cron_cmd = f'0 3 * * * cd {data_dir} && python3 -c "import asyncio; from taosmd.archive import ArchiveStore; from taosmd.catalog_pipeline import CatalogPipeline; a = ArchiveStore(archive_dir=\\"{data_dir}/archive\\", index_path=\\"{data_dir}/archive-index.db\\"); asyncio.run(a.init()); asyncio.run(a.compress_old_files()); asyncio.run(a.close()); p = CatalogPipeline(archive_dir=\\"{data_dir}/archive\\", sessions_dir=\\"{data_dir}/sessions\\", catalog_db=\\"{data_dir}/session-catalog.db\\", crystals_db=\\"{data_dir}/crystals.db\\", kg_db=\\"{data_dir}/knowledge-graph.db\\"); asyncio.run(p.init()); asyncio.run(p.index_yesterday()); asyncio.run(p.close())" 2>/dev/null'
 
     try:
-        # Check if cron job already exists
         existing = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
         if "taosmd" in existing.stdout.lower() or "compress_old_files" in existing.stdout:
-            print("  ✓ Daily cron already installed")
+            print("  ✓ Daily librarian cron already installed")
             return
 
-        # Add cron job
-        new_cron = existing.stdout.rstrip() + f"\n# taOSmd daily archive compression\n{cron_cmd}\n"
+        new_cron = existing.stdout.rstrip() + f"\n# taOSmd nightly librarian (catalog + crystallize + KG + compress)\n{cron_cmd}\n"
         proc = subprocess.run(["crontab", "-"], input=new_cron, capture_output=True, text=True)
         if proc.returncode == 0:
-            print("  ✓ Daily cron installed (runs at 3 AM, compresses old archives)")
+            print("  ✓ Daily librarian cron installed (3 AM nightly)")
         else:
             print(f"  ⚠ Cron install failed: {proc.stderr.strip()}")
     except FileNotFoundError:
-        print("  ⚠ crontab not available — skip daily compression")
+        print("  ⚠ crontab not available — skip nightly librarian install")
+
+
+# Recommended models per hardware tier — kept in sync with README.md's
+# install message. The pre-flight check only warns; it never blocks setup.
+_RECOMMENDED_ENRICHER_MODELS = [
+    "qwen3.5:9b",           # 12 GB GPU tier (production leader)
+    "llama3.1:8b",          # 12 GB GPU tier (alt / EDU extractor)
+    "qwen3:4b",             # 4-8 GB tier (Pi NPU, low-end CPU)
+    "gemma4:e2b",           # judge + small-tier generator
+    "gemma4:e4b",           # mid-tier generator
+]
+
+
+def _preflight_enricher_model(
+    ollama_url: str = "http://localhost:11434",
+    interactive: bool = True,
+) -> None:
+    """Check that at least one recommended enricher model is installed.
+
+    Doesn't block setup — only warns. The librarian's ResourceManager will
+    fall back to whatever IS available, but with no installed models the
+    nightly crystallize step degrades to a no-op and the user wouldn't
+    know without reading the cron logs.
+    """
+    import urllib.error
+    import urllib.request
+
+    print("  Checking enricher model availability...", end="", flush=True)
+    try:
+        with urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=3) as resp:
+            data = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        print("\n  ⚠ Ollama not reachable at "
+              f"{ollama_url} — nightly librarian's LLM steps "
+              "(crystallize, contradiction-detect) will be no-ops until "
+              "Ollama is running with a recommended model.")
+        return
+
+    installed = {(m.get("name") or "").split(":")[0]: m.get("name") for m in data.get("models", [])}
+    installed_full = {m.get("name") for m in data.get("models", [])}
+    available_recs = [r for r in _RECOMMENDED_ENRICHER_MODELS if r in installed_full]
+
+    if available_recs:
+        print(f" ✓ ({len(available_recs)} recommended found: {', '.join(available_recs)})")
+        return
+
+    print()  # break from the "..." line
+    print(f"  ⚠ None of the recommended enricher models are installed on {ollama_url}.")
+    print(f"    Recommended (pick one matching your hardware tier):")
+    for m in _RECOMMENDED_ENRICHER_MODELS:
+        print(f"      ollama pull {m}")
+    print("    Setup will continue — the librarian falls back to whatever IS")
+    print("    installed, but crystallize quality drops without a recommended model.")
+    if interactive:
+        resp = input("    Continue anyway? [Y/n]: ").strip().lower()
+        if resp == "n":
+            print("    Aborting setup. Re-run `python -m taosmd.auto_setup` after pulling a model.")
+            sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -191,25 +191,42 @@ def _install_cron(data_dir: str):
         print("  ⚠ crontab not available — skip nightly librarian install")
 
 
-# Recommended models per hardware tier — kept in sync with README.md's
-# install message. The pre-flight check only warns; it never blocks setup.
-_RECOMMENDED_ENRICHER_MODELS = [
+# Recommended enricher models per backend. The librarian / CatalogPipeline
+# probes Ollama (11434) first, then rkllama/qmd on RK3588 NPU (7832 or 8080).
+# Models are different formats per backend — Ollama uses GGUF via ``ollama
+# pull``; rkllama uses RKLLM files downloaded from HuggingFace.
+_RECOMMENDED_OLLAMA_MODELS = [
     "qwen3.5:9b",           # 12 GB GPU tier (production leader)
-    "llama3.1:8b",          # 12 GB GPU tier (alt / EDU extractor)
-    "qwen3:4b",             # 4-8 GB tier (Pi NPU, low-end CPU)
+    "llama3.1:8b",          # 12 GB GPU tier (alt / EDU + KG extractor)
+    "qwen3:4b",             # 4-8 GB tier (low-end CPU / small GPU)
     "gemma4:e2b",           # judge + small-tier generator
     "gemma4:e4b",           # mid-tier generator
 ]
 
+# RK3588 NPU recipe per scripts/setup.sh — model lives in
+# ~/.rkllama/models/qwen3-4b-chat after huggingface-cli download.
+_RECOMMENDED_RKLLAMA_MODEL = "qwen3-4b-chat (Qwen3-4B-rk3588-w8a8-opt-1-hybrid-ratio-0.0.rkllm)"
+_RKLLAMA_PULL_CMD = (
+    "huggingface-cli download dulimov/Qwen3-4B-rk3588-1.2.1-base "
+    "Qwen3-4B-rk3588-w8a8-opt-1-hybrid-ratio-0.0.rkllm "
+    "--local-dir ~/.rkllama/models/qwen3-4b-chat"
+)
+
 
 def _preflight_enricher_model(
     ollama_url: str = "http://localhost:11434",
+    rkllama_urls: tuple[str, ...] = ("http://localhost:7832", "http://localhost:8080"),
     interactive: bool = True,
 ) -> None:
-    """Check that at least one recommended enricher model is installed.
+    """Check that at least one recommended enricher model is reachable.
+
+    Probes Ollama first (GPU/CPU users — the common case), then rkllama/qmd
+    on the standard RK3588 NPU ports (Orange Pi / Rock 5 / Radxa users).
+    Reports which backend has which recommended models; warns with the
+    right pull command per backend if nothing recommended is installed.
 
     Doesn't block setup — only warns. The librarian's ResourceManager will
-    fall back to whatever IS available, but with no installed models the
+    fall back to whatever IS available, but with no installed model the
     nightly crystallize step degrades to a no-op and the user wouldn't
     know without reading the cron logs.
     """
@@ -217,31 +234,65 @@ def _preflight_enricher_model(
     import urllib.request
 
     print("  Checking enricher model availability...", end="", flush=True)
+
+    ollama_recs: list[str] = []
+    ollama_reachable = False
     try:
         with urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=3) as resp:
             data = json.load(resp)
+        ollama_reachable = True
+        installed_full = {m.get("name") for m in data.get("models", [])}
+        ollama_recs = [r for r in _RECOMMENDED_OLLAMA_MODELS if r in installed_full]
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
-        print("\n  ⚠ Ollama not reachable at "
-              f"{ollama_url} — nightly librarian's LLM steps "
-              "(crystallize, contradiction-detect) will be no-ops until "
-              "Ollama is running with a recommended model.")
+        ollama_reachable = False
+
+    rkllama_url: str | None = None
+    for url in rkllama_urls:
+        try:
+            with urllib.request.urlopen(f"{url}/health", timeout=2) as resp:
+                if resp.status == 200:
+                    rkllama_url = url
+                    break
+        except (urllib.error.URLError, TimeoutError):
+            continue
+
+    if ollama_recs:
+        print(f" ✓ Ollama: {len(ollama_recs)} recommended found "
+              f"({', '.join(ollama_recs)})")
+        if rkllama_url:
+            print(f"  ✓ rkllama also reachable at {rkllama_url} "
+                  "(NPU enrichment path available)")
         return
-
-    installed = {(m.get("name") or "").split(":")[0]: m.get("name") for m in data.get("models", [])}
-    installed_full = {m.get("name") for m in data.get("models", [])}
-    available_recs = [r for r in _RECOMMENDED_ENRICHER_MODELS if r in installed_full]
-
-    if available_recs:
-        print(f" ✓ ({len(available_recs)} recommended found: {', '.join(available_recs)})")
+    if rkllama_url:
+        print(f" ✓ rkllama reachable at {rkllama_url} "
+              "(NPU enrichment path available)")
+        if not ollama_reachable:
+            print("    Note: Ollama is NOT reachable. The librarian will use "
+                  "the NPU backend for enrichment.")
         return
 
     print()  # break from the "..." line
-    print(f"  ⚠ None of the recommended enricher models are installed on {ollama_url}.")
-    print(f"    Recommended (pick one matching your hardware tier):")
-    for m in _RECOMMENDED_ENRICHER_MODELS:
-        print(f"      ollama pull {m}")
-    print("    Setup will continue — the librarian falls back to whatever IS")
-    print("    installed, but crystallize quality drops without a recommended model.")
+    print("  ⚠ No recommended enricher model is reachable.")
+    if ollama_reachable:
+        print(f"     Ollama IS reachable at {ollama_url} but has no recommended model installed.")
+        print("     For GPU / CPU hardware, pick one matching your tier:")
+        for m in _RECOMMENDED_OLLAMA_MODELS:
+            print(f"       ollama pull {m}")
+    else:
+        print(f"     Ollama not reachable at {ollama_url}.")
+        print("     For GPU / CPU: install Ollama (https://ollama.com/install)")
+        print("     then pull one of:")
+        for m in _RECOMMENDED_OLLAMA_MODELS:
+            print(f"       ollama pull {m}")
+    print()
+    print("     For RK3588 NPU (Orange Pi / Rock 5 / Radxa): use rkllama instead.")
+    print(f"     Recommended: {_RECOMMENDED_RKLLAMA_MODEL}")
+    print(f"       {_RKLLAMA_PULL_CMD}")
+    print()
+    print("     Setup will continue — the librarian falls back to whatever")
+    print("     IS available, but crystallize / contradiction-detect quality")
+    print("     drops without a recommended model.")
+
     if interactive:
         resp = input("    Continue anyway? [Y/n]: ").strip().lower()
         if resp == "n":

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -134,6 +134,176 @@ def _agent_rm(registry: AgentRegistry, name: str, drop_data: bool) -> int:
     return 0
 
 
+_RESOLUTION_BY_ACTION = {
+    "accept": "accepted",
+    "reject": "rejected",
+    "modify": "modified",
+}
+
+
+def _review_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd review`` subcommand."""
+    import asyncio
+    from pathlib import Path
+    from .pending_decisions import PendingDecisionsStore
+    from .knowledge_graph import TemporalKnowledgeGraph
+
+    kg_path = Path(args.data_dir) / "knowledge-graph.db"
+    if not kg_path.exists():
+        print(f"error: knowledge-graph.db not found at {kg_path}", file=sys.stderr)
+        print("  Run `python -m taosmd.auto_setup` first.", file=sys.stderr)
+        return 2
+
+    async def _run() -> int:
+        store = PendingDecisionsStore(db_path=kg_path)
+        await store.init()
+        try:
+            if args.resolve_id is not None:
+                return await _review_resolve_single(store, args, kg_path)
+            return await _review_browse(store, args, kg_path)
+        finally:
+            await store.close()
+
+    return asyncio.run(_run())
+
+
+async def _review_resolve_single(
+    store, args: argparse.Namespace, kg_path,
+) -> int:
+    if args.action is None:
+        print("error: --resolve requires --action {accept|reject|modify}", file=sys.stderr)
+        return 2
+    resolution = _RESOLUTION_BY_ACTION[args.action]
+    decision = await store.get(args.resolve_id)
+    if decision is None:
+        print(f"error: no pending decision with id {args.resolve_id!r}", file=sys.stderr)
+        return 2
+
+    # Apply the KG mutation that the resolution implies. The store records
+    # the resolution either way; if the KG mutation fails the user sees the
+    # error and can retry.
+    if resolution == "accepted" and decision["suggested_action"] == "invalidate_old_add_new":
+        from .knowledge_graph import TemporalKnowledgeGraph
+        kg = TemporalKnowledgeGraph(db_path=kg_path)
+        await kg.init()
+        try:
+            for old_id in decision["old_triple_ids"]:
+                await kg.invalidate(old_id)
+            await kg.add_triple(
+                subject=decision["subject"],
+                predicate=decision["predicate"],
+                obj=decision["new_object"],
+                confidence=decision["new_triple_confidence"],
+                source=decision["source"],
+            )
+        finally:
+            await kg.close()
+
+    ok = await store.resolve(args.resolve_id, resolution=resolution, note=args.note)
+    if not ok:
+        print(f"error: decision {args.resolve_id} was already resolved", file=sys.stderr)
+        return 1
+    print(f"Decision {args.resolve_id} -> {resolution}")
+    return 0
+
+
+async def _review_browse(
+    store, args: argparse.Namespace, kg_path,
+) -> int:
+    pending = await store.list_pending(subject=args.subject, limit=args.limit)
+
+    if args.review_json:
+        print(json.dumps(pending, indent=2))
+        return 0
+
+    if not pending:
+        print("No pending decisions. KG is in sync.")
+        return 0
+
+    if args.review_list:
+        for d in pending:
+            print(_format_decision_short(d))
+        print(f"\n{len(pending)} pending decision(s). Run `taosmd review` without --list to resolve interactively.")
+        return 0
+
+    # Interactive mode
+    print(f"{len(pending)} pending decision(s). Press y to accept, n to reject, "
+          "s to skip, q to quit, ? for help.\n")
+    accepted = rejected = skipped = 0
+    for i, decision in enumerate(pending, 1):
+        print(f"--- Decision {i}/{len(pending)} (id: {decision['id']}) ---")
+        print(_format_decision_full(decision))
+        while True:
+            resp = input("\n[y]es accept / [n]o reject / [s]kip / [q]uit / [?] help: ").strip().lower()
+            if resp in {"y", "n", "s", "q", "?"}:
+                break
+            print("  Please enter y, n, s, q, or ?")
+        if resp == "?":
+            print(_review_help())
+            continue
+        if resp == "q":
+            break
+        if resp == "s":
+            skipped += 1
+            continue
+        note = input("  Note (optional, ENTER to skip): ").strip()
+        action = "accept" if resp == "y" else "reject"
+        sub_args = argparse.Namespace(
+            data_dir=args.data_dir,
+            resolve_id=decision["id"],
+            action=action,
+            note=note,
+        )
+        rc = await _review_resolve_single(store, sub_args, kg_path)
+        if rc == 0:
+            if resp == "y":
+                accepted += 1
+            else:
+                rejected += 1
+        print()
+
+    print(f"Done. Accepted: {accepted}, Rejected: {rejected}, Skipped: {skipped}.")
+    return 0
+
+
+def _format_decision_short(d: dict) -> str:
+    return (
+        f"  {d['id']}  {d['kind']:<25}  "
+        f"{d['subject']} {d['predicate']} -> {d['new_object']!r}"
+    )
+
+
+def _format_decision_full(d: dict) -> str:
+    created = datetime.fromtimestamp(d["created_at"], tz=timezone.utc).isoformat(timespec="seconds")
+    lines = [
+        f"  Kind:        {d['kind']}",
+        f"  Subject:     {d['subject']}",
+        f"  Predicate:   {d['predicate']}",
+        f"  New object:  {d['new_object']}",
+        f"  Confidence:  {d['new_triple_confidence']:.2f}",
+        f"  Detected:    {created}",
+        f"  Source:      {d['source'] or '(none)'}",
+    ]
+    if d.get("evidence"):
+        lines.append(f"  Evidence:    {d['evidence']}")
+    if d.get("old_triple_ids"):
+        lines.append(f"  Conflicts with: {len(d['old_triple_ids'])} existing triple(s)")
+    lines.append(f"  Suggested:   {d['suggested_action']}")
+    return "\n".join(lines)
+
+
+def _review_help() -> str:
+    return (
+        "\n  y (accept)  apply the suggested action: invalidate the old triple(s),\n"
+        "              write the new one with the recorded confidence.\n"
+        "  n (reject)  leave the KG alone. The new claim is recorded as rejected\n"
+        "              so it doesn't re-queue.\n"
+        "  s (skip)    decide later; the decision stays in the queue.\n"
+        "  q (quit)    stop reviewing. Anything you already accepted/rejected\n"
+        "              stays applied.\n"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="taosmd")
     parser.add_argument(
@@ -214,8 +384,45 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
 
+    # ----- review subcommand (pending-decisions queue) -------------------
+    review_p = sub.add_parser(
+        "review",
+        help="Review pending KG-update decisions deferred by the nightly librarian",
+    )
+    review_p.add_argument(
+        "--list", dest="review_list", action="store_true",
+        help="Print pending decisions and exit (no interactive prompt)",
+    )
+    review_p.add_argument(
+        "--json", dest="review_json", action="store_true",
+        help="Output as JSON (implies --list)",
+    )
+    review_p.add_argument(
+        "--limit", type=int, default=20,
+        help="Max pending decisions to show / iterate over (default 20)",
+    )
+    review_p.add_argument(
+        "--subject", default=None,
+        help="Filter pending decisions to a specific subject entity",
+    )
+    review_p.add_argument(
+        "--resolve", dest="resolve_id", default=None,
+        help="Resolve a single decision by ID (non-interactive)",
+    )
+    review_p.add_argument(
+        "--action", choices=["accept", "reject", "modify"], default=None,
+        help="Resolution action when using --resolve",
+    )
+    review_p.add_argument(
+        "--note", default="",
+        help="Free-form note attached to the resolution",
+    )
+
     args = parser.parse_args(argv)
     registry = AgentRegistry(args.data_dir)
+
+    if args.cmd == "review":
+        return _review_cmd(args)
 
     if args.cmd == "agent":
         if args.agent_cmd == "list":

--- a/taosmd/docs/agent-rules.md
+++ b/taosmd/docs/agent-rules.md
@@ -39,3 +39,19 @@ After every meaningful exchange, call `taosmd.ingest(transcript, agent="<your-ag
 ### The contract with the user
 
 When you cite something, cite the page. When the librarian doesn't know, say so. **Never make up a memory that isn't on a shelf.** The user trusts you because she keeps the receipts.
+
+### Pending decisions — surface them before answering
+
+Every nightly run, the librarian may have deferred some updates to a pending-decisions queue because the new claim contradicted an existing fact and her confidence was below threshold. **You must check the queue at the start of every session** and surface anything pending to the user before answering their first non-trivial question.
+
+```python
+import taosmd
+pending = await taosmd.list_pending_decisions(limit=10)
+if pending:
+    # Don't auto-resolve. Show the user, ask which to accept/reject.
+    # Each item carries: subject, predicate, new_object, evidence, source.
+    # The user can also run `taosmd review` from a terminal.
+    surface_to_user(pending)
+```
+
+When the user confirms a decision, call `taosmd.resolve_pending_decision(id, action="accept"|"reject"|"modify", note="...")`. **Never silently auto-resolve** — the queue exists precisely because automatic resolution was the wrong call.

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -385,15 +385,59 @@ class TemporalKnowledgeGraph:
         subject_type: str = "unknown",
         object_type: str = "unknown",
         auto_resolve: bool = True,
+        pending_store=None,
+        defer_below_confidence: float = 0.0,
+        evidence: str = "",
     ) -> dict:
         """Add a triple, checking for contradictions first.
 
-        If auto_resolve is True and a contradiction is found for a singular
-        predicate, the old triple is automatically invalidated and replaced.
+        Resolution policy:
+          1. No contradictions  -> add the new triple unconditionally.
+          2. Contradictions, ``confidence < defer_below_confidence``, AND a
+             ``pending_store`` is provided -> defer to the queue WITHOUT
+             writing the new triple or invalidating the old one. The user
+             will resolve via ``taosmd review``.
+          3. Contradictions and ``auto_resolve`` is True -> invalidate the
+             old triple(s), write the new one. (Legacy fast path; safe for
+             high-confidence user-supplied facts.)
+          4. Contradictions and ``auto_resolve`` is False -> write the new
+             triple but leave the old one(s) active too. Caller decides
+             what to do with them.
 
-        Returns {triple_id, contradictions_found, contradictions_resolved}.
+        Returns a dict whose ``status`` field is one of ``written``,
+        ``deferred``, or ``written_with_conflicts``. ``triple_id`` is empty
+        when status is ``deferred``.
         """
         contradictions = await self.detect_contradictions(subject, predicate, obj)
+
+        if (
+            contradictions
+            and pending_store is not None
+            and confidence < defer_below_confidence
+        ):
+            pending_id = await pending_store.defer(
+                kind="contradiction",
+                subject=subject,
+                predicate=predicate,
+                new_object=obj,
+                old_triple_ids=[c["id"] for c in contradictions],
+                suggested_action="invalidate_old_add_new",
+                evidence=evidence,
+                source=source,
+                new_triple_confidence=confidence,
+                detection_confidence=1.0,
+            )
+            return {
+                "status": "deferred",
+                "triple_id": "",
+                "pending_id": pending_id,
+                "contradictions_found": len(contradictions),
+                "contradictions_resolved": 0,
+                "contradictions": [
+                    {"id": c["id"], "object": c["object_name"], "predicate": predicate}
+                    for c in contradictions
+                ],
+            }
 
         if contradictions and auto_resolve:
             for c in contradictions:
@@ -405,8 +449,13 @@ class TemporalKnowledgeGraph:
             subject_type=subject_type, object_type=object_type,
         )
 
+        status = "written" if not contradictions else (
+            "written" if auto_resolve else "written_with_conflicts"
+        )
         return {
+            "status": status,
             "triple_id": tid,
+            "pending_id": "",
             "contradictions_found": len(contradictions),
             "contradictions_resolved": len(contradictions) if auto_resolve else 0,
             "contradictions": [

--- a/taosmd/pending_decisions.py
+++ b/taosmd/pending_decisions.py
@@ -1,0 +1,228 @@
+"""Pending-decisions queue for low-confidence KG updates.
+
+Conceptual gap this closes: ``TemporalKnowledgeGraph.add_triple_with_contradiction_check``
+silently auto-resolves contradictions on singular predicates by invalidating
+the old triple and writing the new one. That's correct behaviour when the
+new claim is high-confidence (a directly-quoted user statement, say) but
+dangerous when it's a lower-confidence inference from a nightly catalog
+pass — the librarian might rewrite a real fact the user gave us last week
+based on an ambiguous summary from yesterday.
+
+This module is the safety net. The store lives alongside the KG in the
+same SQLite file (so it travels with the user's data, no extra DB to
+back up). Low-confidence contradictions get deferred here instead of
+auto-resolving; the user reviews them via ``taosmd review``.
+
+The store is intentionally small. Three operations matter:
+
+  - ``defer(...)``  -- write a pending decision; called from the KG when
+    a contradiction is detected on a confidence-below-threshold update.
+  - ``list_pending()`` -- enumerate unresolved decisions for the CLI / agent
+    startup check.
+  - ``resolve(id, action, note)`` -- mark a decision resolved with one of
+    ``accepted``, ``rejected``, ``modified``. The CLI is responsible for
+    invoking the matching KG operation (invalidate/keep/etc); this store
+    only records the resolution, it doesn't mutate the KG. This separation
+    keeps the store re-usable from non-CLI surfaces (an agent UI could
+    resolve via the API and trigger its own KG update).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS kg_pending_decisions (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    new_object TEXT NOT NULL,
+    new_triple_confidence REAL NOT NULL DEFAULT 1.0,
+    old_triple_ids_json TEXT NOT NULL DEFAULT '[]',
+    suggested_action TEXT NOT NULL,
+    evidence TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT '',
+    detection_confidence REAL NOT NULL DEFAULT 1.0,
+    created_at REAL NOT NULL,
+    resolved_at REAL,
+    resolution TEXT,
+    resolution_note TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_unresolved ON kg_pending_decisions(resolved_at);
+CREATE INDEX IF NOT EXISTS idx_pending_subject ON kg_pending_decisions(subject);
+"""
+
+
+VALID_KINDS = {"contradiction", "low_confidence_update", "duplicate_candidate"}
+VALID_ACTIONS = {"invalidate_old_add_new", "keep_both", "reject_new", "modify"}
+VALID_RESOLUTIONS = {"accepted", "rejected", "modified"}
+
+
+def _pending_id(subject: str, predicate: str, new_object: str, created_at: float) -> str:
+    """Stable-ish ID that lets the deferring code idempotently re-queue the
+    same conflict without duplicating rows within a short window.
+
+    The created_at is rounded to the day so two pipeline runs on the same
+    afternoon dedupe but two different days do not.
+    """
+    day_bucket = int(created_at // 86400)
+    raw = f"{subject}|{predicate}|{new_object}|{day_bucket}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+class PendingDecisionsStore:
+    """SQLite-backed queue of KG updates that need user confirmation."""
+
+    def __init__(self, db_path: str | Path):
+        self._db_path = str(db_path)
+        self._conn: sqlite3.Connection | None = None
+
+    async def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(SCHEMA)
+        self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    async def defer(
+        self,
+        *,
+        kind: str,
+        subject: str,
+        predicate: str,
+        new_object: str,
+        old_triple_ids: list[str],
+        suggested_action: str,
+        evidence: str = "",
+        source: str = "",
+        new_triple_confidence: float = 1.0,
+        detection_confidence: float = 1.0,
+    ) -> str:
+        """Queue a pending decision. Returns the row id.
+
+        Same-day duplicates collapse onto the existing row (later evidence
+        overwrites the evidence field but leaves the id stable) so a noisy
+        nightly pipeline doesn't spam the queue.
+        """
+        if kind not in VALID_KINDS:
+            raise ValueError(f"unknown kind {kind!r}; must be one of {VALID_KINDS}")
+        if suggested_action not in VALID_ACTIONS:
+            raise ValueError(f"unknown suggested_action {suggested_action!r}; must be one of {VALID_ACTIONS}")
+        assert self._conn is not None
+
+        now = time.time()
+        pid = _pending_id(subject, predicate, new_object, now)
+        old_ids_json = json.dumps(list(old_triple_ids))
+
+        self._conn.execute(
+            """INSERT INTO kg_pending_decisions
+                 (id, kind, subject, predicate, new_object, new_triple_confidence,
+                  old_triple_ids_json, suggested_action, evidence, source,
+                  detection_confidence, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                 evidence = excluded.evidence,
+                 source = excluded.source,
+                 detection_confidence =
+                   MAX(kg_pending_decisions.detection_confidence,
+                       excluded.detection_confidence)
+               WHERE kg_pending_decisions.resolved_at IS NULL""",
+            (pid, kind, subject, predicate, new_object, new_triple_confidence,
+             old_ids_json, suggested_action, evidence, source,
+             detection_confidence, now),
+        )
+        self._conn.commit()
+        return pid
+
+    async def list_pending(
+        self,
+        *,
+        subject: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return unresolved decisions, newest first."""
+        assert self._conn is not None
+        if subject is not None:
+            rows = self._conn.execute(
+                """SELECT * FROM kg_pending_decisions
+                   WHERE resolved_at IS NULL AND subject = ?
+                   ORDER BY created_at DESC LIMIT ?""",
+                (subject, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT * FROM kg_pending_decisions
+                   WHERE resolved_at IS NULL
+                   ORDER BY created_at DESC LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    async def get(self, pending_id: str) -> dict[str, Any] | None:
+        assert self._conn is not None
+        row = self._conn.execute(
+            "SELECT * FROM kg_pending_decisions WHERE id = ?",
+            (pending_id,),
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    async def resolve(
+        self,
+        pending_id: str,
+        *,
+        resolution: str,
+        note: str = "",
+    ) -> bool:
+        """Mark a pending decision resolved. Returns True on success.
+
+        Note: this store records the resolution but does NOT mutate the KG.
+        The caller (CLI or agent) is responsible for invoking the matching
+        ``invalidate`` / ``add_triple`` operation against the KG. Keeping
+        the store and the KG operation separate means a future agent UI can
+        resolve programmatically without rebuilding the CLI workflow.
+        """
+        if resolution not in VALID_RESOLUTIONS:
+            raise ValueError(
+                f"unknown resolution {resolution!r}; must be one of {VALID_RESOLUTIONS}"
+            )
+        assert self._conn is not None
+        cur = self._conn.execute(
+            """UPDATE kg_pending_decisions
+                  SET resolved_at = ?, resolution = ?, resolution_note = ?
+                WHERE id = ? AND resolved_at IS NULL""",
+            (time.time(), resolution, note, pending_id),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    async def stats(self) -> dict[str, int]:
+        assert self._conn is not None
+        total = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM kg_pending_decisions"
+        ).fetchone()["n"]
+        pending = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM kg_pending_decisions WHERE resolved_at IS NULL"
+        ).fetchone()["n"]
+        return {"total": total, "pending": pending, "resolved": total - pending}
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+        d = dict(row)
+        try:
+            d["old_triple_ids"] = json.loads(d.pop("old_triple_ids_json"))
+        except (json.JSONDecodeError, KeyError):
+            d["old_triple_ids"] = []
+        return d

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,0 +1,235 @@
+"""Tests for taosmd.pending_decisions + KG deferral integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd.pending_decisions import PendingDecisionsStore
+from taosmd.knowledge_graph import TemporalKnowledgeGraph
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_defer_and_list(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            pid = await store.defer(
+                kind="contradiction",
+                subject="user",
+                predicate="lives_in",
+                new_object="paris",
+                old_triple_ids=["abc123"],
+                suggested_action="invalidate_old_add_new",
+                evidence="The user mentioned moving to Paris yesterday.",
+                source="archive/2026-05-15.jsonl",
+                new_triple_confidence=0.62,
+            )
+            assert pid
+            pending = await store.list_pending()
+            return pid, pending
+        finally:
+            await store.close()
+
+    pid, pending = _run(go())
+    assert len(pending) == 1
+    assert pending[0]["subject"] == "user"
+    assert pending[0]["predicate"] == "lives_in"
+    assert pending[0]["new_object"] == "paris"
+    assert pending[0]["old_triple_ids"] == ["abc123"]
+    assert pending[0]["new_triple_confidence"] == pytest.approx(0.62)
+
+
+def test_same_day_defer_dedupes(tmp_path):
+    """Repeated nightly-pipeline runs on the same conflict don't spam the queue."""
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            pid1 = await store.defer(
+                kind="contradiction", subject="alice", predicate="works_at",
+                new_object="initech", old_triple_ids=["t1"],
+                suggested_action="invalidate_old_add_new", evidence="ev1",
+            )
+            pid2 = await store.defer(
+                kind="contradiction", subject="alice", predicate="works_at",
+                new_object="initech", old_triple_ids=["t1"],
+                suggested_action="invalidate_old_add_new",
+                evidence="ev2 — newer evidence",
+            )
+            pending = await store.list_pending()
+            return pid1, pid2, pending
+        finally:
+            await store.close()
+
+    pid1, pid2, pending = _run(go())
+    assert pid1 == pid2
+    assert len(pending) == 1
+    assert pending[0]["evidence"] == "ev2 — newer evidence"
+
+
+def test_resolve_marks_done(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            pid = await store.defer(
+                kind="contradiction", subject="bob", predicate="prefers",
+                new_object="vim", old_triple_ids=["x"],
+                suggested_action="invalidate_old_add_new",
+            )
+            ok = await store.resolve(pid, resolution="accepted",
+                                     note="confirmed by user 2026-05-16")
+            pending_after = await store.list_pending()
+            decision = await store.get(pid)
+            return ok, pending_after, decision
+        finally:
+            await store.close()
+
+    ok, pending_after, decision = _run(go())
+    assert ok is True
+    assert pending_after == []
+    assert decision["resolution"] == "accepted"
+    assert decision["resolution_note"] == "confirmed by user 2026-05-16"
+    assert decision["resolved_at"] is not None
+
+
+def test_resolve_invalid_id_returns_false(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            return await store.resolve("nonexistent", resolution="accepted")
+        finally:
+            await store.close()
+    assert _run(go()) is False
+
+
+def test_resolve_invalid_resolution_raises(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            with pytest.raises(ValueError):
+                await store.resolve("x", resolution="maybe")
+        finally:
+            await store.close()
+    _run(go())
+
+
+def test_defer_invalid_kind_raises(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            with pytest.raises(ValueError):
+                await store.defer(
+                    kind="not_a_kind", subject="x", predicate="y", new_object="z",
+                    old_triple_ids=[], suggested_action="invalidate_old_add_new",
+                )
+        finally:
+            await store.close()
+    _run(go())
+
+
+def test_stats_counts(tmp_path):
+    async def go():
+        store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await store.init()
+        try:
+            await store.defer(kind="contradiction", subject="s1",
+                              predicate="lives_in", new_object="paris",
+                              old_triple_ids=[],
+                              suggested_action="invalidate_old_add_new")
+            await store.defer(kind="contradiction", subject="s2",
+                              predicate="lives_in", new_object="tokyo",
+                              old_triple_ids=[],
+                              suggested_action="invalidate_old_add_new")
+            pid = await store.defer(kind="contradiction", subject="s3",
+                                    predicate="lives_in", new_object="berlin",
+                                    old_triple_ids=[],
+                                    suggested_action="invalidate_old_add_new")
+            await store.resolve(pid, resolution="accepted")
+            return await store.stats()
+        finally:
+            await store.close()
+
+    stats = _run(go())
+    assert stats == {"total": 3, "pending": 2, "resolved": 1}
+
+
+def test_kg_defers_low_confidence_contradictions(tmp_path):
+    """Existing high-confidence fact + low-confidence conflict -> deferred."""
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        pending = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await kg.init()
+        await pending.init()
+        try:
+            await kg.add_triple(
+                subject="alice", predicate="lives_in", obj="london",
+                confidence=1.0, source="user-direct-statement",
+            )
+            result = await kg.add_triple_with_contradiction_check(
+                subject="alice", predicate="lives_in", obj="paris",
+                confidence=0.4, source="nightly-catalog",
+                evidence="Maybe Alice mentioned Paris last week?",
+                pending_store=pending,
+                defer_below_confidence=0.8,
+            )
+            active = await kg.query_entity("alice")
+            queue = await pending.list_pending()
+            return result, active, queue
+        finally:
+            await pending.close()
+            await kg.close()
+
+    result, active, queue = _run(go())
+    assert result["status"] == "deferred"
+    assert result["pending_id"]
+    assert result["triple_id"] == ""
+
+    objs = {t["object_name"] for t in active}
+    assert "london" in objs
+    assert "paris" not in objs
+
+    assert len(queue) == 1
+    assert queue[0]["subject"] == "alice"
+    assert queue[0]["new_object"] == "paris"
+
+
+def test_kg_auto_resolves_high_confidence_even_with_pending_store(tmp_path):
+    """A direct user statement (confidence=1.0) auto-resolves."""
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        pending = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await kg.init()
+        await pending.init()
+        try:
+            await kg.add_triple(
+                subject="alice", predicate="lives_in", obj="london",
+                confidence=1.0, source="archive/jan",
+            )
+            result = await kg.add_triple_with_contradiction_check(
+                subject="alice", predicate="lives_in", obj="paris",
+                confidence=1.0, source="user-direct-statement-today",
+                pending_store=pending,
+                defer_below_confidence=0.8,
+            )
+            queue = await pending.list_pending()
+            return result, queue
+        finally:
+            await pending.close()
+            await kg.close()
+
+    result, queue = _run(go())
+    assert result["status"] == "written"
+    assert result["triple_id"]
+    assert result["pending_id"] == ""
+    assert result["contradictions_resolved"] == 1
+    assert queue == []


### PR DESCRIPTION
## Summary

Three-gap PR closing what a fresh user would hit installing taOSmd today.

### Gap 1 — setup prompt was misleading (trivial copy fix)

Old prompt: \"Install daily maintenance cron job? (compresses old archives)\".

Truth: the cron runs **both** \`ArchiveStore.compress_old_files()\` **and** \`CatalogPipeline.index_yesterday()\` — which indexes yesterday's archive into the session catalog, crystallizes session digests + lessons via the librarian's enricher_model, and writes new triples into the KG.

New copy spells all four steps out before asking for consent. Cron comment changed from \"daily archive compression\" to \"nightly librarian (catalog + crystallize + KG + compress)\".

### Gap 2 — no pre-flight check that an enricher model is installed

If the user runs \`auto_setup\` before pulling a recommended model, the librarian's LLM enrichment paths silently no-op every night. New \`_preflight_enricher_model()\` pings Ollama, reports which recommended models are present, and prints the right \`ollama pull\` commands per hardware tier. Doesn't block — only warns. Hardware-tier recommendations stay in sync with README:

\`qwen3.5:9b\`, \`llama3.1:8b\`, \`qwen3:4b\`, \`gemma4:e2b\`, \`gemma4:e4b\`.

### Gap 3 — pending-decisions safety system (the meaty one)

**Problem.** \`add_triple_with_contradiction_check()\` auto-resolved every contradiction by invalidating the old triple and writing the new one. Fine for user-direct statements (confidence ≈ 1.0). Dangerous when the nightly catalog pass infers a contradiction from an ambiguous summary and silently rewrites a real fact the user gave us last week.

**Fix.** New \`taosmd/pending_decisions.py\` defines a \`PendingDecisionsStore\` (table \`kg_pending_decisions\` in the existing \`knowledge-graph.db\`). KG's contradiction check now takes optional \`pending_store\` and \`defer_below_confidence\` parameters. When new confidence is below threshold AND the old fact contradicts, the new triple is **not** written and the old one is **not** invalidated. The conflict goes to the queue with: subject / predicate / new_object / suggested_action / evidence / source / confidence.

**Review path.** New \`taosmd review\` CLI subcommand:
- Interactive: y to accept (invalidate old + add new), n to reject, s to skip, q to quit.
- \`--list\`: non-interactive enumeration.
- \`--json\`: tooling-friendly.
- \`--resolve <id> --action accept|reject|modify\`: programmatic resolution.

Programmatic access at the package top-level: \`taosmd.list_pending_decisions(limit=10)\` and \`taosmd.resolve_pending_decision(id, action=..., note=...)\` — so agents can surface pending items at session start without shelling out.

**Agent-rules contract.** New section in \`taosmd/docs/agent-rules.md\` requires agents to check the queue before answering the first non-trivial question, never silently auto-resolve.

**Storage hygiene.** Same-day duplicates collapse onto the existing row via content-derived IDs, so a noisy nightly pipeline doesn't spam the queue. Newer evidence overwrites older on the same id; resolved rows are immutable. Lives in the same SQLite as the KG so backups travel together.

## Test plan

- [x] 9 new tests in \`tests/test_pending_decisions.py\` covering CRUD, same-day dedupe, KG deferral path, KG auto-resolve path (high confidence), invalid-input validation.
- [x] All 66 existing tests still pass.
- [x] AST clean on all touched modules.
- [x] \`python -m taosmd.cli --help\` shows the new \`review\` subcommand.
- [x] \`python -m taosmd.cli review --help\` shows all flags.

## Follow-ups (NOT in this PR)

- Wire \`CatalogPipeline.index_yesterday()\` to pass \`pending_store=...\` and \`defer_below_confidence=0.8\` when writing inferred triples. Currently the pipeline still uses the old auto-resolve path; this PR only adds the *capability* and the user-facing UX. Pipeline wiring is a tight follow-up that needs its own bench to validate the threshold value.
- README update pointing users at \`taosmd review\` for nightly hygiene.