### PR TITLE
feat(emem): pass-2 typed event lift constrained by closed vocab (task #57)

### DIFF
--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -320,6 +320,9 @@ async def _ingest_conversation(
     vmem: VectorMemory, conv: dict, multi_level: bool = False,
     *, emem_edu: bool = False, emem_edu_extract_model: str = "",
     ollama_url: str = "", http_client: "httpx.AsyncClient | None" = None,
+    emem_edu_pass2_events: bool = False,
+    emem_edu_pass2_model: str = "",
+    kg=None,
 ) -> tuple[int, float, dict[str, dict]]:
     """Ingest conversation turns into vmem.
 
@@ -352,6 +355,9 @@ async def _ingest_conversation(
         return await _ingest_conversation_edus(
             vmem, conv, http_client=http_client, ollama_url=ollama_url,
             extract_model=emem_edu_extract_model,
+            pass2_events=emem_edu_pass2_events,
+            pass2_model=emem_edu_pass2_model or emem_edu_extract_model,
+            kg=kg,
         )
     t0 = time.time()
     added = 0
@@ -434,6 +440,9 @@ async def _ingest_conversation(
 async def _ingest_conversation_edus(
     vmem: VectorMemory, conv: dict, *,
     http_client: httpx.AsyncClient, ollama_url: str, extract_model: str,
+    pass2_events: bool = False,
+    pass2_model: str = "",
+    kg=None,
 ) -> tuple[int, float, dict[str, dict]]:
     """EMem-style EDU ingest path. One LLM call per session.
 
@@ -444,8 +453,18 @@ async def _ingest_conversation_edus(
     metadata covering all turns from all sessions, used for evidence-recall
     bookkeeping (EDUs with multi-turn attribution still resolve dia_ids
     correctly).
+
+    ``pass2_events``: when True (and ``kg`` is provided), each ingested
+    EDU is also lifted into ``{event_type, triples}`` via
+    :func:`taosmd.emem_event_lift.lift_edu_to_triples`. Triples are
+    written to the supplied KG with ``strict_vocab=True`` so any
+    predicate outside ALLOWED_PREDICATES raises rather than silently
+    drifting. Adds one LLM call per EDU (~5-15 s on llama3.1:8b at this
+    tier) so opt-in only — not the validated production recipe.
     """
     from taosmd.emem_edu import extract_session_edus, format_session_for_extraction
+    if pass2_events:
+        from taosmd.emem_event_lift import lift_edu_to_triples
 
     conversation = conv.get("conversation", conv)
     t0 = time.time()
@@ -538,6 +557,39 @@ async def _ingest_conversation_edus(
                 },
             )
             added += 1
+
+            # Pass-2: lift this EDU into typed (s, p, o) triples constrained
+            # by the closed vocab. Writes go straight into the KG with
+            # strict_vocab=True; the lifter has already dropped any
+            # invalid-predicate triples, so a ValueError here is signal of
+            # a genuine bug (e.g. vocab mutation between calls).
+            if pass2_events and kg is not None:
+                lift = await lift_edu_to_triples(
+                    edu_text,
+                    model=pass2_model,
+                    ollama_url=ollama_url,
+                    http_client=http_client,
+                )
+                for triple in lift.get("triples", []):
+                    try:
+                        await kg.add_triple(
+                            subject=triple["subject"],
+                            predicate=triple["predicate"],
+                            obj=triple["object"],
+                            source=f"emem_edu:pass2:{session_key}",
+                            confidence=0.7,
+                            strict_vocab=True,
+                        )
+                    except ValueError as exc:
+                        # strict_vocab rejected — log and move on rather
+                        # than fail the whole bench. Indicates either the
+                        # vocab needs a new predicate or the lifter's own
+                        # vocab filter has a gap.
+                        print(
+                            f"[locomo_runner] pass-2 triple rejected: "
+                            f"{triple!r} ({exc})",
+                            file=sys.stderr,
+                        )
 
     return added, time.time() - t0, turn_index
 
@@ -1199,15 +1251,33 @@ async def run(args: argparse.Namespace) -> int:
                 onnx_path=args.onnx_path,
             )
             await vmem.init(http_client=client)
+            kg = None
+            if args.emem_edu and args.emem_edu_pass2_events:
+                from taosmd.knowledge_graph import TemporalKnowledgeGraph
+                kg = TemporalKnowledgeGraph(db_path=os.path.join(tmp, "kg.db"))
+                await kg.init()
             added, ingest_s, turn_index = await _ingest_conversation(
                 vmem, conv, multi_level=args.multi_level_retrieval,
                 emem_edu=args.emem_edu,
                 emem_edu_extract_model=args.emem_edu_extract_model,
                 ollama_url=args.ollama_url,
                 http_client=client,
+                emem_edu_pass2_events=args.emem_edu_pass2_events,
+                emem_edu_pass2_model=args.emem_edu_pass2_model or args.emem_edu_extract_model,
+                kg=kg,
             )
             unit = "EDUs" if args.emem_edu else "turns"
-            print(f"[{conv_id}] ingested {added} {unit} in {ingest_s:.1f}s", flush=True)
+            if kg is not None:
+                kg_stats = await kg.stats()
+                print(
+                    f"[{conv_id}] ingested {added} {unit} in {ingest_s:.1f}s  "
+                    f"(pass2: {kg_stats['active_triples']} active triples, "
+                    f"{kg_stats['entities']} entities)",
+                    flush=True,
+                )
+                await kg.close()
+            else:
+                print(f"[{conv_id}] ingested {added} {unit} in {ingest_s:.1f}s", flush=True)
 
             # Pick eligible QAs up-front. --per-conv-limit caps QAs per
             # conversation (for balanced sampling); --limit is the global cap.
@@ -1476,6 +1546,21 @@ def _parse_args() -> argparse.Namespace:
                         "filter step at retrieval time. Useful for A/B-ing "
                         "EDU storage alone vs EDU+filter, since the filter "
                         "is one extra LLM call per QA (~5-15s).")
+    p.add_argument("--emem-edu-pass2-events", action="store_true",
+                   help="Pass-2 typed event lift on top of EMem-EDU ingest. "
+                        "After each EDU is stored, makes one LLM call to lift "
+                        "the EDU into (subject, predicate, object) triples "
+                        "constrained by the closed vocab in "
+                        "taosmd.predicate_vocab. Triples land in a per-conv "
+                        "transient KG (kg.db in the tempdir). Opt-in: pass-1 "
+                        "is the validated production recipe for retrieval, "
+                        "pass-2 populates the structured-KG side which "
+                        "LoCoMo doesn't measure but production agents query. "
+                        "Adds ~5-15 s LLM cost per EDU.")
+    p.add_argument("--emem-edu-pass2-model", default="",
+                   help="Model for the pass-2 event lift. Defaults to "
+                        "--emem-edu-extract-model. Set explicitly to use a "
+                        "different model for pass-2 than pass-1 extraction.")
     p.add_argument("--strategy", choices=["vector-only", "full"], default="vector-only")
     p.add_argument("--out", default=None)
     p.add_argument("--run-id", default=None)

--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -17,6 +17,7 @@ from .crystallize import CrystalStore
 from .reflect import InsightStore
 from .pending_decisions import PendingDecisionsStore
 from . import predicate_vocab
+from . import emem_event_lift
 from .session_catalog import SessionCatalog
 from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve

--- a/taosmd/emem_event_lift.py
+++ b/taosmd/emem_event_lift.py
@@ -1,0 +1,199 @@
+"""EMem pass-2 — lift EDUs into typed (subject, predicate, object) triples.
+
+Pass 1 (``taosmd.emem_edu.extract_session_edus``) decomposes a conversation
+session into atomic Elementary Discourse Units like "Bob traveled to Tokyo
+for 5 days in March 2024 for the Global AI Innovation Symposium". That's
+already the validated SH-specialist retrieval recipe — see PR #74 and
+docs/benchmarks.md.
+
+Pass 2 turns each EDU into structured KG triples whose predicates are
+constrained to ``taosmd.predicate_vocab.ALLOWED_PREDICATES``. The EDU
+above becomes:
+
+  [("bob", "moved_to", "tokyo"),
+   ("bob", "attended", "global ai innovation symposium 2024")]
+
+This is opt-in via ``--emem-edu-pass2-events`` on the LoCoMo runner. The
+pass-1 retrieval recipe is unchanged whether pass-2 runs or not; pass-2
+exists to populate the KG side of the system (structured queries like
+"who has Bob met?") which LoCoMo doesn't measure but production agents
+will.
+
+Why constrain the predicate? Because gbrain-style "closed vocab" beats
+free-form predicates for query-side consistency. Same reason the closed
+vocab landed in PR #76: if the librarian decides "is at" today and
+"works at" tomorrow, ``query_predicate("works_at")`` misses half the
+data. Constraining at extraction time prevents drift at source.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from .predicate_vocab import ALLOWED_PREDICATES, normalise
+
+
+# The system prompt lists every allowed predicate inline so the model can
+# pick from a fixed set rather than inventing new ones. We keep the list
+# sorted + comma-separated for token efficiency. Renders at ~250 tokens —
+# acceptable per-call overhead for a 5-15 s LLM round trip.
+def _allowed_predicates_inline() -> str:
+    return ", ".join(sorted(ALLOWED_PREDICATES))
+
+
+_SYSTEM_PROMPT = """\
+You are extracting structured (subject, predicate, object) triples from a single Elementary Discourse Unit (EDU) — a short, atomic factual statement.
+
+For each triple:
+- subject and object must be normalised entity names. Lowercase, use the most informative name (e.g. "bob" not "he", "global ai innovation symposium 2024" not "the conference").
+- predicate MUST be one of these allowed predicates and nothing else:
+{predicates_inline}
+
+If a fact's natural predicate isn't in the allowed list, EITHER pick the closest match OR drop the triple — do not invent a new predicate. Drop triples you can't express cleanly.
+
+Return JSON of the form:
+  {{"event_type": "<short label, e.g. 'travel', 'meeting', 'employment_change'>",
+    "triples": [{{"subject": "...", "predicate": "...", "object": "..."}}, ...]}}
+
+If the EDU has no extractable triples (pleasantry, hedge, opinion without a fact), return {{"event_type": "none", "triples": []}}.
+"""
+
+
+_ONESHOT_INPUT = """\
+EDU: Bob traveled to Tokyo for 5 days in March 2024 to attend the Global AI Innovation Symposium at Tokyo University.
+"""
+
+
+_ONESHOT_OUTPUT = json.dumps({
+    "event_type": "travel",
+    "triples": [
+        {"subject": "bob", "predicate": "moved_to", "object": "tokyo"},
+        {"subject": "bob", "predicate": "attended",
+         "object": "global ai innovation symposium 2024"},
+        {"subject": "global ai innovation symposium 2024",
+         "predicate": "located_in", "object": "tokyo university"},
+    ],
+})
+
+
+async def _ollama_chat_json(
+    client: httpx.AsyncClient, ollama_url: str, model: str,
+    messages: list[dict], *, timeout: float = 120.0, num_predict: int = 2048,
+) -> str:
+    """POST to /api/chat with format=json. Mirrors emem_edu._ollama_chat_json
+    so we can stay deterministic + JSON-strict on the small open-source models
+    that get used as extractors at our hardware tier.
+    """
+    resp = await client.post(
+        f"{ollama_url.rstrip('/')}/api/chat",
+        json={
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": 0.0, "num_predict": num_predict},
+        },
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return (data.get("message") or {}).get("content", "")
+
+
+def _system_prompt() -> str:
+    return _SYSTEM_PROMPT.format(predicates_inline=_allowed_predicates_inline())
+
+
+async def lift_edu_to_triples(
+    edu_text: str,
+    *,
+    model: str,
+    ollama_url: str,
+    http_client: httpx.AsyncClient,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+    """Lift a single EDU into ``{event_type, triples}`` with vocab-constrained predicates.
+
+    Returns ``{"event_type": str, "triples": [{"subject", "predicate", "object"}]}``.
+    Predicates are normalised + filtered against ``ALLOWED_PREDICATES`` here
+    in the client (belt-and-braces — the system prompt asks for it, but
+    smaller models occasionally invent). Triples whose predicate doesn't
+    survive normalisation/filtering are silently dropped (logged at debug
+    by the caller if it cares); we'd rather lose a noisy triple than write
+    a free-form one and corrode the vocab.
+
+    Returns ``{"event_type": "none", "triples": []}`` on transport / JSON
+    error — caller can treat empty as "nothing extracted" without needing
+    to differentiate "nothing there" from "extractor failed".
+    """
+    messages = [
+        {"role": "system", "content": _system_prompt()},
+        {"role": "user", "content": _ONESHOT_INPUT},
+        {"role": "assistant", "content": _ONESHOT_OUTPUT},
+        {"role": "user", "content": f"EDU: {edu_text}"},
+    ]
+
+    try:
+        raw = await _ollama_chat_json(
+            http_client, ollama_url, model, messages,
+            timeout=timeout, num_predict=2048,
+        )
+        parsed = json.loads(raw)
+    except (httpx.HTTPError, json.JSONDecodeError):
+        return {"event_type": "none", "triples": []}
+
+    event_type = (parsed.get("event_type") or "none").strip().lower()
+    out_triples: list[dict[str, str]] = []
+    for t in parsed.get("triples", []) or []:
+        s = (t.get("subject") or "").strip().lower()
+        p_raw = (t.get("predicate") or "").strip().lower()
+        o = (t.get("object") or "").strip().lower()
+        if not s or not p_raw or not o:
+            continue
+        # Normalise through synonym table first; reject if still outside vocab.
+        p = normalise(p_raw)
+        if p not in ALLOWED_PREDICATES:
+            continue
+        out_triples.append({"subject": s, "predicate": p, "object": o})
+
+    return {"event_type": event_type, "triples": out_triples}
+
+
+async def lift_edus_to_events(
+    edus: list[dict],
+    *,
+    model: str,
+    ollama_url: str,
+    http_client: httpx.AsyncClient,
+    timeout: float = 120.0,
+) -> list[dict[str, Any]]:
+    """Lift a batch of EDUs in sequence. One LLM call per EDU.
+
+    Returns one ``{event_type, triples, source_edu, source_turn_ids}`` dict
+    per input EDU. ``source_edu`` is the original EDU text (preserved so
+    KG writers can record provenance); ``source_turn_ids`` is copied from
+    the pass-1 EDU output so the resulting triples remain traceable to the
+    underlying conversation turns.
+
+    Sequential calls (not concurrent) to avoid hammering Ollama under
+    NUM_PARALLEL=1, which is the default LoCoMo bench config. Caller can
+    parallelise across sessions if they want — within a session, pass-1
+    already serialised on ingest order.
+    """
+    out: list[dict[str, Any]] = []
+    for edu in edus:
+        edu_text = (edu.get("edu_text") or "").strip()
+        if not edu_text:
+            continue
+        result = await lift_edu_to_triples(
+            edu_text,
+            model=model, ollama_url=ollama_url,
+            http_client=http_client, timeout=timeout,
+        )
+        result["source_edu"] = edu_text
+        result["source_turn_ids"] = edu.get("source_turn_ids", []) or []
+        out.append(result)
+    return out

--- a/tests/test_emem_event_lift.py
+++ b/tests/test_emem_event_lift.py
@@ -1,0 +1,260 @@
+"""Tests for taosmd.emem_event_lift — EMem pass-2 typed event lift.
+
+Tests stub Ollama via a fake httpx-shaped client. We exercise:
+
+  - happy-path: well-formed JSON with vocab-valid predicates round-trips
+  - belt-and-braces filter: predicates outside ALLOWED_PREDICATES are
+    dropped client-side even if the model emits them
+  - synonym normalisation: model emits 'employed_by', we record 'works_at'
+  - error fallback: transport / JSON failure returns the no-op shape
+  - batch lifter: lift_edus_to_events preserves source_edu + source_turn_ids
+
+Plus an integration with TemporalKnowledgeGraph that exercises the
+strict_vocab write path — pass-2 outputs going into a KG must round-trip
+through the closed vocab.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from taosmd.emem_event_lift import lift_edu_to_triples, lift_edus_to_events
+from taosmd.knowledge_graph import TemporalKnowledgeGraph
+from taosmd.predicate_vocab import ALLOWED_PREDICATES
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeOllamaClient:
+    """httpx.AsyncClient stub that returns a predetermined JSON payload."""
+
+    def __init__(self, content_json: dict[str, Any]):
+        self._content = json.dumps(content_json)
+
+    async def post(self, url, json=None, timeout=None):
+        # Ignore inputs — return the canned content. Mirrors Ollama's
+        # /api/chat shape: {"message": {"content": "<json string>"}}.
+        return _FakeResponse({"message": {"content": self._content}})
+
+
+# ---------------------------------------------------------------------------
+# Single-EDU lift
+# ---------------------------------------------------------------------------
+
+
+def test_lift_edu_happy_path():
+    """Model emits 3 vocab-valid triples → all 3 survive the filter."""
+    client = _FakeOllamaClient({
+        "event_type": "travel",
+        "triples": [
+            {"subject": "bob", "predicate": "moved_to", "object": "tokyo"},
+            {"subject": "bob", "predicate": "attended",
+             "object": "global ai innovation symposium 2024"},
+            {"subject": "global ai innovation symposium 2024",
+             "predicate": "located_in", "object": "tokyo university"},
+        ],
+    })
+
+    result = _run(lift_edu_to_triples(
+        "Bob traveled to Tokyo for the Global AI Innovation Symposium.",
+        model="llama3.1:8b",
+        ollama_url="http://localhost:11434",
+        http_client=client,
+    ))
+
+    assert result["event_type"] == "travel"
+    assert len(result["triples"]) == 3
+    assert all(t["predicate"] in ALLOWED_PREDICATES for t in result["triples"])
+    subjects = {t["subject"] for t in result["triples"]}
+    assert "bob" in subjects
+
+
+def test_lift_edu_drops_unknown_predicates():
+    """Model invents a predicate not in the closed vocab → lifter drops it."""
+    client = _FakeOllamaClient({
+        "event_type": "misc",
+        "triples": [
+            {"subject": "alice", "predicate": "works_at", "object": "stripe"},
+            {"subject": "alice", "predicate": "frobnicates", "object": "things"},
+            {"subject": "alice", "predicate": "dabbles_in", "object": "ml"},
+        ],
+    })
+
+    result = _run(lift_edu_to_triples(
+        "Alice works at Stripe and tinkers with ML.",
+        model="llama3.1:8b",
+        ollama_url="http://localhost:11434",
+        http_client=client,
+    ))
+
+    # Only the works_at triple survives.
+    assert len(result["triples"]) == 1
+    assert result["triples"][0]["predicate"] == "works_at"
+
+
+def test_lift_edu_resolves_synonyms_via_predicate_vocab():
+    """Model emits 'employed_by' (a synonym) → recorded as canonical 'works_at'."""
+    client = _FakeOllamaClient({
+        "event_type": "employment",
+        "triples": [
+            {"subject": "alice", "predicate": "employed_by", "object": "stripe"},
+        ],
+    })
+
+    result = _run(lift_edu_to_triples(
+        "Alice is employed by Stripe.",
+        model="llama3.1:8b",
+        ollama_url="http://localhost:11434",
+        http_client=client,
+    ))
+
+    assert len(result["triples"]) == 1
+    assert result["triples"][0]["predicate"] == "works_at"
+
+
+def test_lift_edu_drops_empty_fields():
+    """Triples missing subject / predicate / object are silently dropped."""
+    client = _FakeOllamaClient({
+        "event_type": "misc",
+        "triples": [
+            {"subject": "", "predicate": "works_at", "object": "stripe"},
+            {"subject": "alice", "predicate": "", "object": "stripe"},
+            {"subject": "alice", "predicate": "works_at", "object": ""},
+            {"subject": "alice", "predicate": "works_at", "object": "stripe"},
+        ],
+    })
+
+    result = _run(lift_edu_to_triples(
+        "x", model="m", ollama_url="http://x", http_client=client,
+    ))
+    assert len(result["triples"]) == 1
+
+
+class _BrokenClient:
+    async def post(self, url, json=None, timeout=None):
+        import httpx
+        raise httpx.HTTPError("simulated transport failure")
+
+
+def test_lift_edu_returns_noop_on_transport_error():
+    result = _run(lift_edu_to_triples(
+        "x", model="m", ollama_url="http://x", http_client=_BrokenClient(),
+    ))
+    assert result == {"event_type": "none", "triples": []}
+
+
+class _BadJsonClient:
+    async def post(self, url, json=None, timeout=None):
+        return _FakeResponse({"message": {"content": "not json at all"}})
+
+
+def test_lift_edu_returns_noop_on_bad_json():
+    result = _run(lift_edu_to_triples(
+        "x", model="m", ollama_url="http://x", http_client=_BadJsonClient(),
+    ))
+    assert result == {"event_type": "none", "triples": []}
+
+
+# ---------------------------------------------------------------------------
+# Batch lift
+# ---------------------------------------------------------------------------
+
+
+def test_lift_edus_preserves_source_metadata():
+    """source_edu + source_turn_ids must travel with each lift result."""
+    client = _FakeOllamaClient({
+        "event_type": "travel",
+        "triples": [
+            {"subject": "bob", "predicate": "moved_to", "object": "tokyo"},
+        ],
+    })
+
+    edus = [
+        {"edu_text": "Bob moved to Tokyo.", "source_turn_ids": [2, 4]},
+        {"edu_text": "Bob attended the conference.", "source_turn_ids": [6]},
+    ]
+    results = _run(lift_edus_to_events(
+        edus, model="m", ollama_url="http://x", http_client=client,
+    ))
+
+    assert len(results) == 2
+    assert results[0]["source_edu"] == "Bob moved to Tokyo."
+    assert results[0]["source_turn_ids"] == [2, 4]
+    assert results[1]["source_edu"] == "Bob attended the conference."
+    assert results[1]["source_turn_ids"] == [6]
+
+
+def test_lift_edus_skips_empty_edus():
+    """EDU entries with empty edu_text are skipped (no LLM call made)."""
+    client = _FakeOllamaClient({
+        "event_type": "x",
+        "triples": [{"subject": "a", "predicate": "works_at", "object": "b"}],
+    })
+    edus = [
+        {"edu_text": "", "source_turn_ids": [1]},
+        {"edu_text": "   ", "source_turn_ids": [2]},
+        {"edu_text": "Real EDU.", "source_turn_ids": [3]},
+    ]
+    results = _run(lift_edus_to_events(
+        edus, model="m", ollama_url="http://x", http_client=client,
+    ))
+    assert len(results) == 1
+    assert results[0]["source_edu"] == "Real EDU."
+
+
+# ---------------------------------------------------------------------------
+# KG round-trip with strict_vocab
+# ---------------------------------------------------------------------------
+
+
+def test_lifted_triples_round_trip_through_strict_kg(tmp_path):
+    """Pass-2 output → kg.add_triple(strict_vocab=True) succeeds for all triples."""
+    client = _FakeOllamaClient({
+        "event_type": "employment",
+        "triples": [
+            {"subject": "alice", "predicate": "works_at", "object": "stripe"},
+            {"subject": "alice", "predicate": "lives_in", "object": "san francisco"},
+            {"subject": "alice", "predicate": "founded", "object": "side-project"},
+        ],
+    })
+
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+        try:
+            lift = await lift_edu_to_triples(
+                "Alice works at Stripe and founded a side project in SF.",
+                model="m", ollama_url="http://x", http_client=client,
+            )
+            # All triples should land via strict_vocab without raising —
+            # they came from a lifter that already filtered against the
+            # vocab, so the strict KG write is a no-op safety check.
+            for t in lift["triples"]:
+                await kg.add_triple(
+                    subject=t["subject"], predicate=t["predicate"],
+                    obj=t["object"], strict_vocab=True,
+                    source="test:pass2",
+                )
+            return await kg.stats()
+        finally:
+            await kg.close()
+
+    stats = _run(go())
+    assert stats["active_triples"] == 3


### PR DESCRIPTION
## Summary

Task #57 — the last piece of the gbrain-inspired memory architecture chain. Pass-1 (\`extract_session_edus\`) already gave us atomic, normalised-entity, turn-attributed EDUs that win the SH-specialist retrieval slot. Pass-2 lifts each EDU into typed (subject, predicate, object) triples whose predicate must be in \`taosmd.predicate_vocab.ALLOWED_PREDICATES\` (the closed vocab from PR #76).

End-to-end pipeline now:
1. Conversation session → \`extract_session_edus\` → atomic propositions
2. Each EDU → \`lift_edu_to_triples\` → typed structured triples
3. Triples → \`kg.add_triple(strict_vocab=True)\` → queryable KG

## What lands

- **\`taosmd/emem_event_lift.py\`** (199 lines): \`lift_edu_to_triples(edu_text, ...) -> {event_type, triples}\` + \`lift_edus_to_events(edus, ...) -> [...]\`. One Ollama \`/api/chat\` call per EDU, format=json, system prompt spells out every allowed predicate inline.
- **Runner integration** (\`benchmarks/locomo_runner.py\`): \`--emem-edu-pass2-events\` flag + \`--emem-edu-pass2-model\` override. Opens a per-conv \`TemporalKnowledgeGraph\` in the tempdir alongside vmem; \`_ingest_conversation_edus\` writes pass-2 triples to it with \`strict_vocab=True\`.
- **\`tests/test_emem_event_lift.py\`** (9 new tests): happy-path lift, client-side predicate filtering, synonym normalisation, empty-field dropping, transport/JSON failure handling, batch source-metadata preservation, KG strict_vocab round-trip. **All 172 total tests pass.**

## Two safety layers on predicates

1. **System prompt** lists every allowed predicate inline so the model picks from a fixed set (~250 tokens).
2. **Client-side filter** in \`lift_edu_to_triples\` normalises via \`predicate_vocab.normalise\` (resolves synonyms like \`employed_by\` → \`works_at\`) then drops anything still outside \`ALLOWED_PREDICATES\`. Belt-and-braces — small models invent occasionally.

Plus \`kg.add_triple(strict_vocab=True)\` would catch any drift past those two. ValueError from the strict write is logged + skipped rather than failing the bench.

## Why opt-in (default OFF)

- LoCoMo measures retrieval, not KG queries. Pass-1 alone is the validated production recipe (+0.07/+0.10 SH g4:e2b/q3:4b at full 1540, PR #74). Pass-2 doesn't move LoCoMo numbers; it populates the structured KG side that LoCoMo doesn't measure but production agents query.
- One extra LLM call per EDU is real cost (~5-15 s on llama3.1:8b). Default off; explicit opt-in via \`--emem-edu-pass2-events\`.

## What this enables (not in this PR)

- LongMemEval-KU validation: pass-2 should improve knowledge-update category since contradictions become resolvable via the KG's contradiction-detection + pending-decisions queue (PR #71). Future bench.
- Production agents with structured KG queries on user-supplied facts — same conversation data, two access patterns (retrieval + structured).

## Test plan

- [x] AST clean on both new files + the runner change
- [x] \`--help\` shows the new flags
- [x] All 172 tests pass (9 new + 163 existing)
- [x] Mocked Ollama tests exercise: happy-path, drop-unknown-predicate, synonym-normalisation, empty-fields, transport-error, bad-JSON, batch metadata preservation, KG strict_vocab round-trip
- [ ] Operator validation on a real LoCoMo run with \`--emem-edu --emem-edu-pass2-events\` — confirm pass-2 emits triples + populates the per-conv KG without ValueError storms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional knowledge-graph population feature that converts conversation data into typed relationship triples
  * Added CLI configuration options to enable and configure knowledge-graph extraction parameters

* **Tests**
  * Added comprehensive test suite for knowledge-graph event extraction functionality, including error handling and data validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->