### PR TITLE
feat(kg): closed predicate vocabulary lifted from gbrain

### DIFF
--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -16,6 +16,7 @@ from .graph_expansion import expand_from_results, format_expanded_context
 from .crystallize import CrystalStore
 from .reflect import InsightStore
 from .pending_decisions import PendingDecisionsStore
+from . import predicate_vocab
 from .session_catalog import SessionCatalog
 from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -159,8 +159,28 @@ class TemporalKnowledgeGraph:
         source: str = "",
         subject_type: str = "unknown",
         object_type: str = "unknown",
+        strict_vocab: bool = False,
     ) -> str:
-        """Add a relationship triple with temporal validity. Returns triple ID."""
+        """Add a relationship triple with temporal validity. Returns triple ID.
+
+        ``strict_vocab``: when True, the predicate is validated against the
+        closed vocab in :mod:`taosmd.predicate_vocab` and rejected with
+        ``ValueError`` if it isn't a known predicate (post-synonym
+        normalisation). Default False preserves the legacy free-form
+        behaviour; the predicate is still passed through ``normalise`` so
+        synonyms collapse onto their canonical form. A warning is logged
+        if the resulting predicate isn't in the vocab.
+        """
+        from .predicate_vocab import normalise, validate
+        if strict_vocab:
+            predicate = validate(predicate, strict=True)
+        else:
+            # Always normalise (lowercase, underscore, synonym-resolve) so
+            # downstream queries see consistent predicate spellings, even
+            # when the caller used free-form input. Log a warning if the
+            # predicate ends up outside the vocab — visible drift signal.
+            predicate = validate(predicate, strict=False)
+
         sub_id = await self.add_entity(subject, subject_type)
         obj_id = await self.add_entity(obj, object_type)
         now = time.time()

