### PR TITLE
feat(extractor): thread pending_store through process_conversation_turn

### DIFF
--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -205,13 +205,33 @@ async def process_conversation_turn(
     use_llm: bool = True,
     auto_resolve_contradictions: bool = True,
     extraction_model: str = "default",
+    pending_store=None,
+    defer_below_confidence: float = 0.0,
+    default_fact_confidence: float = 1.0,
 ) -> dict:
     """Extract facts from a conversation turn and store in the KG.
 
     Uses LLM extraction when available (higher quality), falls back to regex.
     Checks for contradictions before storing (Mem0-style ADD/UPDATE logic).
 
-    Returns {facts_extracted, triples_created, contradictions_resolved, triple_ids, method}.
+    Safety-net parameters (opt-in):
+      - ``pending_store``: a :class:`PendingDecisionsStore` to defer
+        low-confidence conflicts to. When None, the legacy auto-resolve
+        path runs unchanged.
+      - ``defer_below_confidence``: confidence threshold below which a
+        contradiction is deferred to the pending queue instead of being
+        auto-resolved. Default 0.0 -> never defer (legacy behaviour).
+        Suggested value when ``pending_store`` is set: 0.8.
+      - ``default_fact_confidence``: confidence assigned to each
+        extracted fact when the extractor doesn't supply one. Default
+        1.0 (treat agent / user-direct extraction as ground truth).
+        Callers that extract from less-certain sources (a nightly
+        catalog pass, a summary of a summary) should pass a lower
+        value -- e.g. 0.6 for regex on a session summary -- so the
+        deferral threshold can actually fire.
+
+    Returns ``{facts_extracted, triples_created, contradictions_resolved,
+    deferred, deferred_ids, triple_ids, method}``.
     """
     from .agents import is_task_enabled  # noqa: PLC0415
 
