### PR TITLE
feat(emem): merge EMem-EDU code to master (was docs-only before)

### DIFF
--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -318,6 +318,8 @@ def _session_keys(conversation: dict) -> list[tuple[str, str]]:
 
 async def _ingest_conversation(
     vmem: VectorMemory, conv: dict, multi_level: bool = False,
+    *, emem_edu: bool = False, emem_edu_extract_model: str = "",
+    ollama_url: str = "", http_client: "httpx.AsyncClient | None" = None,
 ) -> tuple[int, float, dict[str, dict]]:
     """Ingest conversation turns into vmem.
 
@@ -332,8 +334,25 @@ async def _ingest_conversation(
     RRF fusion at retrieval naturally surfaces whichever level is most
     relevant for a given question. Equivalent to HyperMem's coarse-to-fine
     Topic/Episode/Fact hierarchy without the LLM-driven construction.
+
+    When emem_edu=True, replaces the raw-turn ingest with EMem-style
+    Elementary Discourse Unit extraction (one LLM call per session, port of
+    arXiv:2511.17208). Each session's turns are decomposed into atomic,
+    self-contained EDUs with normalized entities and turn attribution.
+    `multi_level` is incompatible with `emem_edu` and is ignored when both
+    are set — EDUs replace the turn level rather than augmenting it.
     """
     conversation = conv.get("conversation", conv)
+    if emem_edu:
+        if not http_client or not ollama_url or not emem_edu_extract_model:
+            raise ValueError(
+                "emem_edu=True requires http_client, ollama_url, and "
+                "emem_edu_extract_model"
+            )
+        return await _ingest_conversation_edus(
+            vmem, conv, http_client=http_client, ollama_url=ollama_url,
+            extract_model=emem_edu_extract_model,
+        )
     t0 = time.time()
     added = 0
     turn_index: dict[str, dict] = {}  # str(global_idx) -> {datetime, text, speaker, dia_id}
@@ -408,6 +427,117 @@ async def _ingest_conversation(
                         },
                     )
                     added += 1
