### PR TITLE
feat(bench): --checkpoint-every N for live per-category snapshots

### DIFF
--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -885,6 +885,38 @@ def _summary(rows: list[dict]) -> dict:
     }
 
 
+def _print_checkpoint(results: list[dict], total: int) -> None:
+    """Print a compact per-category Judge-score snapshot mid-bench.
+
+    Called from the per-QA progress hook when ``--checkpoint-every`` fires.
+    Per-category recall is omitted since the runner only computes that for
+    the full result set; we'd duplicate aggregation cost for marginal value.
+
+    Caveat for the reader: at low ``total`` the first-N QAs come from the
+    earliest conversations in dataset order, so per-category numbers
+    aren't a balanced sample of the whole 1540 — wait until at least
+    ~40-50 % before reading SH trend with confidence.
+    """
+    if not results:
+        return
+    by_cat, overall = _aggregate(results)
+    print(
+        f"  [checkpoint @ {total} QAs]  "
+        f"Overall judge={overall['judge']:.3f}  f1={overall['f1']:.3f}  "
+        f"recall={overall['retrieval_recall']:.2f}",
+        flush=True,
+    )
+    for cat in sorted(by_cat.keys(), key=int):
+        s = by_cat[cat]
+        label = CATEGORY_NAMES.get(int(cat), f"cat-{cat}")
+        recall = "-" if int(cat) == 5 else f"{s['retrieval_recall']:.2f}"
+        print(
+            f"    {label:<18} n={s['count']:>4}  judge={s['judge']:.3f}  "
+            f"f1={s['f1']:.3f}  R@K={recall}",
+            flush=True,
+        )
+
+
 def _aggregate(results: list[dict]) -> tuple[dict, dict]:
     by_cat: dict[str, list[dict]] = {}
     for r in results:
@@ -992,6 +1024,12 @@ async def run(args: argparse.Namespace) -> int:
                 total_seen += 1
                 if total_seen % 25 == 0:
                     print(f"  progress: {total_seen} QAs processed", flush=True)
+                # Checkpoint: per-category breakdown every --checkpoint-every
+                # QAs. Cheap (just aggregates the in-memory results list)
+                # and lets the operator decide to abort early if SH or
+                # Overall is trending wrong. Skip if --checkpoint-every is 0.
+                if args.checkpoint_every and total_seen % args.checkpoint_every == 0:
+                    _print_checkpoint(results + [outcome], total_seen)
         return outcome
 
     async with httpx.AsyncClient(timeout=args.timeout) as client:
@@ -1259,6 +1297,19 @@ def _parse_args() -> argparse.Namespace:
         "--timeout", type=float, default=120.0,
         help="HTTP timeout for Ollama calls in seconds. Default 120 (was 60 — "
              "bumped after observing p95 latency of 52s under concurrency=3).",
+    )
+    p.add_argument(
+        "--checkpoint-every", type=int, default=0,
+        help=(
+            "Print a per-category Judge-score snapshot every N QAs. "
+            "0 (default) disables. Useful for early-abort decisions on "
+            "long full-1540 runs: a value of 100 yields ~15 checkpoints "
+            "and lets you pull the plug if SH or Overall is trending "
+            "wrong. Caveat: QAs come out in conversation order so the "
+            "first N aren't a balanced sample of the whole set — wait "
+            "until at least 40-50%% before reading SH trend with "
+            "confidence."
+        ),
     )
     return p.parse_args()
 


### PR DESCRIPTION
## Summary

Step 2 of today's plan. Adds \`--checkpoint-every N\` to \`benchmarks/locomo_runner.py\` so future bench runs print a per-category Judge / F1 / R@K snapshot every N QAs.

## Use case

Smarter smoke-vs-full decisions. Instead of running a 50-QA smoke first, then a separate full-1540 run after, you can launch full-1540 with \`--checkpoint-every 100\` (≈15 checkpoints) and abort early at any boundary if SH or Overall is trending wrong.

## Caveat surfaced in the help text

QAs come out in dataset / conversation order, so the first N aren't a balanced sample of the whole 1540 — the first 25% over-represents whichever conversations come first. Reliable SH trend reads only land at 40-50%+. Useful as a guard against catastrophic regression, not as a precision early-call. This is in the function docstring and the \`--help\` blurb so future operators don't get over-confident in early checkpoints.

## What changes

- New \`_print_checkpoint(results, total)\` helper above \`_aggregate()\` — calls existing \`_aggregate\` on the in-memory results, prints Overall + per-category summary.
- The \`_guarded\` per-QA hook now invokes \`_print_checkpoint\` when \`args.checkpoint_every > 0\` and \`total_seen\` hits the modulus.
- New \`--checkpoint-every\` CLI flag (default 0 = disabled).

## What doesn't change

- Zero behaviour change when \`--checkpoint-every\` is 0 (existing default).
- No new LLM round-trips. Just aggregating the in-memory result list at cadence.
- All 138 existing tests still pass.

## Test plan

- [x] AST + \`--help\` confirms the flag is registered
- [x] All 138 existing tests pass
- [ ] Operator validation on the next real bench — run with \`--checkpoint-every 100\` to confirm the output is useful