@@ -238,47 +258,66 @@ async def process_conversation_turn(
     else:
         facts = extract_facts_from_text(text)
 
-    triple_ids = []
+    triple_ids: list[str] = []
+    deferred_ids: list[str] = []
     contradictions = 0
 
     for fact in facts:
         try:
             # Use contradiction-aware insertion for singular predicates.
-            # auto_resolve_contradictions=True (default): older contradicting
-            # triples get superseded — supersede chains form. False: facts
-            # coexist; ablation needed to measure whether supersede helps.
+            # When pending_store is provided AND the fact's confidence is
+            # below defer_below_confidence, the new triple is queued for
+            # user review instead of auto-resolving against the existing
+            # fact — see taosmd/pending_decisions.py.
+            fact_confidence = float(fact.get("confidence", default_fact_confidence))
             result = await kg.add_triple_with_contradiction_check(
                 subject=fact["subject"],
                 predicate=fact["predicate"],
                 obj=fact["object"],
+                confidence=fact_confidence,
                 source=f"{source}:{agent_name or 'user'}",
                 auto_resolve=auto_resolve_contradictions,
+                pending_store=pending_store,
+                defer_below_confidence=defer_below_confidence,
+                evidence=text[:500],
             )
-            triple_ids.append(result["triple_id"])
-            contradictions += result["contradictions_resolved"]
+            if result.get("status") == "deferred":
+                deferred_ids.append(result["pending_id"])
+                continue
+            if result.get("triple_id"):
+                triple_ids.append(result["triple_id"])
+            contradictions += result.get("contradictions_resolved", 0)
         except Exception as e:
             logger.debug("Failed to add triple: %s", e)
 
     # Archive the extraction event
-    if archive and triple_ids:
+    if archive and (triple_ids or deferred_ids):
+        deferred_note = f", {len(deferred_ids)} deferred for review" if deferred_ids else ""
         await archive.record(
             event_type="memory_extraction",
             data={
                 "facts_extracted": len(facts),
                 "triples_created": len(triple_ids),
                 "contradictions_resolved": contradictions,
+                "deferred": len(deferred_ids),
+                "deferred_ids": deferred_ids,
                 "method": method,
                 "source": source,
                 "facts": facts,
             },
             agent_name=agent_name,
-            summary=f"Extracted {len(facts)} facts ({method}) from {source}, {contradictions} contradictions resolved",
+            summary=(
+                f"Extracted {len(facts)} facts ({method}) from {source}, "
+                f"{contradictions} contradictions resolved{deferred_note}"
+            ),
         )
 
     return {
         "facts_extracted": len(facts),
         "triples_created": len(triple_ids),
         "contradictions_resolved": contradictions,
+        "deferred": len(deferred_ids),
+        "deferred_ids": deferred_ids,
         "triple_ids": triple_ids,
         "method": method,
     }

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -203,6 +203,63 @@ def test_kg_defers_low_confidence_contradictions(tmp_path):
     assert queue[0]["new_object"] == "paris"
 
 
+def test_process_conversation_turn_defers_low_confidence(tmp_path):
+    """Agent ingest path threads pending_store + defer_below_confidence through."""
+    from taosmd.memory_extractor import process_conversation_turn
+
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        pending = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+        await kg.init()
+        await pending.init()
+        try:
+            # Seed an existing high-confidence preference. "prefers" is in
+            # SINGULAR_PREDICATES so a new "prefers" for the same subject
+            # triggers the contradiction check.
+            await kg.add_triple(
+                subject="alice", predicate="prefers", obj="vim",
+                confidence=1.0, source="user-direct",
+            )
+
+            # New regex-extracted fact contradicts but at confidence 0.5
+            # (below the 0.8 threshold) -> goes to the pending queue
+            # instead of overwriting the existing fact.
+            result = await process_conversation_turn(
+                text="Alice prefers emacs.",
+                agent_name="testbot",
+                kg=kg,
+                archive=None,
+                source="nightly-summary",
+                use_llm=False,                       # force regex extractor
+                pending_store=pending,
+                defer_below_confidence=0.8,
+                default_fact_confidence=0.5,
+            )
+            active = await kg.query_entity("alice")
+            queue = await pending.list_pending()
+            return result, active, queue
+        finally:
+            await pending.close()
+            await kg.close()
+
+    result, active, queue = _run(go())
+
+    assert result["facts_extracted"] == 1
+    assert result["deferred"] == 1
+    assert result["triples_created"] == 0
+    assert result["deferred_ids"]
+
+    # The old fact survives because the new claim was deferred.
+    objs = {t["object_name"] for t in active}
+    assert "vim" in objs
+    assert "emacs" not in objs
+
+    assert len(queue) == 1
+    assert queue[0]["subject"] == "Alice"
+    assert queue[0]["predicate"] == "prefers"
+    assert queue[0]["new_object"] == "emacs"
+
+
 def test_kg_auto_resolves_high_confidence_even_with_pending_store(tmp_path):
     """A direct user statement (confidence=1.0) auto-resolves."""
     async def go():


### PR DESCRIPTION
## Summary

Re-open of #72 (auto-closed when PR #71's base branch was deleted on squash-merge). One commit on top of master.

Follow-up to PR #71 that closed three install-UX + safety gaps. After tracing every \`add_triple\` call site, the actual wiring needed is **not** in the nightly catalog pipeline (which only writes \`learned\` triples, not in \`SINGULAR_PREDICATES\`) but in \`memory_extractor.process_conversation_turn\` — the agent / user ingest path.

Adds three opt-in parameters:

| Param | Default | Effect |
|---|---|---|
| \`pending_store\` | \`None\` | When set, low-confidence contradictions defer to the queue. |
| \`defer_below_confidence\` | \`0.0\` | Threshold below which a conflicting new triple defers. Suggested \`0.8\` for nightly / inferred sources. |
| \`default_fact_confidence\` | \`1.0\` | Confidence applied when the extractor doesn't supply one. Callers extracting from less-certain sources should pass \`0.5\` so the threshold can fire. |

Return shape adds \`deferred\` and \`deferred_ids\`. Archive event records the deferred count too.

## Test plan

- [x] New test \`test_process_conversation_turn_defers_low_confidence\` exercises the full path end-to-end (regex extraction → KG conflict check → pending queue → old fact survives).
- [x] All 138 tests pass.

## Scope-honest note

The nightly catalog pipeline doesn't currently extract user-fact triples from session content — it only extracts lessons via \`cs.crystallize()\`. The plumbing is now ready for a future PR that adds session-content fact extraction to the pipeline; that PR needs its own bench to validate the threshold (false-defer rate vs missed-real-conflict rate). Deliberately not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented confidence-based fact deferral system that queues low-confidence claims for later review
  * Deferred facts are now tracked with counts and identifiers included in extraction results
  * Enhanced contradiction handling with improved fact storage management

* **Tests**
  * Added integration test for deferred fact handling workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->