### PR TITLE
fix: scrub LAN IP from spec doc

### DIFF
--- a/docs/specs/2026-04-19-locomo-scorecards.md
+++ b/docs/specs/2026-04-19-locomo-scorecards.md
@@ -9,7 +9,7 @@ methodology.
 categories Single-hop (1) / Temporal (2) / Multi-hop (3) / Open-dom (4).
 Adversarial (cat 5) excluded — reported separately when run.
 
-**Host.** All runs on Fedora workstation (192.168.6.108), RTX 3060 12GB,
+**Host.** All runs on Fedora workstation, RTX 3060 12 GB,
 Ollama (`OLLAMA_NUM_PARALLEL=3`), ONNX embed backend, top-K=10.
 
 **Generator.** gemma4:e2b Q4_K_M (5.1B params actual) via Ollama unless


### PR DESCRIPTION
Removes the private LAN IP from docs/specs/2026-04-19-locomo-scorecards.md. HEAD-only scrub; older history retains the IP. Force-pushing a history rewrite would fully remove it but requires explicit consent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting and metadata in specifications documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->