+
+    return added, time.time() - t0, turn_index
+
+
+async def _ingest_conversation_edus(
+    vmem: VectorMemory, conv: dict, *,
+    http_client: httpx.AsyncClient, ollama_url: str, extract_model: str,
+) -> tuple[int, float, dict[str, dict]]:
+    """EMem-style EDU ingest path. One LLM call per session.
+
+    Falls back to per-turn EDUs if extraction errors / parses-empty for a
+    session — never leaves a session unindexed. Returns (added, elapsed,
+    turn_index) with the same shape as the raw-turn path so the caller can
+    treat the modes interchangeably; turn_index here maps turn_idx -> turn
+    metadata covering all turns from all sessions, used for evidence-recall
+    bookkeeping (EDUs with multi-turn attribution still resolve dia_ids
+    correctly).
+    """
+    from taosmd.emem_edu import extract_session_edus, format_session_for_extraction
+
+    conversation = conv.get("conversation", conv)
+    t0 = time.time()
+    added = 0
+    turn_index: dict[str, dict] = {}
+    global_idx = 0
+
+    speakers_seen: list[str] = []
+    for session_key, _dt in _session_keys(conversation):
+        for turn in conversation.get(session_key) or []:
+            sp = turn.get("speaker", "")
+            if sp and sp not in speakers_seen:
+                speakers_seen.append(sp)
+
+    for session_key, dt in _session_keys(conversation):
+        turns = conversation.get(session_key) or []
+        if not turns:
+            continue
+
+        session_first_idx = global_idx
+        local_turn_meta: list[dict] = []
+        for turn in turns:
+            text = (turn.get("text") or "").strip()
+            speaker = turn.get("speaker", "")
+            dia_id = turn.get("dia_id", "")
+            local_turn_meta.append({
+                "text": text, "speaker": speaker, "dia_id": dia_id,
+            })
+            turn_index[str(global_idx)] = {
+                "datetime": dt,
+                "text": f"[{speaker}] {text}" if text else "",
+                "speaker": speaker,
+                "dia_id": dia_id,
+            }
+            global_idx += 1
+
+        non_empty_turns = [t for t in turns if (t.get("text") or "").strip()]
+        if not non_empty_turns:
+            continue
+        session_text = format_session_for_extraction(non_empty_turns, dt)
+
+        edus: list[dict] = []
+        try:
+            edus = await extract_session_edus(
+                session_text, speakers_seen,
+                model=extract_model, ollama_url=ollama_url,
+                http_client=http_client,
+            )
+        except Exception as exc:
+            print(
+                f"[locomo_runner] EDU extraction failed for {session_key}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
+        if not edus:
+            for local_i, meta in enumerate(local_turn_meta):
+                if not meta["text"]:
+                    continue
+                edus.append({
+                    "edu_text": f"[{meta['speaker']}] {meta['text']}",
+                    "source_turn_ids": [local_i + 1],
+                })
+
+        for edu in edus:
+            edu_text = edu["edu_text"]
+            local_turn_ids = edu.get("source_turn_ids") or []
+            global_turn_ids: list[int] = []
+            primary_dia_id = ""
+            primary_speaker = ""
+            for ltid in local_turn_ids:
+                gidx = session_first_idx + (ltid - 1)
+                if str(gidx) in turn_index:
+                    global_turn_ids.append(gidx)
+                    if not primary_dia_id:
+                        primary_dia_id = turn_index[str(gidx)].get("dia_id", "")
+                        primary_speaker = turn_index[str(gidx)].get("speaker", "")
+            primary_global = global_turn_ids[0] if global_turn_ids else session_first_idx
+
+            await vmem.add(
+                edu_text,
+                metadata={
+                    "dia_id": primary_dia_id,
+                    "session": session_key,
+                    "datetime": dt,
+                    "speaker": primary_speaker,
+                    "turn_idx": primary_global,
+                    "level": "edu",
+                    "source_turn_ids": global_turn_ids,
+                },
+            )
+            added += 1
 
     return added, time.time() - t0, turn_index
 
@@ -658,6 +788,8 @@ async def _process_qa(
     llm_rerank_model: str = "llama3.1:8b",
     llm_rerank_top_k: int = 10,
     gen_temp: float = 0.2,
+    emem_edu_filter: bool = False,
+    emem_edu_filter_model: str = "",
 ) -> dict | None:
     if "answer" not in qa:
         return None
@@ -775,6 +907,28 @@ async def _process_qa(
             hits = _apply_temporal_recency_boost(hits, turn_index, temporal_boost)
 
         retrieval_ms = (time.time() - t0) * 1000.0
+
+        # EMem LLM filter — runs AFTER retrieval/rerank, BEFORE adjacent-turn
+        # injection. Single LLM call per QA; passes the candidate EDU texts
+        # to the filter model and keeps only the relevant subset (preserving
+        # original ranking). Empty filter result -> fall back to unfiltered
+        # hits (otherwise we'd starve the generator on a filter parse error).
+        if emem_edu_filter and hits:
+            from taosmd.emem_edu import filter_edus
+            candidate_texts = [h.get("text", "") for h in hits]
+            kept = await filter_edus(
+                question, candidate_texts,
+                model=emem_edu_filter_model, ollama_url=ollama_url,
+                http_client=client,
+            )
+            if kept:
+                # Preserve the LLM's filter order — that's the rerank signal.
+                # Drop duplicates by first occurrence (multiple hits could
+                # share text, in pathological cases).
+                by_text: dict[str, dict] = {}
+                for h in hits:
+                    by_text.setdefault(h.get("text", ""), h)
+                hits = [by_text[t] for t in kept if t in by_text]
 
         adj_map = _build_adjacent_map(hits, turn_index, adjacent_turns)
 
@@ -1013,6 +1167,8 @@ async def run(args: argparse.Namespace) -> int:
                     llm_rerank_top_k=args.llm_rerank_top_k,
                     gen_temp=args.gen_temp,
                     expansion_model=args.expansion_model,
+                    emem_edu_filter=(args.emem_edu and not args.emem_edu_no_filter),
+                    emem_edu_filter_model=args.emem_edu_filter_model or args.emem_edu_extract_model,
                 )
             except Exception as e:
                 async with progress_lock:
@@ -1044,9 +1200,14 @@ async def run(args: argparse.Namespace) -> int:
             )
             await vmem.init(http_client=client)
             added, ingest_s, turn_index = await _ingest_conversation(
-                vmem, conv, multi_level=args.multi_level_retrieval
+                vmem, conv, multi_level=args.multi_level_retrieval,
+                emem_edu=args.emem_edu,
+                emem_edu_extract_model=args.emem_edu_extract_model,
+                ollama_url=args.ollama_url,
+                http_client=client,
             )
