### PR TITLE
feat(loaders): typed ingestor package (cognee-style LoaderInterface)

### DIFF
--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -18,6 +18,7 @@ from .reflect import InsightStore
 from .pending_decisions import PendingDecisionsStore
 from . import predicate_vocab
 from . import emem_event_lift
+from . import loaders
 from .session_catalog import SessionCatalog
 from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve

--- a/taosmd/loaders/__init__.py
+++ b/taosmd/loaders/__init__.py
@@ -1,0 +1,62 @@
+"""Typed ingestors for taOSmd.
+
+Cognee-style ``LoaderInterface`` (one file in, one typed ``Blob`` out) +
+memobase-style discriminated-union envelopes (``ChatBlob``,
+``TranscriptBlob``, ``EmailBlob``, ``DocBlob``) so downstream extractors
+see structured data rather than a string blob.
+
+The registry picks a loader by file extension + MIME type; concrete
+loaders convert their source format into the canonical typed envelope.
+Existing string-based ingest paths (``process_conversation_turn`` etc.)
+keep working unchanged — this package adds an alternative typed path
+for callers that have format-specific data on disk.
+
+Usage::
+
+    from taosmd.loaders import pick_loader
+
+    blob = await pick_loader("meeting.transcript.json").load(
+        "meeting.transcript.json"
+    )
+    # blob is a TranscriptBlob with .transcripts: list[TranscriptStamp]
+    for stamp in blob.transcripts:
+        print(stamp.speaker, stamp.start_timestamp_in_seconds, stamp.text)
+
+See ``reference_memory_systems_survey.md`` for the design rationale.
+"""
+
+from .blob import (
+    Blob,
+    BlobType,
+    ChatBlob,
+    ChatMessage,
+    DocBlob,
+    EmailBlob,
+    TranscriptBlob,
+    TranscriptStamp,
+)
+from .interface import LoaderInterface
+from .registry import REGISTRY, pick_loader, register_loader
+from .chat_loader import ChatLoader
+from .doc_loader import DocLoader
+from .email_loader import EmailLoader
+from .transcript_loader import TranscriptLoader
+
+__all__ = [
+    "Blob",
+    "BlobType",
+    "ChatBlob",
+    "ChatMessage",
+    "DocBlob",
+    "EmailBlob",
+    "TranscriptBlob",
+    "TranscriptStamp",
+    "LoaderInterface",
+    "ChatLoader",
+    "DocLoader",
+    "EmailLoader",
+    "TranscriptLoader",
+    "REGISTRY",
+    "pick_loader",
+    "register_loader",
+]