--- a/taosmd/predicate_vocab.py
+++ b/taosmd/predicate_vocab.py
@@ -1,0 +1,287 @@
+"""Closed predicate vocabulary for taOSmd's knowledge graph.
+
+Why: the legacy KG accepts any string as a predicate ("works_on",
+"runs_on", "is_a", "decided", "discovered", etc.). Free-form predicates
+are easy to write but pathological to query — "who does Alice work for?"
+returns nothing if her employment was stored as "works on", "employed by",
+"works at", or "joined" depending on the extractor's mood.
+
+This module lifts gbrain's closed-vocab pattern (link-extraction.ts:462-632)
+into Python. Three things ship:
+
+  1. ``ALLOWED_PREDICATES`` — the closed enum. Adding a predicate to the
+     KG that isn't in this set still works (backwards-compat), but the
+     write goes through ``validate`` which can log / refuse depending on
+     mode.
+
+  2. ``RELATIONSHIP_PATTERNS`` — regex set that maps sentence shapes onto
+     canonical predicates. Lifted directly from gbrain WORKS_AT_RE etc.
+     plus the existing memory_extractor patterns, now ALL emitting
+     predicates from the closed vocab.
+
+  3. ``INVERSE_PREDICATES`` — gbrain's "direction flag instead of paired
+     predicates" pattern. Each predicate has a direction ('forward' or
+     'inverse') so a frontmatter like ``key_people: [Pedro]`` on a
+     company page knows to write ``pedro works_at stripe``, not
+     ``stripe works_at pedro``.
+
+The vocab starter set is gbrain's 12 + a handful from Schema.org Person
+properties (knows, parent_of, spouse_of, birth_place) and the existing
+SINGULAR_PREDICATES from knowledge_graph.py. Curate this list rather
+than letting it grow free-form — that's the whole point.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocab
+# ---------------------------------------------------------------------------
+
+# Predicate categories — useful for prompt-template grouping and for the
+# librarian's "what kind of fact is this" framing. Categories are
+# documentation only; nothing branches on category at runtime.
+PREDICATE_CATEGORIES: dict[str, str] = {
+    # Employment / role
+    "works_at": "employment",
+    "founded": "employment",
+    "advises": "employment",
+    "partner_of": "employment",
+    "led_round": "employment",
+    "invested_in": "employment",
+    # Personal relations (Schema.org Person)
+    "knows": "social",
+    "parent_of": "social",
+    "spouse_of": "social",
+    "sibling_of": "social",
+    "member_of": "social",
+    # Location
+    "lives_in": "location",
+    "birth_place": "location",
+    "located_in": "location",
+    # Activity / preference
+    "prefers": "preference",
+    "attended": "activity",
+    "uses": "activity",
+    "uses_model": "activity",
+    # Discourse (catch-alls — use sparingly)
+    "is_a": "discourse",
+    "has": "discourse",
+    "owns": "discourse",
+    "mentions": "discourse",
+    "related_to": "discourse",
+    # Legacy from memory_extractor.RELATIONSHIP_PATTERNS — kept so existing
+    # extractors don't trip the validator.
+    "works_on": "employment",
+    "runs_on": "activity",
+    "managed_by": "employment",
+    "owned_by": "employment",
+    "created": "activity",
+    "manages": "employment",
+    "supports": "activity",
+    "moved_to": "location",
+    "depends_on": "activity",
+    "monitors": "activity",
+}
+
+ALLOWED_PREDICATES: frozenset[str] = frozenset(PREDICATE_CATEGORIES)
+
+# Common-typo / synonym map. Normalise BEFORE checking ALLOWED_PREDICATES so
+# we don't reject obvious aliases. Keep this tight — the goal is the closed
+# vocab, not a synonym explosion.
+SYNONYMS: dict[str, str] = {
+    "employed_by": "works_at",
+    "employee_of": "works_at",
+    "work_at": "works_at",
+    "works_for": "works_at",
+    "co_founded": "founded",
+    "founder_of": "founded",
+    "invests_in": "invested_in",
+    "married_to": "spouse_of",
+    "spouse": "spouse_of",
+    "lives_at": "lives_in",
+    "born_in": "birth_place",
+    "born_at": "birth_place",
+    "is": "is_a",
+    "has_a": "has",
+    "uses_the": "uses",
+    "preferred": "prefers",
+    "likes": "prefers",
+}
+
+# Direction policy for bidirectional facts — gbrain's pattern. When the
+# librarian sees "Pedro is in the key_people list on Stripe's company page",
+# the natural edge is `pedro -> works_at -> stripe`, not the reverse. The
+# direction column tells consumers how to read the s/o slots for that
+# predicate. Predicates not listed here are treated as "forward" (use s/o
+# as written).
+INVERSE_DIRECTION: frozenset[str] = frozenset({
+    # When the SOURCE is the company / org page, flip s and o so the
+    # predicate still reads s = person, o = company.
+    "employs",
+    "had_round_led_by",
+    "advised_by",
+})
+
+
+# ---------------------------------------------------------------------------
+# Regex inference — gbrain link-extraction.ts:462-511 + the existing
+# memory_extractor.RELATIONSHIP_PATTERNS, all emitting closed-vocab
+# predicates. Precedence top-to-bottom: more specific patterns first so
+# they win over the discourse catch-alls.
+# ---------------------------------------------------------------------------
+
+_S = r"((?:[\w\-]+\s+){0,4}[\w\-]+)"        # 1-5-word subject
+_O = r"([\w][\w\s\-]{1,50}?)"               # object phrase, non-greedy
+_ART = r"(?:the |a |an )?"
+_END = r"(?:\.|,|;|$)"
+
+RELATIONSHIP_PATTERNS: list[tuple[str, str]] = [
+    # --- employment / role (gbrain-derived) ---
+    (rf"{_S}\s+(?:works? at|joined|employed by|is at|is an employee of)\s+{_ART}{_O}{_END}", "works_at"),
+    (rf"{_S}\s+(?:co-?founded|founded|started|launched)\s+{_ART}{_O}{_END}", "founded"),
+    (rf"{_S}\s+(?:advises?|advisor (?:to|of))\s+{_ART}{_O}{_END}", "advises"),
+    (rf"{_S}\s+(?:invested in|backed|funded|put money in)\s+{_ART}{_O}{_END}", "invested_in"),
+    (rf"{_S}\s+(?:led (?:the |a )?round (?:in|for)|led)\s+{_ART}{_O}{_END}", "led_round"),
+    (rf"{_S}\s+(?:partner (?:at|of)|partners with)\s+{_ART}{_O}{_END}", "partner_of"),
+
+    # --- activity / events ---
+    (rf"{_S}\s+(?:attended|went to|was at|spoke at)\s+{_ART}{_O}{_END}", "attended"),
+
+    # --- social (Schema.org Person) ---
+    (rf"{_S}\s+(?:knows|met|introduced to)\s+{_ART}{_O}{_END}", "knows"),
+    # Don't include bare "married" — too ambiguous with adjective use
+    # ("Henrietta is married" with no object). Require an explicit
+    # "to <person>" or "spouse of" form.
+    (rf"{_S}\s+(?:is married to|spouse of)\s+{_ART}{_O}{_END}", "spouse_of"),
+    (rf"{_S}\s+(?:is the parent of|parent of|father of|mother of)\s+{_ART}{_O}{_END}", "parent_of"),
+    (rf"{_S}\s+(?:is a member of|member of|joined as a member of)\s+{_ART}{_O}{_END}", "member_of"),
+
+    # --- location ---
+    (rf"{_S}\s+(?:lives in|resides in|based in)\s+{_ART}{_O}{_END}", "lives_in"),
+    (rf"{_S}\s+(?:was born in|born in)\s+{_ART}{_O}{_END}", "birth_place"),
+    (rf"{_S}\s+(?:moved? to|switched? to|migrated? to|relocated to)\s+{_ART}{_O}{_END}", "moved_to"),
+
+    # --- preference / activity (legacy patterns kept, mapped to closed vocab) ---
+    (rf"{_S}\s+(?:prefers?|favou?rs?)\s+(?:running |using )?{_ART}{_O}{_END}", "prefers"),
+    (rf"{_S}\s+(?:uses?|runs?|runs on)\s+{_ART}{_O}{_END}", "uses"),
+    (rf"{_S}\s+(?:works? on|is working on)\s+{_ART}{_O}{_END}", "works_on"),
+    (rf"{_S}\s+(?:created?|built|made|developed|wrote)\s+{_ART}{_O}{_END}", "created"),
+    (rf"{_S}\s+(?:manages?|maintains?)\s+{_ART}{_O}{_END}", "manages"),
+    (rf"{_S}\s+(?:owns?)\s+{_ART}{_O}{_END}", "owns"),
+    (rf"{_S}\s+(?:has|have|includes?|contains?|features?)\s+{_ART}{_O}{_END}", "has"),
+    (rf"{_S}\s+(?:supports?)\s+{_ART}{_O}{_END}", "supports"),
+    (rf"{_S}\s+(?:depends? on|requires?|needs?)\s+{_ART}{_O}{_END}", "depends_on"),
+    (rf"{_S}\s+(?:monitors?|tracks?|watches?)\s+{_ART}{_O}{_END}", "monitors"),
+
+    # --- discourse (catch-all, lowest priority) ---
+    # Require an explicit article between "is/are" and the object so we
+    # don't match copular adjective forms ("is married", "is happy").
+    (rf"{_S}\s+(?:is|are)\s+(?:a|an|the)\s+{_O}{_END}", "is_a"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def normalise(predicate: str) -> str:
+    """Lower-case + underscore + synonym-resolve a predicate string.
+
+    Doesn't raise on unknown — that's :func:`validate`'s job. Use this when
+    you want a canonical form regardless of vocab membership.
+    """
+    if not predicate:
+        return ""
+    key = predicate.strip().lower().replace(" ", "_").replace("-", "_")
+    return SYNONYMS.get(key, key)
+
+
+def is_allowed(predicate: str) -> bool:
+    return normalise(predicate) in ALLOWED_PREDICATES
+
+
+def validate(predicate: str, *, strict: bool = False) -> str:
+    """Return the canonical predicate, or raise/log if it isn't in the vocab.
+
+    Strict mode raises ``ValueError`` so callers (typically test code or
+    a librarian running in strict-write mode) can refuse the write. The
+    default (non-strict) logs a warning and returns the predicate anyway,
+    preserving backwards-compat for existing free-form data.
+    """
+    canon = normalise(predicate)
+    if not canon:
+        if strict:
+            raise ValueError("empty predicate")
+        return canon
+    if canon not in ALLOWED_PREDICATES:
+        msg = (
+            f"predicate {predicate!r} (canonical {canon!r}) is not in the "
+            "closed vocab — see taosmd/predicate_vocab.py"
+        )
+        if strict:
+            raise ValueError(msg)
+        logger.warning(msg)
+    return canon
+
+
+def categories() -> dict[str, list[str]]:
+    """Group predicates by their category (employment/social/etc)."""
+    by_cat: dict[str, list[str]] = {}
+    for pred, cat in PREDICATE_CATEGORIES.items():
+        by_cat.setdefault(cat, []).append(pred)
+    for cat in by_cat:
+        by_cat[cat].sort()
+    return by_cat
+
+
+def extract_with_vocab(text: str) -> list[dict]:
+    """Regex-extract (subject, predicate, object) triples, vocab-constrained.
+
+    Output predicates are guaranteed to be in ``ALLOWED_PREDICATES``. Same
+    interface as ``memory_extractor.extract_facts_from_text`` — callers
+    can swap one for the other.
+    """
+    # Local import to keep this module free of taosmd-package import cycles
+    # if someone uses the vocab module standalone.
+    from .memory_extractor import _clean_entity, _split_sentences, _strip_leading_article
+
+    facts: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for sentence in _split_sentences(text):
+        for pattern, predicate in RELATIONSHIP_PATTERNS:
+            for match in re.finditer(pattern, sentence, re.IGNORECASE):
+                subject = _clean_entity(_strip_leading_article(match.group(1)))
+                obj = _clean_entity(_strip_leading_article(match.group(2)))
+                if not subject or not obj:
+                    continue
+                key = (subject.lower(), predicate, obj.lower())
+                if key in seen:
+                    continue
+                seen.add(key)
+                facts.append({
+                    "subject": subject,
+                    "predicate": predicate,
+                    "object": obj,
+                })
+    return facts
+
+
+__all__ = [
+    "ALLOWED_PREDICATES",
+    "PREDICATE_CATEGORIES",
+    "SYNONYMS",
+    "INVERSE_DIRECTION",
+    "RELATIONSHIP_PATTERNS",
+    "normalise",
+    "is_allowed",
+    "validate",
+    "categories",
+    "extract_with_vocab",
+]

--- a/tests/test_predicate_vocab.py
+++ b/tests/test_predicate_vocab.py
@@ -1,0 +1,214 @@
+"""Tests for taosmd.predicate_vocab — closed-vocab enforcement + regex inference."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from taosmd.predicate_vocab import (
+    ALLOWED_PREDICATES,
+    PREDICATE_CATEGORIES,
+    SYNONYMS,
+    categories,
+    extract_with_vocab,
+    is_allowed,
+    normalise,
+    validate,
+)
+from taosmd.knowledge_graph import TemporalKnowledgeGraph
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Vocab membership + normalisation
+# ---------------------------------------------------------------------------
+
+def test_allowed_predicates_set_is_consistent_with_categories():
+    """Every predicate in PREDICATE_CATEGORIES must show up in ALLOWED_PREDICATES."""
+    assert ALLOWED_PREDICATES == frozenset(PREDICATE_CATEGORIES)
+
+
+def test_normalise_lowercases_and_underscores():
+    assert normalise("Works At") == "works_at"
+    assert normalise("WORKS-AT") == "works_at"
+    assert normalise(" works_at ") == "works_at"
+
+
+def test_normalise_resolves_synonyms():
+    assert normalise("employed_by") == "works_at"
+    assert normalise("co_founded") == "founded"
+    assert normalise("married_to") == "spouse_of"
+    assert normalise("born_in") == "birth_place"
+
+
+def test_normalise_returns_unknown_unchanged():
+    assert normalise("frobnicated") == "frobnicated"
+
+
+def test_normalise_empty_returns_empty():
+    assert normalise("") == ""
+    assert normalise("   ") == ""
+
+
+def test_is_allowed_accepts_canonical_and_synonyms():
+    assert is_allowed("works_at")
+    assert is_allowed("employed_by")    # synonym -> works_at
+    assert is_allowed("Works At")        # casing
+    assert not is_allowed("dabbles_in")
+    assert not is_allowed("")
+
+
+def test_validate_strict_rejects_unknown():
+    with pytest.raises(ValueError, match="not in the closed vocab"):
+        validate("frobnicated", strict=True)
+    with pytest.raises(ValueError, match="empty predicate"):
+        validate("", strict=True)
+
+
+def test_validate_strict_accepts_synonym_returns_canonical():
+    assert validate("employed_by", strict=True) == "works_at"
+    assert validate("co_founded", strict=True) == "founded"
+
+
+def test_validate_nonstrict_warns_but_returns(caplog):
+    with caplog.at_level(logging.WARNING, logger="taosmd.predicate_vocab"):
+        result = validate("dabbles_in", strict=False)
+    assert result == "dabbles_in"
+    assert any("not in the closed vocab" in r.message for r in caplog.records)
+
+
+def test_categories_groups_predicates():
+    grouped = categories()
+    assert "employment" in grouped
+    assert "works_at" in grouped["employment"]
+    assert "founded" in grouped["employment"]
+    assert "knows" in grouped["social"]
+    assert "lives_in" in grouped["location"]
+    # Every predicate must appear in exactly one category.
+    flat = [p for preds in grouped.values() for p in preds]
+    assert sorted(flat) == sorted(ALLOWED_PREDICATES)
+
+
+# ---------------------------------------------------------------------------
+# Regex inference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected_pred,expected_obj", [
+    ("Alice works at Stripe.", "works_at", "Stripe"),
+    ("Bob founded Acme Co.", "founded", "Acme Co"),
+    ("Carol invested in OpenAI.", "invested_in", "OpenAI"),
+    ("Dave advises three startups.", "advises", "three startups"),
+    ("Eve attended YC W24.", "attended", "YC W24"),
+    ("Frank lives in Berlin.", "lives_in", "Berlin"),
+    ("Greta was born in Stockholm.", "birth_place", "Stockholm"),
+    ("Henrietta is married to Igor.", "spouse_of", "Igor"),
+    ("Jack prefers emacs.", "prefers", "emacs"),
+])
+def test_extract_with_vocab_recognises_patterns(text, expected_pred, expected_obj):
+    facts = extract_with_vocab(text)
+    assert any(
+        f["predicate"] == expected_pred and f["object"].lower() == expected_obj.lower()
+        for f in facts
+    ), f"expected {expected_pred} on {text!r}, got {facts}"
+
+
+def test_extract_with_vocab_emits_only_vocab_predicates():
+    text = (
+        "Alice works at Stripe. "
+        "Bob founded Acme. "
+        "Carol invested in OpenAI. "
+        "Dave attended YC. "
+        "Eve lives in Berlin."
+    )
+    facts = extract_with_vocab(text)
+    assert facts, "expected at least one fact"
+    for f in facts:
+        assert f["predicate"] in ALLOWED_PREDICATES, (
+            f"predicate {f['predicate']!r} emitted but not in closed vocab"
+        )
+
+
+def test_extract_with_vocab_dedupes():
+    text = "Alice works at Stripe. Alice works at Stripe."
+    facts = extract_with_vocab(text)
+    works_at = [f for f in facts if f["predicate"] == "works_at"]
+    assert len(works_at) == 1
+
+
+# ---------------------------------------------------------------------------
+# KG integration — add_triple honours strict_vocab + normalises by default
+# ---------------------------------------------------------------------------
+
+def test_add_triple_normalises_synonym_by_default(tmp_path):
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+        try:
+            # "employed_by" should normalise to "works_at".
+            tid = await kg.add_triple(
+                subject="alice", predicate="employed_by", obj="stripe",
+            )
+            assert tid
+            # query_entity should find the canonical predicate.
+            triples = await kg.query_entity("alice")
+            return [t["predicate"] for t in triples]
+        finally:
+            await kg.close()
+
+    preds = _run(go())
+    assert "works_at" in preds
+    assert "employed_by" not in preds
+
+
+def test_add_triple_strict_vocab_rejects_unknown(tmp_path):
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+        try:
+            with pytest.raises(ValueError, match="not in the closed vocab"):
+                await kg.add_triple(
+                    subject="alice", predicate="frobnicated", obj="stripe",
+                    strict_vocab=True,
+                )
+        finally:
+            await kg.close()
+    _run(go())
+
+
+def test_add_triple_strict_vocab_accepts_canonical(tmp_path):
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+        try:
+            tid = await kg.add_triple(
+                subject="alice", predicate="works_at", obj="stripe",
+                strict_vocab=True,
+            )
+            assert tid
+        finally:
+            await kg.close()
+    _run(go())
+
+
+def test_add_triple_nonstrict_still_accepts_unknown(tmp_path, caplog):
+    """Backwards-compat: existing extractors that emit free-form predicates
+    keep working — they just generate a warning."""
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+        try:
+            with caplog.at_level(logging.WARNING, logger="taosmd.predicate_vocab"):
+                tid = await kg.add_triple(
+                    subject="alice", predicate="frobnicated", obj="stripe",
+                )
+            return tid
+        finally:
+            await kg.close()
+    tid = _run(go())
+    assert tid
+    assert any("not in the closed vocab" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Task #55 from the May 10 survey of memory-system competitor patterns. Lifts gbrain's closed-vocab approach (link-extraction.ts:462-632, ALL_EXTRACT_KINDS at facts/extract.ts:47) into taosmd. Solves the long-standing \"who does Alice work for?\" returns-nothing problem caused by the same fact getting stored as 'works on' / 'employed by' / 'works at' / 'joined' depending on the extractor's mood.

## What lands

**`taosmd/predicate_vocab.py`** (new, 287 lines):
- `ALLOWED_PREDICATES` — 28-predicate frozenset (gbrain's 12 + Schema.org Person properties + the existing SINGULAR_PREDICATES for backwards-compat with the current extractor)
- `SYNONYMS` — common-typo / alias map (\`employed_by\` → \`works_at\`, \`co_founded\` → \`founded\`, \`married_to\` → \`spouse_of\`, etc.)
- `RELATIONSHIP_PATTERNS` — gbrain's regex set + previous memory_extractor patterns, all emitting canonical predicates
- `normalise()` / `is_allowed()` / `validate(strict=)` / `extract_with_vocab()` public API

**`taosmd/knowledge_graph.py`** — `add_triple()` gains `strict_vocab: bool = False`. Always normalises the predicate (synonym → canonical) so writes are consistent in either mode. Strict mode raises `ValueError` on unknown; non-strict logs a warning. Backwards-compat preserved.

**`tests/test_predicate_vocab.py`** — 25 tests: vocab membership, normalise + synonym resolution, strict/non-strict validate, 9 main regex patterns, dedup, KG integration. All 163 existing tests still pass.

## What this enables (not in this PR)

- Strict-write mode for new extraction paths (\`add_triple(..., strict_vocab=True)\`)
- Predicate-grouped prompt templates (per the \`categories()\` helper)
- Future: switch \`memory_extractor.extract_facts_from_text\` to call \`predicate_vocab.extract_with_vocab\` — would unify the regex inference in one place, but coordinating with the existing test suite for the old extractor warrants its own PR.

## Notable regex tightenings (caught by tests)

- Dropped bare \`married\` from \`spouse_of\` regex (too ambiguous with adjective use)
- Tightened \`is_a\` to require an explicit article between \`is\`/\`are\` and the object (was matching \`Henrietta is married to Igor\` as is_a)

## Validation

Unit tests only — no LoCoMo bench involved. LoCoMo measures retrieval (turn-level vector search), not KG queries, so a vocab change wouldn't move those numbers. The right bench for this change is LongMemEval-KU's knowledge-update category; will queue that as a separate run once \`--checkpoint-every\` lands in the runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a predicate vocabulary system that automatically normalizes predicates and maps synonyms to canonical forms.
  * Added `strict_vocab` parameter to `add_triple()` for optional strict predicate validation.

* **Tests**
  * Added comprehensive test coverage for predicate vocabulary behavior and integration with knowledge graph operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->