-            print(f"[{conv_id}] ingested {added} turns in {ingest_s:.1f}s", flush=True)
+            unit = "EDUs" if args.emem_edu else "turns"
+            print(f"[{conv_id}] ingested {added} {unit} in {ingest_s:.1f}s", flush=True)
 
             # Pick eligible QAs up-front. --per-conv-limit caps QAs per
             # conversation (for balanced sampling); --limit is the global cap.
@@ -1096,6 +1257,13 @@ async def run(args: argparse.Namespace) -> int:
         "hyde": args.hyde,
         "no_think_prefix": args.no_think_prefix,
         "few_shot": args.few_shot,
+        "emem_edu": args.emem_edu,
+        "emem_edu_extract_model": args.emem_edu_extract_model if args.emem_edu else "",
+        "emem_edu_filter": (args.emem_edu and not args.emem_edu_no_filter),
+        "emem_edu_filter_model": (
+            (args.emem_edu_filter_model or args.emem_edu_extract_model)
+            if args.emem_edu and not args.emem_edu_no_filter else ""
+        ),
         "strategy": args.strategy,
         "total_qa": len(results),
         "categories_included": sorted(include_cats),
@@ -1285,6 +1453,29 @@ def _parse_args() -> argparse.Namespace:
                         "CoVe verification calls). Default 0.2 — the value "
                         "every prior LoCoMo cell ran at; sweep 0.0 / 0.5 / "
                         "0.8 to test sampling sensitivity.")
+    p.add_argument("--emem-edu", action="store_true",
+                   help="EMem-style EDU ingest (arXiv:2511.17208, vector-only "
+                        "variant). Replaces raw-turn ingest with one LLM call "
+                        "per session that decomposes turns into atomic, "
+                        "self-contained Elementary Discourse Units with "
+                        "normalized entities and turn attribution. EDUs are "
+                        "stored at level='edu' in vmem; existing dense + "
+                        "fusion + reranker paths apply unchanged. Adds an "
+                        "LLM filter call per QA (see --emem-edu-no-filter to "
+                        "disable). Incompatible with --multi-level-retrieval.")
+    p.add_argument("--emem-edu-extract-model", default="llama3.1:8b",
+                   help="Model for per-session EDU extraction. Default "
+                        "llama3.1:8b (fast, clean JSON, no think-mode "
+                        "quirk). Must be served by the Ollama URL.")
+    p.add_argument("--emem-edu-filter-model", default="",
+                   help="Model for the per-QA EDU filter step. Defaults to "
+                        "--emem-edu-extract-model. Set explicitly when "
+                        "running extraction on a different tier than filter.")
+    p.add_argument("--emem-edu-no-filter", action="store_true",
+                   help="Run the EMem-EDU ingest path but SKIP the LLM "
+                        "filter step at retrieval time. Useful for A/B-ing "
+                        "EDU storage alone vs EDU+filter, since the filter "
+                        "is one extra LLM call per QA (~5-15s).")
     p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
     p.add_argument("--out", default=None)
     p.add_argument("--run-id", default=None)

