### PR TITLE
feat(extractor): thread pending_store through process_conversation_turn (PR #71 follow-up)

### DIFF
--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -205,13 +205,33 @@ async def process_conversation_turn(
     use_llm: bool = True,
     auto_resolve_contradictions: bool = True,
     extraction_model: str = "default",
+    pending_store=None,
+    defer_below_confidence: float = 0.0,
+    default_fact_confidence: float = 1.0,
 ) -> dict:
     """Extract facts from a conversation turn and store in the KG.
 
     Uses LLM extraction when available (higher quality), falls back to regex.
     Checks for contradictions before storing (Mem0-style ADD/UPDATE logic).
 
-    Returns {facts_extracted, triples_created, contradictions_resolved, triple_ids, method}.
+    Safety-net parameters (opt-in):
+      - ``pending_store``: a :class:`PendingDecisionsStore` to defer
+        low-confidence conflicts to. When None, the legacy auto-resolve
+        path runs unchanged.
+      - ``defer_below_confidence``: confidence threshold below which a
+        contradiction is deferred to the pending queue instead of being
+        auto-resolved. Default 0.0 -> never defer (legacy behaviour).
+        Suggested value when ``pending_store`` is set: 0.8.
+      - ``default_fact_confidence``: confidence assigned to each
+        extracted fact when the extractor doesn't supply one. Default
+        1.0 (treat agent / user-direct extraction as ground truth).
+        Callers that extract from less-certain sources (a nightly
+        catalog pass, a summary of a summary) should pass a lower
+        value -- e.g. 0.6 for regex on a session summary -- so the
+        deferral threshold can actually fire.
+
+    Returns ``{facts_extracted, triples_created, contradictions_resolved,
+    deferred, deferred_ids, triple_ids, method}``.
     """
     from .agents import is_task_enabled  # noqa: PLC0415
 
@@ -238,47 +258,66 @@ async def process_conversation_turn(
     else:
         facts = extract_facts_from_text(text)
 
-    triple_ids = []
+    triple_ids: list[str] = []
+    deferred_ids: list[str] = []
     contradictions = 0
 
     for fact in facts:
         try:
             # Use contradiction-aware insertion for singular predicates.
-            # auto_resolve_contradictions=True (default): older contradicting
-            # triples get superseded — supersede chains form. False: facts
-            # coexist; ablation needed to measure whether supersede helps.
+            # When pending_store is provided AND the fact's confidence is
+            # below defer_below_confidence, the new triple is queued for
+            # user review instead of auto-resolving against the existing
+            # fact — see taosmd/pending_decisions.py.
+            fact_confidence = float(fact.get("confidence", default_fact_confidence))
             result = await kg.add_triple_with_contradiction_check(
                 subject=fact["subject"],
                 predicate=fact["predicate"],
                 obj=fact["object"],
+                confidence=fact_confidence,
                 source=f"{source}:{agent_name or 'user'}",
                 auto_resolve=auto_resolve_contradictions,
+                pending_store=pending_store,
+                defer_below_confidence=defer_below_confidence,
+                evidence=text[:500],
             )
-            triple_ids.append(result["triple_id"])
-            contradictions += result["contradictions_resolved"]
+            if result.get("status") == "deferred":
+                deferred_ids.append(result["pending_id"])
+                continue
+            if result.get("triple_id"):
+                triple_ids.append(result["triple_id"])
+            contradictions += result.get("contradictions_resolved", 0)
         except Exception as e:
             logger.debug("Failed to add triple: %s", e)
 
     # Archive the extraction event
-    if archive and triple_ids:
+    if archive and (triple_ids or deferred_ids):
+        deferred_note = f", {len(deferred_ids)} deferred for review" if deferred_ids else ""
         await archive.record(
             event_type="memory_extraction",
             data={
                 "facts_extracted": len(facts),
                 "triples_created": len(triple_ids),
                 "contradictions_resolved": contradictions,
+                "deferred": len(deferred_ids),
+                "deferred_ids": deferred_ids,
                 "method": method,
                 "source": source,
                 "facts": facts,
             },
             agent_name=agent_name,
-            summary=f"Extracted {len(facts)} facts ({method}) from {source}, {contradictions} contradictions resolved",
+            summary=(
+                f"Extracted {len(facts)} facts ({method}) from {source}, "
+                f"{contradictions} contradictions resolved{deferred_note}"
+            ),
         )
 
     return {
         "facts_extracted": len(facts),
         "triples_created": len(triple_ids),
         "contradictions_resolved": contradictions,
+        "deferred": len(deferred_ids),
+        "deferred_ids": deferred_ids,
         "triple_ids": triple_ids,
         "method": method,
     }

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -203,6 +203,63 @@ def test_kg_defers_low_confidence_contradictions(tmp_path):
     assert queue[0]["new_object"] == "paris"
 
 
+def test_process_conversation_turn_defers_low_confidence(tmp_path):
+    """Agent ingest path threads pending_store + defer_below_confidence through."""
+    from taosmd.memory_extractor import process_conversation_turn
+
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        pending = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await kg.init()
+        await pending.init()
+        try:
+            # Seed an existing high-confidence preference. "prefers" is in
+            # SINGULAR_PREDICATES so a new "prefers" for the same subject
+            # triggers the contradiction check.
+            await kg.add_triple(
+                subject="alice", predicate="prefers", obj="vim",
+                confidence=1.0, source="user-direct",
+            )
+
+            # New regex-extracted fact contradicts but at confidence 0.5
+            # (below the 0.8 threshold) -> goes to the pending queue
+            # instead of overwriting the existing fact.
+            result = await process_conversation_turn(
+                text="Alice prefers emacs.",
+                agent_name="testbot",
+                kg=kg,
+                archive=None,
+                source="nightly-summary",
+                use_llm=False,                       # force regex extractor
+                pending_store=pending,
+                defer_below_confidence=0.8,
+                default_fact_confidence=0.5,
+            )
+            active = await kg.query_entity("alice")
+            queue = await pending.list_pending()
+            return result, active, queue
+        finally:
+            await pending.close()
+            await kg.close()
+
+    result, active, queue = _run(go())
+
+    assert result["facts_extracted"] == 1
+    assert result["deferred"] == 1
+    assert result["triples_created"] == 0
+    assert result["deferred_ids"]
+
+    # The old fact survives because the new claim was deferred.
+    objs = {t["object_name"] for t in active}
+    assert "vim" in objs
+    assert "emacs" not in objs
+
+    assert len(queue) == 1
+    assert queue[0]["subject"] == "Alice"
+    assert queue[0]["predicate"] == "prefers"
+    assert queue[0]["new_object"] == "emacs"
+
+
 def test_kg_auto_resolves_high_confidence_even_with_pending_store(tmp_path):
     """A direct user statement (confidence=1.0) auto-resolves."""
     async def go():


### PR DESCRIPTION
## Summary

Follow-up to PR #71 with a **scope-correcting** finding.

### What I assumed in PR #71

\"Wire \`CatalogPipeline.index_yesterday()\` to pass \`pending_store=...\` and \`defer_below_confidence=0.8\` when writing inferred triples.\"

### What's actually true

After tracing every call site of \`kg.add_triple\` / \`kg.add_triple_with_contradiction_check\` in the codebase:

- The **nightly catalog pipeline only writes \`learned\` triples** via \`cs.crystallize()\` — and \`learned\` is **not** in \`TemporalKnowledgeGraph.SINGULAR_PREDICATES\`, so contradiction checks never fire there. There's nothing to defer.
- The only call site that actually uses \`add_triple_with_contradiction_check\` is \`memory_extractor.process_conversation_turn\` — the **agent / user ingest path**, hit every time an agent processes a conversation turn.

So the real wiring is plumbing the deferral knobs through \`process_conversation_turn\` so live agent ingest can defer instead of overwrite when a low-confidence inference contradicts a high-confidence existing fact.

### Changes

\`memory_extractor.process_conversation_turn\` gains three new parameters:

| Param | Default | Effect |
|---|---|---|
| \`pending_store\` | \`None\` | When provided, low-confidence contradictions go to the queue (legacy path when \`None\`). |
| \`defer_below_confidence\` | \`0.0\` | Threshold below which a conflicting new triple defers. \`0\` = never defer. Suggested \`0.8\` for nightly / inferred sources. |
| \`default_fact_confidence\` | \`1.0\` | Confidence applied to each extracted fact when the extractor doesn't supply one. Callers extracting from less-certain sources (regex on a session summary, etc.) should pass \`0.5\` so the deferral threshold can actually fire. |

Return shape gains \`deferred\` (int) and \`deferred_ids\` (list[str]) so callers can surface the queue immediately without waiting for the next agent session-start check.

Archive event records the deferred count too, so retroactive audit works (\"did the librarian defer anything yesterday?\").

## Test plan

- [x] New \`test_process_conversation_turn_defers_low_confidence\` — full end-to-end: regex extraction → KG conflict check → pending queue → old fact survives, new claim is queued.
- [x] All 138 tests pass (10 in PR #71's file + 128 existing).
- [x] AST clean.

## Scope-honest note (for future PR)

The nightly catalog pipeline currently doesn't extract user-fact triples from session content — it only extracts lessons. There's a meaningful future PR that:
1. Adds a fact-extraction stage to \`CatalogPipeline.index_day\` that calls this newly-wired \`process_conversation_turn\` with \`default_fact_confidence=0.5\` (since session-summary inference is intrinsically less certain than a user-direct statement) + \`pending_store\` + \`defer_below_confidence=0.8\`.
2. Validates the threshold value via a small bench (false-defer rate vs missed-real-conflict rate).

The plumbing is now ready for that wiring; the wiring itself is deliberately not in this PR.

## Stacking

This PR targets \`feat/pending-decisions-and-setup-honesty\` (PR #71) as its base, not master. Will rebase to master once #71 merges.