--- a/taosmd/loaders/blob.py
+++ b/taosmd/loaders/blob.py
@@ -1,0 +1,118 @@
+"""Typed blob envelopes — what loaders produce, what extractors consume.
+
+The discriminated union (``Blob.kind`` is one of ``BlobType`` enum values)
+lets downstream consumers ``match`` on type rather than inspecting field
+shapes. Inspired by memobase's blob.py (``ChatBlob``, ``TranscriptBlob``,
+etc.) but pared down to what we actually need at the taOSmd tier.
+
+The envelopes are intentionally NOT pydantic — keeping them stdlib-only
+keeps the loader package importable without pulling pydantic into
+non-LLM code paths (matters for Pi tier where the dep matrix is tight).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class BlobType(str, Enum):
+    """The 4 first-class data shapes taOSmd's loaders produce.
+
+    More can be added (image, code, calendar-event) when we have a
+    concrete consumer; resist letting this grow speculatively.
+    """
+    CHAT = "chat"
+    TRANSCRIPT = "transcript"
+    EMAIL = "email"
+    DOC = "doc"
+
+
+@dataclass
+class ChatMessage:
+    """One turn in a chat-shaped exchange.
+
+    ``alias`` is the speaker-display-name field memobase uses to support
+    multi-party threading (when "User" isn't always the same person).
+    Empty string when irrelevant.
+    """
+    role: str                 # "user" / "assistant" / "system" / custom
+    content: str
+    alias: str = ""
+    timestamp: float = 0.0    # POSIX seconds; 0.0 when unknown
+
+
+@dataclass
+class TranscriptStamp:
+    """One stamp in a transcript-shaped recording.
+
+    ``start_timestamp_in_seconds`` is offset from start of recording, not
+    wall clock — matches what Whisper / VTT / SRT all give back. ``speaker``
+    is whichever label the diarisation produced (often "speaker_0" /
+    "speaker_1"); empty when undiarised.
+    """
+    text: str
+    start_timestamp_in_seconds: float = 0.0
+    speaker: str = ""
+
+
+@dataclass
+class Blob:
+    """Base envelope. Every typed blob inherits this + sets ``kind``.
+
+    ``source_path`` is the filesystem path the loader read from (for
+    provenance). ``raw_text`` is a flattened-text view of the blob —
+    handy fallback for legacy ingest paths that want a single string.
+    Empty when expensive to compute; consumers should rely on the typed
+    fields when present.
+    """
+    kind: BlobType
+    source_path: str = ""
+    raw_text: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ChatBlob(Blob):
+    """Chat-shaped blob: a sequence of role+content turns."""
+    kind: BlobType = BlobType.CHAT
+    messages: list[ChatMessage] = field(default_factory=list)
+
+
+@dataclass
+class TranscriptBlob(Blob):
+    """Transcript-shaped blob: speaker-stamped text segments + offsets."""
+    kind: BlobType = BlobType.TRANSCRIPT
+    transcripts: list[TranscriptStamp] = field(default_factory=list)
+
+
+@dataclass
+class EmailBlob(Blob):
+    """Email-shaped blob: structured headers + body + threading id.
+
+    ``in_reply_to`` is the RFC 5322 Message-Id we're replying to; empty
+    when the email starts a new thread. ``message_id`` is this email's
+    own id, used by downstream threading.
+    """
+    kind: BlobType = BlobType.EMAIL
+    sender: str = ""
+    recipients: list[str] = field(default_factory=list)
+    subject: str = ""
+    body: str = ""
+    sent_at: float = 0.0          # POSIX seconds; 0.0 when unknown
+    message_id: str = ""
+    in_reply_to: str = ""
+
+
+@dataclass
+class DocBlob(Blob):
+    """Plain doc-shaped blob: text or markdown content.
+
+    The catch-all type. Use this when no specialised loader handles a
+    file's format; the extraction step then operates on ``raw_text`` /
+    ``content`` directly without typed structure to lean on.
+    """
+    kind: BlobType = BlobType.DOC
+    title: str = ""
+    content: str = ""

--- a/taosmd/loaders/chat_loader.py
+++ b/taosmd/loaders/chat_loader.py
@@ -1,0 +1,79 @@
+"""ChatLoader — reads chat-shaped JSON files into a ``ChatBlob``.
+
+Accepted shapes:
+
+  Shape A — list of message dicts (matches OpenAI / Anthropic message
+  arrays and most chat-export tools):
+    [
+      {"role": "user", "content": "hi", "timestamp": 1716000000.0},
+      {"role": "assistant", "content": "hello", "alias": "Alex"}
+    ]
+
+  Shape B — object with a ``messages`` key (matches several agent
+  frameworks that include extra session metadata at the top level):
+    {"messages": [...], "agent": "alex", "session_id": "..."}
+
+  Each message can include any of ``role``, ``content``, ``alias``,
+  ``timestamp`` — missing fields default to ``""`` / ``0.0``.
+
+Anything else falls through to ``DocLoader`` via the registry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import ClassVar
+
+from .blob import ChatBlob, ChatMessage
+from .interface import LoaderInterface
+
+
+class ChatLoader(LoaderInterface):
+    loader_name: ClassVar[str] = "chat"
+    supported_extensions: ClassVar[tuple[str, ...]] = ("chat.json", "messages.json")
+    supported_mime_types: ClassVar[tuple[str, ...]] = ("application/x-chat+json",)
+
+    @classmethod
+    def can_handle(cls, extension: str = "", mime_type: str = "") -> bool:
+        """Same as base + match the multi-suffix forms ``*.chat.json`` /
+        ``*.messages.json`` even when the path's ``Path.suffix`` only
+        captures ``.json``."""
+        if super().can_handle(extension=extension, mime_type=mime_type):
+            return True
+        ext = extension.lower().lstrip(".") if extension else ""
+        return ext.endswith("chat.json") or ext.endswith("messages.json")
+
+    async def load(self, file_path: str | Path, **kwargs) -> ChatBlob:
+        path = Path(file_path)
+        with open(path) as f:
+            data = json.load(f)
+        if isinstance(data, dict) and "messages" in data:
+            raw_messages = data["messages"]
+        elif isinstance(data, list):
+            raw_messages = data
+        else:
+            raise ValueError(
+                f"ChatLoader: {path} doesn't match chat shape "
+                "(expected list of messages or {messages: [...]})"
+            )
+
+        messages: list[ChatMessage] = []
+        for m in raw_messages:
+            if not isinstance(m, dict):
+                continue
+            messages.append(ChatMessage(
+                role=str(m.get("role", "")),
+                content=str(m.get("content", "")),
+                alias=str(m.get("alias", "")),
+                timestamp=float(m.get("timestamp", 0.0) or 0.0),
+            ))
+
+        raw_text = "\n".join(
+            f"[{m.alias or m.role}] {m.content}" for m in messages
+        )
+        return ChatBlob(
+            source_path=str(path),
+            raw_text=raw_text,
+            messages=messages,
+        )

--- a/taosmd/loaders/doc_loader.py
+++ b/taosmd/loaders/doc_loader.py
@@ -1,0 +1,43 @@
+"""DocLoader — catch-all for plain text + markdown into a ``DocBlob``.
+
+This is the loader the registry picks when nothing more specific
+claims a file. It does no parsing beyond extracting an optional title
+from the first markdown ``#`` heading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from .blob import DocBlob
+from .interface import LoaderInterface
+
+
+class DocLoader(LoaderInterface):
+    loader_name: ClassVar[str] = "doc"
+    supported_extensions: ClassVar[tuple[str, ...]] = (
+        "txt", "md", "markdown", "rst",
+    )
+    supported_mime_types: ClassVar[tuple[str, ...]] = (
+        "text/plain", "text/markdown",
+    )
+
+    async def load(self, file_path: str | Path, **kwargs) -> DocBlob:
+        path = Path(file_path)
+        with open(path, encoding="utf-8", errors="replace") as f:
+            content = f.read()
+
+        title = ""
+        for line in content.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("# "):
+                title = stripped[2:].strip()
+                break
+
+        return DocBlob(
+            source_path=str(path),
+            raw_text=content,
+            title=title,
+            content=content,
+        )

--- a/taosmd/loaders/email_loader.py
+++ b/taosmd/loaders/email_loader.py
@@ -1,0 +1,88 @@
+"""EmailLoader — reads RFC 5322 .eml into an ``EmailBlob``.
+
+Uses the stdlib ``email`` module so we don't pull a parser dep. Handles
+both ``.eml`` and ``.mbox`` files; for mbox, the first message in the
+file is used (multi-message mbox would need a different envelope — a
+``MailboxBlob`` containing many ``EmailBlob``s; defer until we have a
+real caller).
+
+Threading via ``Message-Id`` + ``In-Reply-To`` headers — both surfaced
+on the blob so downstream extractors can rebuild thread trees later.
+"""
+
+from __future__ import annotations
+
+import email
+from email import policy
+from email.utils import getaddresses, parsedate_to_datetime
+from pathlib import Path
+from typing import ClassVar
+
+from .blob import EmailBlob
+from .interface import LoaderInterface
+
+
+class EmailLoader(LoaderInterface):
+    loader_name: ClassVar[str] = "email"
+    supported_extensions: ClassVar[tuple[str, ...]] = ("eml", "mbox")
+    supported_mime_types: ClassVar[tuple[str, ...]] = (
+        "message/rfc822", "application/mbox",
+    )
+
+    async def load(self, file_path: str | Path, **kwargs) -> EmailBlob:
+        path = Path(file_path)
+        with open(path, "rb") as f:
+            msg = email.message_from_binary_file(f, policy=policy.default)
+
+        # body — prefer text/plain part, fall back to flat string.
+        if msg.is_multipart():
+            body = ""
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    try:
+                        body = part.get_content().strip()
+                    except (AttributeError, LookupError):
+                        body = ""
+                    if body:
+                        break
+        else:
+            try:
+                body = msg.get_content().strip()
+            except (AttributeError, LookupError):
+                body = ""
+
+        recipients = [
+            addr for _, addr in getaddresses(msg.get_all("To", []))
+            if addr
+        ]
+        sent_at = 0.0
+        date_hdr = msg.get("Date", "")
+        if date_hdr:
+            try:
+                sent_at = parsedate_to_datetime(date_hdr).timestamp()
+            except (TypeError, ValueError):
+                sent_at = 0.0
+
+        sender_raw = msg.get("From", "")
+        sender_addrs = getaddresses([sender_raw]) if sender_raw else []
+        sender = sender_addrs[0][1] if sender_addrs else sender_raw
+
+        subject = msg.get("Subject", "")
+        message_id = (msg.get("Message-Id", "") or "").strip("<>")
+        in_reply_to = (msg.get("In-Reply-To", "") or "").strip("<>")
+
+        raw_text = (
+            f"From: {sender}\nTo: {', '.join(recipients)}\n"
+            f"Subject: {subject}\n\n{body}"
+        )
+        return EmailBlob(
+            source_path=str(path),
+            raw_text=raw_text,
+            sender=sender,
+            recipients=recipients,
+            subject=subject,
+            body=body,
+            sent_at=sent_at,
+            message_id=message_id,
+            in_reply_to=in_reply_to,
+        )

--- a/taosmd/loaders/interface.py
+++ b/taosmd/loaders/interface.py
@@ -1,0 +1,59 @@
+"""LoaderInterface — the ABC every concrete loader implements.
+
+Lifted from cognee's LoaderInterface (cognee/infrastructure/loaders/
+LoaderInterface.py): each loader declares which extensions and MIME
+types it can handle, the registry picks one for a given path, and the
+loader's ``load()`` returns a typed ``Blob``.
+
+The signature differs slightly from cognee's: cognee returns ``str``,
+we return a ``Blob`` subclass so downstream consumers get the typed
+fields. The cost is each loader picks its blob type; the win is no
+second parsing pass downstream.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import ClassVar
+
+from .blob import Blob
+
+
+class LoaderInterface(ABC):
+    """Cognee-style ABC for typed file ingestors.
+
+    Subclasses set the three ClassVars and implement ``load``. The
+    registry uses ``can_handle`` to pick a loader for a given path.
+    """
+
+    loader_name: ClassVar[str] = ""
+    supported_extensions: ClassVar[tuple[str, ...]] = ()
+    supported_mime_types: ClassVar[tuple[str, ...]] = ()
+
+    @classmethod
+    def can_handle(cls, extension: str = "", mime_type: str = "") -> bool:
+        """Return True when this loader claims a file with the given
+        extension and / or MIME type. Extension comparison is case-
+        insensitive and the leading dot is optional. Either argument can
+        be empty — the registry passes whichever it could determine.
+        """
+        ext = extension.lower().lstrip(".") if extension else ""
+        mt = mime_type.lower() if mime_type else ""
+        if ext and any(ext == s.lower().lstrip(".") for s in cls.supported_extensions):
+            return True
+        if mt and any(mt == s.lower() for s in cls.supported_mime_types):
+            return True
+        return False
+
+    @abstractmethod
+    async def load(self, file_path: str | Path, **kwargs) -> Blob:
+        """Read the file at ``file_path`` and return a typed ``Blob``.
+
+        Implementations should set ``Blob.source_path`` to a string of
+        ``file_path`` and populate ``raw_text`` opportunistically — when
+        a string view is cheap to derive, it lets legacy ingest paths
+        keep working. When it isn't cheap, leave it empty and rely on
+        the typed fields.
+        """
+        raise NotImplementedError