--- a/taosmd/emem_edu.py
+++ b/taosmd/emem_edu.py
@@ -1,0 +1,257 @@
+"""EMem-style EDU extraction + LLM filter (vector-only variant).
+
+Port of arXiv:2511.17208 EMem (no graph). Two functions:
+
+  extract_session_edus(session_text, speaker_names, ...)
+      One LLM call per session. Decomposes turns into atomic, self-contained
+      Elementary Discourse Units (EDUs) with turn attributions.
+
+  filter_edus(query, candidate_edus, ...)
+      One LLM call per query. Selects relevant EDUs from a candidate list
+      using EMem's "be maximally inclusive" prompt.
+
+Prompts adapted from /tmp/memresearch/emem/src/emem/prompts/templates/
+(conversation_edu_extraction_v1.py, edu_filter_locomo_v1.py).
+
+Both call Ollama's /api/chat with format=json so the open-source generators
+return parseable JSON without us building an explicit JSON schema for every
+model. JSON-parse failure surfaces as an exception — the caller decides
+whether to fallback (the LoCoMo runner does turn-level fallback at ingest
+and an empty-filter fallback at retrieval).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+
+_EXTRACTION_SYSTEM = (
+    "Given a conversation session between speakers with numbered turns, your task is to decompose it into Elementary Discourse Units (EDUs) "
+    "- short spans of text that are minimal yet complete in meaning. Each EDU should express a single fact, event, or "
+    "proposition and be atomic (not easily divisible further while still making sense). "
+    "It is important that you preserve all information from the conversation - no detail should be lost in the extraction process.\n"
+    "Requirements for Conversation EDUs with Turn Attribution:\n"
+    "1. Each EDU should be a self-contained unit of meaning that can be understood independently. It should not depend on any other EDU for understanding, although it may relate to it\n"
+    "2. Avoid pronouns or ambiguous references - use specific names and details, and consistently use the most informative name for each entity in all EDUs\n"
+    "3. The extracted EDUs must include all the information conveyed in the current conversation session. The extracted EDUs should collectively capture everything discussed\n"
+    "4. For each EDU, you must provide the source_turn_ids field containing a list of turn ID integers from which the EDU was extracted or referenced (e.g., [1], [3, 5], etc.)\n"
+    "5. EDUs can span multiple turns if they represent the same factual unit - in such cases, include all relevant turn IDs\n"
+    "6. Focus on extracting facts, events, and substantive information rather than conversational pleasantries\n"
+    "7. Infer and add complete temporal context where needed for clarity\n"
+    "8. Pay attention to capturing all details, facts, decisions, concerns, and substantive information from all speakers\n"
+    'Return JSON of the form {"edus": [{"edu_text": "...", "source_turn_ids": [n, ...]}, ...]}.'
+)
+
+
+_EXTRACTION_ONESHOT_INPUT = """Session conversation:
+Date: 2:30 pm on 15 March, 2024
+
+Turn 1:
+Alice: Hey Bob! How was your trip to Tokyo?
+
+Turn 2:
+Bob: It was amazing! I spent 5 days there for the Global AI Innovation Symposium 2024. The conference at Tokyo University was incredible.
+
+Turn 3:
+Alice: That sounds exciting! What was the main focus?
+
+Turn 4:
+Bob: They had sessions on large language models and robotics. I presented our recent work on multimodal learning.
+
+Turn 5:
+Alice: How did it go?
+
+Turn 6:
+Bob: Really well! We got great feedback and Dr. Yamamoto from Sony AI wants to collaborate on our next project.
+
+Turn 7:
+Alice: That's fantastic! When are you planning to start that collaboration?
+
+Turn 8:
+Bob: We're aiming for next month. He said they have a $2 million budget for joint research.
+
+Speaker names: Alice, Bob"""
+
+
+_EXTRACTION_ONESHOT_OUTPUT = json.dumps({
+    "edus": [
+        {"edu_text": "Bob traveled to Tokyo for 5 days to attend the Global AI Innovation Symposium 2024 in March 2024", "source_turn_ids": [2]},
+        {"edu_text": "The Global AI Innovation Symposium 2024 was held at Tokyo University in Tokyo", "source_turn_ids": [2]},
+        {"edu_text": "The Global AI Innovation Symposium 2024 included sessions on large language models and robotics", "source_turn_ids": [4]},
+        {"edu_text": "Bob presented his team's recent work on multimodal learning at the Global AI Innovation Symposium 2024", "source_turn_ids": [4]},
+        {"edu_text": "Bob's presentation on multimodal learning at the Global AI Innovation Symposium 2024 received great feedback", "source_turn_ids": [6]},
+        {"edu_text": "Dr. Yamamoto from Sony AI expressed interest in collaborating with Bob on a joint research project", "source_turn_ids": [6]},
+        {"edu_text": "Bob and Dr. Yamamoto from Sony AI plan to start the Bob-Sony AI collaboration project in April 2024", "source_turn_ids": [8]},
+        {"edu_text": "Dr. Yamamoto from Sony AI has a $2 million budget for the Bob-Sony AI collaboration project", "source_turn_ids": [8]},
+    ]
+})
+
+
+_FILTER_SYSTEM = (
+    "You are a conversational memory retrieval assistant helping to filter candidate memory units (EDUs - Elementary Discourse Units) for answering a user's query.\n\n"
+    "Your task is to select EDUs that are relevant to answering the query. Be MAXIMALLY INCLUSIVE - err on the side of keeping too many rather than too few:\n\n"
+    "**CRITICAL RULES:**\n"
+    "1. **Keep EDUs with embedded information**: Even if an EDU contains extra context or discusses multiple topics, KEEP IT if ANY part is relevant to the query. Don't discard EDUs just because they're long or contain additional information.\n"
+    "2. **All temporal references**: Keep EVERY EDU that mentions dates, times, durations, or events within the query's timeframe, even if buried in longer descriptions.\n"
+    "3. **All quantitative information**: Keep EVERY EDU containing numbers, counts, amounts, or measurements related to the query domain.\n"
+    "4. **Direct matches**: Keep ANY EDU that directly mentions entities, actions, or topics from the query.\n"
+    "5. **Multi-hop reasoning**: Include EDUs that form chains of information.\n"
+    "6. **Historical context**: Keep EDUs about past activities, purchases, visits, or experiences that relate to the query domain.\n"
+    "7. **Prefer false positives over false negatives**: It's MUCH better to include an irrelevant EDU than to miss a relevant one. When uncertain, ALWAYS include it.\n"
+    "8. **Copy exactly**: Selected EDUs must be copied exactly as they appear in the candidate list.\n\n"
+    "Remember: Your job is NOT to find the perfect answer, but to keep ALL EDUs that MIGHT help answer the query. Be generous!\n\n"
+    'Return JSON of the form {"selected_edus": ["edu text 1", "edu text 2", ...]}.'
+)
+
+
+_FILTER_ONESHOT_QUERY = "How many loyalty points does Sarah currently have at her favorite bookstore?"
+
+_FILTER_ONESHOT_CANDIDATES = [
+    "On June 10, 2023, Sarah purchased three books at Barnes & Noble and earned 45 loyalty points, bringing the total to 320 points.",
+    "Sarah enjoys reading mystery novels and has been collecting books from her favorite authors.",
+    "On May 15, 2023, Sarah signed up for the Barnes & Noble membership program and received 50 welcome bonus points.",
+    "Sarah is considering purchasing a new bookshelf to organize her growing book collection.",
+    "Barnes & Noble offers 1 point for every dollar spent on books and other items.",
+    "Sarah's favorite bookstore is Barnes & Noble, where she shops regularly for books and gifts.",
+    "Sarah redeemed 75 points for a discount on June 12, 2023, leaving 245 points in her account.",
+    "On June 14, 2023, Sarah purchased a journal at Barnes & Noble for $25 and earned 25 points, bringing the total to 270 points.",
+]
+
+_FILTER_ONESHOT_OUTPUT = json.dumps({
+    "selected_edus": [
+        "On May 15, 2023, Sarah signed up for the Barnes & Noble membership program and received 50 welcome bonus points.",
+        "On June 10, 2023, Sarah purchased three books at Barnes & Noble and earned 45 loyalty points, bringing the total to 320 points.",
+        "Barnes & Noble offers 1 point for every dollar spent on books and other items.",
+        "Sarah's favorite bookstore is Barnes & Noble, where she shops regularly for books and gifts.",
+        "Sarah redeemed 75 points for a discount on June 12, 2023, leaving 245 points in her account.",
+        "On June 14, 2023, Sarah purchased a journal at Barnes & Noble for $25 and earned 25 points, bringing the total to 270 points.",
+    ]
+})
+
+
+def format_session_for_extraction(turns: list[dict], session_date: str) -> str:
+    """Format LoCoMo session turns into the EMem extraction prompt input.
+
+    Returns a numbered-turn block exactly matching the one-shot example. Turn
+    IDs are 1-indexed because the prompt's exemplar uses 1-indexed turns.
+    """
+    lines = [f"Date: {session_date}", ""]
+    for i, turn in enumerate(turns, start=1):
+        lines.append(f"Turn {i}:")
+        lines.append(f"{turn.get('speaker', '')}: {turn.get('text', '')}")
+        lines.append("")
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+async def _ollama_chat_json(
+    client: httpx.AsyncClient, ollama_url: str, model: str,
+    messages: list[dict], *, timeout: float = 120.0, num_predict: int = 4096,
+) -> str:
+    """POST to /api/chat with format=json. Returns the assistant content string."""
+    resp = await client.post(
+        f"{ollama_url.rstrip('/')}/api/chat",
+        json={
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": 0.0, "num_predict": num_predict},
+        },
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return (data.get("message") or {}).get("content", "")
+
+
+async def extract_session_edus(
+    session_text: str, speaker_names: list[str], *,
+    model: str, ollama_url: str, http_client: httpx.AsyncClient,
+    timeout: float = 240.0,
+) -> list[dict]:
+    """Extract EDUs from one session. Returns list of {edu_text, source_turn_ids}.
+
+    Raises on transport / JSON-parse failure — caller decides fallback. (The
+    LoCoMo runner falls back to a per-turn EDU when this raises.)
+    """
+    user_msg = f"Session conversation:\n{session_text}\n\nSpeaker names: {', '.join(speaker_names)}"
+    messages = [
+        {"role": "system", "content": _EXTRACTION_SYSTEM},
+        {"role": "user", "content": _EXTRACTION_ONESHOT_INPUT},
+        {"role": "assistant", "content": _EXTRACTION_ONESHOT_OUTPUT},
+        {"role": "user", "content": user_msg},
+    ]
+
+    raw = await _ollama_chat_json(
+        http_client, ollama_url, model, messages,
+        timeout=timeout, num_predict=8192,
+    )
+    parsed = json.loads(raw)
+    edus: list[dict] = []
+    for entry in parsed.get("edus", []) or []:
+        text = (entry.get("edu_text") or "").strip()
+        if not text:
+            continue
+        turn_ids_raw = entry.get("source_turn_ids") or []
+        turn_ids: list[int] = []
+        for tid in turn_ids_raw:
+            try:
+                turn_ids.append(int(tid))
+            except (TypeError, ValueError):
+                continue
+        edus.append({"edu_text": text, "source_turn_ids": turn_ids})
+    return edus
+
+
+async def filter_edus(
+    query: str, candidate_edus: list[str], *,
+    model: str, ollama_url: str, http_client: httpx.AsyncClient,
+    timeout: float = 120.0,
+) -> list[str]:
+    """Filter candidate EDUs to those relevant to the query. Exact-text match.
+
+    Returns a subset of `candidate_edus` (preserving original order). Empty
+    list on parse / transport failure rather than raising — at retrieval time
+    we'd rather pass the unfiltered candidates through than crash the whole QA.
+    """
+    if not candidate_edus:
+        return []
+
+    user_msg = (
+        f"Query: {query}\n\n"
+        f"Candidate EDUs:\n{json.dumps(candidate_edus, indent=2)}"
+    )
+    oneshot_user = (
+        f"Query: {_FILTER_ONESHOT_QUERY}\n\n"
+        f"Candidate EDUs:\n{json.dumps(_FILTER_ONESHOT_CANDIDATES, indent=2)}"
+    )
+    messages = [
+        {"role": "system", "content": _FILTER_SYSTEM},
+        {"role": "user", "content": oneshot_user},
+        {"role": "assistant", "content": _FILTER_ONESHOT_OUTPUT},
+        {"role": "user", "content": user_msg},
+    ]
+
+    try:
+        raw = await _ollama_chat_json(
+            http_client, ollama_url, model, messages,
+            timeout=timeout, num_predict=4096,
+        )
+        parsed = json.loads(raw)
+    except (httpx.HTTPError, json.JSONDecodeError):
+        return []
+
+    selected = parsed.get("selected_edus", []) or []
+    candidate_set = set(candidate_edus)
+    keep_in_order: list[str] = []
+    seen: set[str] = set()
+    for edu in selected:
+        if isinstance(edu, str) and edu in candidate_set and edu not in seen:
+            keep_in_order.append(edu)
+            seen.add(edu)
+    return keep_in_order

--- a/taosmd/emem_edu.py
+++ b/taosmd/emem_edu.py
@@ -247,11 +247,28 @@ async def filter_edus(
         return []
 
     selected = parsed.get("selected_edus", []) or []
-    candidate_set = set(candidate_edus)
+    if not selected:
+        return []
+
+    # Fuzzy-match selected -> candidate. Smaller open-source models paraphrase
+    # the EDU when writing JSON (truncate, drop punctuation, slight reword)
+    # often enough that exact-string lookup silently drops most candidates.
+    # HippoRAG's reference uses difflib.get_close_matches with cutoff=0.0;
+    # we use 0.6 to keep unrelated EDUs out on pure noise. Each selected
+    # entry resolves to at most one candidate; candidates are emitted only
+    # once even if the model lists them twice.
+    import difflib
     keep_in_order: list[str] = []
-    seen: set[str] = set()
+    seen_idx: set[int] = set()
     for edu in selected:
-        if isinstance(edu, str) and edu in candidate_set and edu not in seen:
-            keep_in_order.append(edu)
-            seen.add(edu)
+        if not isinstance(edu, str) or not edu.strip():
+            continue
+        matches = difflib.get_close_matches(edu, candidate_edus, n=1, cutoff=0.6)
+        if not matches:
+            continue
+        idx = candidate_edus.index(matches[0])
+        if idx in seen_idx:
+            continue
+        seen_idx.add(idx)
+        keep_in_order.append(candidate_edus[idx])
     return keep_in_order


### PR DESCRIPTION
## Summary

Closes the same branch-hygiene gap PR #69 closed for the leader stack. The EMem-EDU recipe — full-1540 validated as the SH-specialist (+0.07 SH g4:e2b, +0.10 SH q3:4b) and documented in docs/benchmarks.md via PR #74 — only ever lived as code on \`feat/emem-edu-filter\`. Anyone cloning master today gets an "unknown argument: --emem-edu" if they try to run the recipe the README documents.

This PR cherry-picks the two EMem-specific commits cleanly onto current master:

- \`feat(emem): EMem-EDU ingest + LLM filter port (vector-only variant)\` — adds \`taosmd/emem_edu.py\` + \`--emem-edu\` / \`--emem-edu-extract-model\` / \`--emem-edu-filter-model\` / \`--emem-edu-no-filter\` CLI flags + runner integration in \`_ingest_conversation\` and \`_process_qa\`.
- \`fix(emem): filter_edus uses fuzzy match instead of exact string lookup\` — the May 14 \`difflib.get_close_matches(cutoff=0.6)\` fix that made the filter step parse correctly even when small models paraphrase EDUs in JSON output.

Conflict resolution: the original branch was off an old master, so cherry-pick conflicts touched \`_process_qa\` kwargs (lost CoVe/LLM-rerank/gen-temp) and the \`_parse_args\` block (lost CoVe/LLM-rerank/gen-temp args). Resolution kept BOTH feature sets — all the leader-stack flags from PR #69 plus the EMem-EDU flags.

## Validation

- All 163 existing tests pass (predicate vocab + pending decisions + everything else)
- \`--help\` confirms every flag is present: \`--fusion mem0_additive\`, \`--cove\`, \`--llm-rerank\`, \`--gen-temp\`, \`--emem-edu\`, \`--checkpoint-every\`
- AST parse clean

No new tests added in this PR — \`taosmd/emem_edu.py\` had no dedicated tests on the original branch; its validation was via the bench chain on Fedora (PR #74 numbers). Adding focused unit tests is a tight follow-up.