--- a/taosmd/loaders/registry.py
+++ b/taosmd/loaders/registry.py
@@ -1,0 +1,86 @@
+"""Loader registry — picks the right loader for a path.
+
+Iteration order matters: more-specific loaders go first so that
+``ChatLoader`` (which claims ``*.chat.json``) wins over a hypothetical
+generic JSON loader. ``DocLoader`` is last as the catch-all for plain
+text-like content.
+
+To add a new loader, append it to ``REGISTRY`` via ``register_loader``
+or insert at a specific index when ordering matters.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+from .chat_loader import ChatLoader
+from .doc_loader import DocLoader
+from .email_loader import EmailLoader
+from .interface import LoaderInterface
+from .transcript_loader import TranscriptLoader
+
+
+# Order: specific → generic. The first loader whose can_handle returns
+# True wins. DocLoader stays last; it's the catch-all.
+REGISTRY: list[type[LoaderInterface]] = [
+    ChatLoader,
+    TranscriptLoader,
+    EmailLoader,
+    DocLoader,
+]
+
+
+def register_loader(
+    loader_cls: type[LoaderInterface],
+    *,
+    index: int | None = None,
+) -> None:
+    """Add a loader class to the registry.
+
+    ``index=None`` (default) appends BEFORE the catch-all ``DocLoader``
+    so generic loaders don't shadow specific ones. Pass an explicit
+    index to override ordering.
+    """
+    if index is None:
+        # Insert before DocLoader (which is last as the catch-all).
+        if REGISTRY and REGISTRY[-1] is DocLoader:
+            REGISTRY.insert(len(REGISTRY) - 1, loader_cls)
+        else:
+            REGISTRY.append(loader_cls)
+    else:
+        REGISTRY.insert(index, loader_cls)
+
+
+def _path_to_extension(path: str | Path) -> str:
+    """Return the lowercased extension, including multi-suffix forms.
+
+    ``meeting.transcript.json`` → ``transcript.json`` (not just ``json``)
+    so loaders that claim a multi-suffix shape get a chance.
+    """
+    p = Path(path)
+    name = p.name.lower()
+    if "." not in name:
+        return ""
+    # Try two-suffix form first ("transcript.json"), then one-suffix.
+    parts = name.split(".")
+    if len(parts) >= 3:
+        return ".".join(parts[-2:])
+    return parts[-1]
+
+
+def pick_loader(file_path: str | Path) -> LoaderInterface:
+    """Return an instance of the first registered loader that claims
+    the given path. Falls back to ``DocLoader`` (the catch-all).
+    """
+    p = Path(file_path)
+    ext = _path_to_extension(p)
+    mime_type, _ = mimetypes.guess_type(str(p))
+    mime_type = mime_type or ""
+
+    for loader_cls in REGISTRY:
+        if loader_cls.can_handle(extension=ext, mime_type=mime_type):
+            return loader_cls()
+    # Belt-and-braces — REGISTRY ends with DocLoader so this is
+    # unreachable, but defend against someone removing the catch-all.
+    return DocLoader()

--- a/taosmd/loaders/transcript_loader.py
+++ b/taosmd/loaders/transcript_loader.py
@@ -1,0 +1,97 @@
+"""TranscriptLoader — reads transcript JSON into a ``TranscriptBlob``.
+
+Accepted shapes:
+
+  Shape A — Whisper-style segments:
+    {"segments": [{"start": 0.0, "end": 4.2, "text": "Hello.", "speaker": "spk_0"}, ...]}
+
+  Shape B — already-canonical TranscriptStamp list:
+    {"transcripts": [{"start_timestamp_in_seconds": 0.0,
+                      "speaker": "spk_0", "text": "Hello."}, ...]}
+
+  Shape C — plain list of stamps (either of the above field names per row):
+    [{"start": 0.0, "speaker": "spk_0", "text": "Hello."}, ...]
+
+VTT / SRT parsing isn't here — those are separate enough to deserve
+their own loader if a user surfaces. For now, JSON only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+
+from .blob import TranscriptBlob, TranscriptStamp
+from .interface import LoaderInterface
+
+
+def _row_to_stamp(row: dict[str, Any]) -> TranscriptStamp | None:
+    text = (row.get("text") or "").strip()
+    if not text:
+        return None
+    start = row.get("start_timestamp_in_seconds", row.get("start", 0.0))
+    speaker = row.get("speaker", "")
+    return TranscriptStamp(
+        text=text,
+        start_timestamp_in_seconds=float(start or 0.0),
+        speaker=str(speaker or ""),
+    )
+
+
+class TranscriptLoader(LoaderInterface):
+    loader_name: ClassVar[str] = "transcript"
+    supported_extensions: ClassVar[tuple[str, ...]] = (
+        "transcript.json", "whisper.json",
+    )
+    supported_mime_types: ClassVar[tuple[str, ...]] = (
+        "application/x-transcript+json",
+    )
+
+    @classmethod
+    def can_handle(cls, extension: str = "", mime_type: str = "") -> bool:
+        if super().can_handle(extension=extension, mime_type=mime_type):
+            return True
+        ext = extension.lower().lstrip(".") if extension else ""
+        return ext.endswith("transcript.json") or ext.endswith("whisper.json")
+
+    async def load(self, file_path: str | Path, **kwargs) -> TranscriptBlob:
+        path = Path(file_path)
+        with open(path) as f:
+            data = json.load(f)
+
+        rows: list[dict] = []
+        if isinstance(data, dict):
+            if "transcripts" in data and isinstance(data["transcripts"], list):
+                rows = data["transcripts"]
+            elif "segments" in data and isinstance(data["segments"], list):
+                rows = data["segments"]
+            else:
+                raise ValueError(
+                    f"TranscriptLoader: {path} doesn't match expected shape "
+                    "(no 'transcripts' or 'segments' key)"
+                )
+        elif isinstance(data, list):
+            rows = data
+        else:
+            raise ValueError(
+                f"TranscriptLoader: {path} root is not a list or object"
+            )
+
+        stamps: list[TranscriptStamp] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            stamp = _row_to_stamp(row)
+            if stamp is not None:
+                stamps.append(stamp)
+
+        raw_text = "\n".join(
+            f"[{s.speaker or '?'} @ {s.start_timestamp_in_seconds:.1f}s] {s.text}"
+            for s in stamps
+        )
+        return TranscriptBlob(
+            source_path=str(path),
+            raw_text=raw_text,
+            transcripts=stamps,
+        )

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,303 @@
+"""Tests for taosmd.loaders — typed ingestors per data type."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from taosmd.loaders import (
+    Blob,
+    BlobType,
+    ChatBlob,
+    ChatLoader,
+    DocBlob,
+    DocLoader,
+    EmailBlob,
+    EmailLoader,
+    TranscriptBlob,
+    TranscriptLoader,
+    pick_loader,
+    register_loader,
+    REGISTRY,
+)
+from taosmd.loaders.interface import LoaderInterface
+from taosmd.loaders.registry import _path_to_extension
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Path-extension helper
+# ---------------------------------------------------------------------------
+
+
+def test_path_to_extension_handles_multi_suffix():
+    assert _path_to_extension("meeting.transcript.json") == "transcript.json"
+    assert _path_to_extension("chat.json") == "json"
+    assert _path_to_extension("notes.md") == "md"
+    assert _path_to_extension("README") == ""
+    assert _path_to_extension("a.b.c.d") == "c.d"
+
+
+# ---------------------------------------------------------------------------
+# ChatLoader
+# ---------------------------------------------------------------------------
+
+
+def test_chat_loader_handles_list_shape(tmp_path):
+    src = tmp_path / "session.chat.json"
+    src.write_text(json.dumps([
+        {"role": "user", "content": "hi", "timestamp": 1716000000.0},
+        {"role": "assistant", "content": "hello", "alias": "Alex"},
+    ]))
+    blob = _run(ChatLoader().load(src))
+
+    assert isinstance(blob, ChatBlob)
+    assert blob.kind == BlobType.CHAT
+    assert blob.source_path == str(src)
+    assert len(blob.messages) == 2
+    assert blob.messages[0].role == "user"
+    assert blob.messages[0].timestamp == 1716000000.0
+    assert blob.messages[1].alias == "Alex"
+    assert "[user] hi" in blob.raw_text
+    assert "[Alex] hello" in blob.raw_text
+
+
+def test_chat_loader_handles_object_shape(tmp_path):
+    src = tmp_path / "wrapped.chat.json"
+    src.write_text(json.dumps({
+        "messages": [{"role": "user", "content": "hi"}],
+        "agent": "alex",
+    }))
+    blob = _run(ChatLoader().load(src))
+    assert len(blob.messages) == 1
+    assert blob.messages[0].content == "hi"
+
+
+def test_chat_loader_rejects_unexpected_shape(tmp_path):
+    src = tmp_path / "bad.chat.json"
+    src.write_text(json.dumps({"not_messages": "wrong"}))
+    with pytest.raises(ValueError, match="chat shape"):
+        _run(ChatLoader().load(src))
+
+
+def test_chat_loader_skips_non_dict_rows(tmp_path):
+    src = tmp_path / "mixed.chat.json"
+    src.write_text(json.dumps([
+        {"role": "user", "content": "hi"},
+        "this is not a message",
+        {"role": "assistant", "content": "ok"},
+    ]))
+    blob = _run(ChatLoader().load(src))
+    assert len(blob.messages) == 2
+
+
+# ---------------------------------------------------------------------------
+# TranscriptLoader
+# ---------------------------------------------------------------------------
+
+
+def test_transcript_loader_whisper_segments(tmp_path):
+    src = tmp_path / "meeting.transcript.json"
+    src.write_text(json.dumps({
+        "segments": [
+            {"start": 0.0, "end": 4.2, "text": "Hello.", "speaker": "spk_0"},
+            {"start": 4.2, "end": 7.0, "text": "Hi there.", "speaker": "spk_1"},
+        ],
+    }))
+    blob = _run(TranscriptLoader().load(src))
+
+    assert isinstance(blob, TranscriptBlob)
+    assert blob.kind == BlobType.TRANSCRIPT
+    assert len(blob.transcripts) == 2
+    assert blob.transcripts[0].speaker == "spk_0"
+    assert blob.transcripts[0].start_timestamp_in_seconds == 0.0
+    assert blob.transcripts[1].text == "Hi there."
+
+
+def test_transcript_loader_canonical_shape(tmp_path):
+    src = tmp_path / "canonical.transcript.json"
+    src.write_text(json.dumps({
+        "transcripts": [
+            {"start_timestamp_in_seconds": 0.5,
+             "speaker": "alice", "text": "Welcome."}
+        ],
+    }))
+    blob = _run(TranscriptLoader().load(src))
+    assert blob.transcripts[0].speaker == "alice"
+    assert blob.transcripts[0].start_timestamp_in_seconds == 0.5
+
+
+def test_transcript_loader_plain_list(tmp_path):
+    src = tmp_path / "list.transcript.json"
+    src.write_text(json.dumps([
+        {"start": 1.0, "speaker": "bob", "text": "Done."}
+    ]))
+    blob = _run(TranscriptLoader().load(src))
+    assert len(blob.transcripts) == 1
+    assert blob.transcripts[0].text == "Done."
+
+
+def test_transcript_loader_drops_empty_text(tmp_path):
+    src = tmp_path / "with_empty.transcript.json"
+    src.write_text(json.dumps({
+        "segments": [
+            {"start": 0.0, "text": "", "speaker": "spk_0"},
+            {"start": 1.0, "text": "Real.", "speaker": "spk_0"},
+            {"start": 2.0, "text": "   ", "speaker": "spk_0"},
+        ],
+    }))
+    blob = _run(TranscriptLoader().load(src))
+    assert len(blob.transcripts) == 1
+    assert blob.transcripts[0].text == "Real."
+
+
+# ---------------------------------------------------------------------------
+# EmailLoader
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_EML = b"""From: alice@example.com
+To: bob@example.com, carol@example.com
+Subject: Re: lunch plans
+Date: Thu, 30 May 2026 12:00:00 +0000
+Message-Id: <abc123@example.com>
+In-Reply-To: <xyz789@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Yes, 1pm sounds good. See you then.
+"""
+
+
+def test_email_loader_extracts_headers_and_body(tmp_path):
+    src = tmp_path / "msg.eml"
+    src.write_bytes(_SAMPLE_EML)
+    blob = _run(EmailLoader().load(src))
+
+    assert isinstance(blob, EmailBlob)
+    assert blob.kind == BlobType.EMAIL
+    assert blob.sender == "alice@example.com"
+    assert "bob@example.com" in blob.recipients
+    assert "carol@example.com" in blob.recipients
+    assert blob.subject == "Re: lunch plans"
+    assert "Yes, 1pm sounds good" in blob.body
+    assert blob.message_id == "abc123@example.com"
+    assert blob.in_reply_to == "xyz789@example.com"
+    assert blob.sent_at > 0  # Date parsed successfully
+
+
+def test_email_loader_handles_missing_threading_headers(tmp_path):
+    src = tmp_path / "fresh.eml"
+    src.write_bytes(
+        b"From: alice@example.com\nTo: bob@example.com\n"
+        b"Subject: Hi\n\nHello.\n"
+    )
+    blob = _run(EmailLoader().load(src))
+    assert blob.message_id == ""
+    assert blob.in_reply_to == ""
+    assert blob.sent_at == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DocLoader
+# ---------------------------------------------------------------------------
+
+
+def test_doc_loader_plain_text(tmp_path):
+    src = tmp_path / "notes.txt"
+    src.write_text("Just some text.\nMore on the next line.")
+    blob = _run(DocLoader().load(src))
+
+    assert isinstance(blob, DocBlob)
+    assert blob.kind == BlobType.DOC
+    assert blob.content == "Just some text.\nMore on the next line."
+    assert blob.title == ""
+
+
+def test_doc_loader_extracts_markdown_title(tmp_path):
+    src = tmp_path / "readme.md"
+    src.write_text("# Project taOSmd\n\nSome description.")
+    blob = _run(DocLoader().load(src))
+    assert blob.title == "Project taOSmd"
+    assert "Some description." in blob.content
+
+
+# ---------------------------------------------------------------------------
+# Registry / pick_loader
+# ---------------------------------------------------------------------------
+
+
+def test_pick_loader_chat(tmp_path):
+    p = tmp_path / "x.chat.json"
+    p.write_text("[]")
+    loader = pick_loader(p)
+    assert isinstance(loader, ChatLoader)
+
+
+def test_pick_loader_transcript(tmp_path):
+    p = tmp_path / "x.transcript.json"
+    p.write_text("[]")
+    loader = pick_loader(p)
+    assert isinstance(loader, TranscriptLoader)
+
+
+def test_pick_loader_email(tmp_path):
+    p = tmp_path / "x.eml"
+    p.write_bytes(b"From: a@b\nSubject: t\n\n")
+    loader = pick_loader(p)
+    assert isinstance(loader, EmailLoader)
+
+
+def test_pick_loader_doc_fallback_for_md(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("# h")
+    loader = pick_loader(p)
+    assert isinstance(loader, DocLoader)
+
+
+def test_pick_loader_doc_fallback_for_unknown(tmp_path):
+    p = tmp_path / "weird.frobnicated"
+    p.write_text("anything")
+    loader = pick_loader(p)
+    # No specialised loader claims .frobnicated; catch-all wins.
+    assert isinstance(loader, DocLoader)
+
+
+def test_register_loader_inserts_before_doc():
+    class _StubLoader(LoaderInterface):
+        loader_name = "stub"
+        supported_extensions = ("stub",)
+        supported_mime_types = ()
+        async def load(self, file_path, **kwargs):
+            return DocBlob(source_path=str(file_path), content="")
+
+    before = list(REGISTRY)
+    try:
+        register_loader(_StubLoader)
+        assert _StubLoader in REGISTRY
+        assert REGISTRY.index(_StubLoader) < REGISTRY.index(DocLoader)
+    finally:
+        REGISTRY[:] = before
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: pick + load
+# ---------------------------------------------------------------------------
+
+
+def test_pick_and_load_e2e(tmp_path):
+    """The high-level API a caller actually uses."""
+    src = tmp_path / "session.chat.json"
+    src.write_text(json.dumps([{"role": "user", "content": "Hi."}]))
+
+    loader = pick_loader(src)
+    blob = _run(loader.load(src))
+
+    assert isinstance(blob, ChatBlob)
+    assert blob.messages[0].content == "Hi."


### PR DESCRIPTION
## Summary

Closes task #56 — the last pending architectural task from the May 10 survey of memory-system competitor patterns. Lifts cognee's \`LoaderInterface\` ABC + memobase's discriminated-union envelope into taosmd as a typed-ingestor package.

## What lands

\`taosmd/loaders/\` — 9 modules, 936 lines total:

- **\`interface.py\`** — \`LoaderInterface\` ABC with \`loader_name\`, \`supported_extensions\`, \`supported_mime_types\`, \`can_handle(extension, mime_type)\`, \`async load(file_path) -> Blob\`. Same shape as cognee's, but returns a typed \`Blob\` subclass instead of \`str\` so downstream consumers get structured fields.
- **\`blob.py\`** — typed envelopes (stdlib dataclasses, no pydantic so we don't pull a dep onto Pi-tier deployments):
  - \`Blob\` (base): \`kind: BlobType\`, \`source_path\`, \`raw_text\`, \`metadata\`
  - \`ChatBlob.messages: list[ChatMessage]\` — role/content/alias/timestamp per turn
  - \`TranscriptBlob.transcripts: list[TranscriptStamp]\` — text/speaker/start_timestamp_in_seconds (matches Whisper / VTT / SRT)
  - \`EmailBlob\` — sender, recipients, subject, body, sent_at, **message_id, in_reply_to** (so future threading work has what it needs)
  - \`DocBlob\` — title + content, catch-all for text/markdown
- **Concrete loaders** — \`chat_loader.py\`, \`transcript_loader.py\`, \`email_loader.py\` (RFC 5322 via stdlib \`email\`), \`doc_loader.py\`.
- **\`registry.py\`** — \`pick_loader(path)\` walks the registered loaders in order; first \`can_handle\` win returns. \`DocLoader\` last as catch-all. \`register_loader(cls)\` inserts new loaders before \`DocLoader\` by default so generic loaders don't shadow specific ones.

## What this changes (and doesn't)

**Does:** adds an alternative typed ingest path for callers with format-specific data on disk — meetings as Whisper transcripts, exported chat sessions, individual emails, plain markdown notes. Each comes back as a typed envelope so downstream extractors can lean on structured fields (speaker, timestamp, in_reply_to) instead of parsing a flattened string.

**Doesn't:** migrate any existing call site. \`process_conversation_turn\` and the string-based ingest paths keep working unchanged. Migration is a separate, smaller refactor once we have a real consumer driving the choice (an agent that wants to ingest a real Whisper transcript and exploit the per-speaker timestamps).

## Test plan

20 new tests covering every loader + the registry + an end-to-end pick+load:
- ChatLoader: list shape, object shape with messages key, rejection of unknown shape, skipping non-dict rows
- TranscriptLoader: Whisper segments, canonical TranscriptStamp list, plain list of stamps, empty-text drop
- EmailLoader: header + body + threading extraction (\`Message-Id\`, \`In-Reply-To\`, parsed \`Date\`), graceful handling when threading headers absent
- DocLoader: plain text, markdown title extraction from first \`# \` heading
- Registry: \`_path_to_extension\` multi-suffix support (\`meeting.transcript.json\` → \`transcript.json\`), \`pick_loader\` selects correct loader for each blob type, unknown extension falls back to \`DocLoader\`, \`register_loader\` inserts before catch-all
- End-to-end: \`pick_loader(path).load(path) -> ChatBlob\`

All 192 total tests pass (172 before + 20 new). No external deps added.

## Open follow-ups (NOT in this PR)

- Migrate \`process_conversation_turn\` to optionally accept a \`Blob\` instead of a string — lets agents that have a typed envelope pass it through without re-flattening.
- Add VTT / SRT subtitle parsers as TranscriptLoader variants once we have a caller with subtitle files.
- A \`MailboxBlob\` containing many \`EmailBlob\`s for true mbox support (current \`EmailLoader\` only handles the first message in a multi-message mbox).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loaders for chat, transcript, email, and document files with automatic format detection and routing
  * Standardized data extraction across multiple file types into typed structured formats

* **Tests**
  * Added comprehensive test suite covering all loader types and file format handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/taosmd/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->