### PR TITLE
feat(config): system-wide memory model (closes #81)

### DIFF
--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -53,6 +53,10 @@ from .agents import (
 )
 from . import prompts
 
+# Install-wide config — the memory/Librarian model is a global setting.
+from . import config
+from .config import get_memory_model, set_memory_model
+
 from importlib.resources import files
 
 
@@ -125,6 +129,9 @@ __all__ = [
     "is_task_enabled",
     "effective_fanout",
     "FANOUT_LEVELS",
+    # Global config — system-wide memory model
+    "get_memory_model",
+    "set_memory_model",
     # Librarian prompts
     "prompts",
 ]

--- a/taosmd/agents.py
+++ b/taosmd/agents.py
@@ -82,15 +82,25 @@ def _default_fanout() -> dict:
 
 
 def _default_librarian() -> dict:
+    # The memory/Librarian model used to live here as a per-agent "model"
+    # key; it is now a system-wide setting (see taosmd.config). Records that
+    # still carry a legacy "model" key get it stripped on read (see
+    # _strip_legacy_model), so it disappears on the next write.
     return {
         "enabled": True,
-        # Provider:model string (e.g. "ollama:qwen3:4b") or None to use the
-        # taosmd install default. Per-agent override lives here so a single
-        # install can run different models per agent.
-        "model": None,
         "tasks": {t: True for t in LIBRARIAN_TASKS},
         "fanout": _default_fanout(),
     }
+
+
+def _strip_legacy_model(lib: dict) -> dict:
+    """Drop the deprecated per-agent ``model`` key from a librarian dict.
+
+    Old records persisted ``librarian.model``; the model is now global, so
+    we ignore the stored value on read. Mutates and returns the dict.
+    """
+    lib.pop("model", None)
+    return lib
 
 
 def _ensure_fanout(lib: dict) -> dict:
@@ -135,7 +145,7 @@ class AgentRecord:
             created_at=int(data.get("created_at", 0)),
             last_ingest_at=int(data.get("last_ingest_at", 0)),
             total_chunks=int(data.get("total_chunks", 0)),
-            librarian=_ensure_fanout(raw_lib),
+            librarian=_strip_legacy_model(_ensure_fanout(raw_lib)),
         )
 
 
@@ -289,7 +299,7 @@ class AgentRegistry:
         """
         agent = self.get_agent(name)
         lib = agent.get("librarian") or _default_librarian()
-        return _ensure_fanout(lib)
+        return _strip_legacy_model(_ensure_fanout(lib))
 
     def set_librarian(
         self,
@@ -306,8 +316,10 @@ class AgentRegistry:
 
         - ``enabled``: master on/off switch. When False, every LLM
           enrichment task is skipped regardless of per-task settings.
-        - ``model``: provider:model override (e.g. "ollama:qwen3:4b").
-          Pass ``clear_model=True`` to revert to the install default.
+        - ``model`` / ``clear_model``: **deprecated**. The memory model is
+          now a system-wide setting; passing either redirects to
+          :func:`taosmd.set_memory_model` and emits a ``DeprecationWarning``.
+          Nothing is stored on the agent.
         - ``tasks``: dict of per-task switches. Keys must come from
           :data:`LIBRARIAN_TASKS`. Unknown keys raise ValueError.
         - ``fanout``: fan-out level — one of ``off | low | med | high``.
@@ -322,6 +334,21 @@ class AgentRegistry:
                     f"unknown librarian task(s): {sorted(unknown)}. "
                     f"Valid tasks: {LIBRARIAN_TASKS}"
                 )
+
+        # Deprecated per-agent model shim: redirect to the global setting.
+        # The model is no longer stored on the agent record.
+        if clear_model or model is not None:
+            import warnings  # noqa: PLC0415
+            from . import config as _config  # noqa: PLC0415
+
+            warnings.warn(
+                "per-agent librarian model is deprecated; the memory model "
+                "is now global — use taosmd.set_memory_model()",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _config.set_memory_model(model or "", clear=clear_model)
+
         if fanout is not None and fanout not in FANOUT_LEVELS:
             raise ValueError(
                 f"unknown fanout level {fanout!r}. "
@@ -332,13 +359,9 @@ class AgentRegistry:
         for a in data["agents"]:
             if a["name"] == name:
                 lib = a.get("librarian") or _default_librarian()
-                lib = _ensure_fanout(lib)
+                lib = _strip_legacy_model(_ensure_fanout(lib))
                 if enabled is not None:
                     lib["enabled"] = bool(enabled)
-                if clear_model:
-                    lib["model"] = None
-                elif model is not None:
-                    lib["model"] = model
                 if tasks is not None:
                     # Preserve unset tasks; only patch the keys provided.
                     lib_tasks = lib.get("tasks") or {t: True for t in LIBRARIAN_TASKS}

--- a/taosmd/catalog_pipeline.py
+++ b/taosmd/catalog_pipeline.py
@@ -21,6 +21,7 @@ from typing import Any
 import httpx
 
 from .agents import run_if_enabled
+from .config import resolve_memory_model
 from .prompts import intake_classification_prompt
 from .session_catalog import SessionCatalog
 from .crystallize import CrystalStore
@@ -163,6 +164,10 @@ class CatalogPipeline:
         sessions_created = split_result.get("sessions_created", 0)
 
         tier, model = await self.detect_best_tier()
+        # The memory model is a system-wide setting. When configured it
+        # overrides the auto-detected model; when unset, the detected model
+        # (prior behaviour) is kept as the fallback.
+        model = resolve_memory_model(model)
 
         # --- Stage 1b: Intake Classification (taxonomy filing) ---
         classify_results = []

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -73,10 +73,8 @@ def _librarian_show(registry: AgentRegistry, name: str, json_out: bool) -> int:
         print(json.dumps(lib, indent=2))
         return 0
     enabled = "ON" if lib.get("enabled", True) else "OFF"
-    model = lib.get("model") or "(install default)"
     print(f"Agent:      {name}")
     print(f"Librarian:  {enabled}")
-    print(f"Model:      {model}")
     print("Tasks:")
     tasks = lib.get("tasks", {})
     for t in LIBRARIAN_TASKS:
@@ -89,8 +87,6 @@ def _librarian_set(
     registry: AgentRegistry,
     name: str,
     enabled: bool | None,
-    model: str | None,
-    clear_model: bool,
     enable_tasks: list[str],
     disable_tasks: list[str],
     fanout: str | None = None,
@@ -105,9 +101,7 @@ def _librarian_set(
         lib = registry.set_librarian(
             name,
             enabled=enabled,
-            model=model,
             tasks=tasks or None,
-            clear_model=clear_model,
             fanout=fanout,
             fanout_auto_scale=fanout_auto_scale,
         )
@@ -118,6 +112,32 @@ def _librarian_set(
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(json.dumps(lib, indent=2))
+    return 0
+
+
+def _memory_model_get() -> int:
+    from . import config  # noqa: PLC0415
+
+    model = config.get_memory_model()
+    print(model if model else "(default)")
+    return 0
+
+
+def _memory_model_set(model: str | None, clear: bool) -> int:
+    from . import config  # noqa: PLC0415
+
+    if not clear and not model:
+        print("error: provide --model <provider:model> or --clear", file=sys.stderr)
+        return 2
+    try:
+        config.set_memory_model(model or "", clear=clear)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if clear:
+        print("Memory model cleared (using default).")
+    else:
+        print(f"Memory model set: {model}")
     return 0
 
 
@@ -347,14 +367,6 @@ def main(argv: list[str] | None = None) -> int:
         help="Master switch OFF (only verbatim archive + vector + keyword)",
     )
     set_p.add_argument(
-        "--model", default=None,
-        help="provider:model override (e.g. ollama:qwen3:4b)",
-    )
-    set_p.add_argument(
-        "--clear-model", action="store_true",
-        help="Revert to the install default model",
-    )
-    set_p.add_argument(
         "--enable", action="append", default=[], metavar="TASK",
         help=f"Enable a specific task. Repeat for multiple. Tasks: {', '.join(LIBRARIAN_TASKS)}",
     )
@@ -382,6 +394,25 @@ def main(argv: list[str] | None = None) -> int:
             "Auto-scale fanout tier on workers with GPU + TurboQuant + ≥12 GB VRAM. "
             "When on, low→med and med→high automatically on capable workers."
         ),
+    )
+
+    # ----- memory-model subcommand (system-wide model) ------------------
+    mm_p = sub.add_parser(
+        "memory-model",
+        help="Get/set the system-wide memory (Librarian) model",
+    )
+    mm_sub = mm_p.add_subparsers(dest="memory_model_cmd", required=True)
+
+    mm_sub.add_parser("get", help="Print the current memory model (or '(default)')")
+
+    mm_set_p = mm_sub.add_parser("set", help="Set or clear the memory model")
+    mm_set_p.add_argument(
+        "--model", default=None,
+        help="provider:model string (e.g. ollama:qwen3:4b)",
+    )
+    mm_set_p.add_argument(
+        "--clear", action="store_true",
+        help="Unset the memory model (revert to default)",
     )
 
     # ----- review subcommand (pending-decisions queue) -------------------
@@ -453,13 +484,17 @@ def main(argv: list[str] | None = None) -> int:
                 registry,
                 args.name,
                 enabled,
-                args.model,
-                args.clear_model,
                 args.enable,
                 args.disable,
                 fanout=args.fanout,
                 fanout_auto_scale=fanout_auto_scale,
             )
+
+    if args.cmd == "memory-model":
+        if args.memory_model_cmd == "get":
+            return _memory_model_get()
+        if args.memory_model_cmd == "set":
+            return _memory_model_set(args.model, args.clear)
 
     parser.print_help()
     return 1

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -1,0 +1,116 @@
+"""Install-wide taOSmd config — a single JSON file at ``~/.taosmd/config.json``.
+
+Historically the memory/Librarian model was a per-agent setting stored on
+each agent record. That made the model awkward to manage on a single-user
+install (set it once, get it everywhere) and impossible to use standalone
+without first registering an agent. The model is now a system-wide setting
+that lives here instead.
+
+The data dir is resolved exactly like :mod:`taosmd.api` — ``TAOSMD_DATA_DIR``
+when set, otherwise ``~/.taosmd``. The file is read/written defensively: a
+missing or corrupt file is treated as "nothing configured" rather than an
+error, so a hand-edited or half-written config never bricks ingest.
+
+Stdlib only — this module must stay dependency-free so it can be imported
+from anywhere in the package without pulling in heavier deps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = os.path.expanduser("~/.taosmd")
+
+# Key under which the global memory/Librarian model is stored.
+_MEMORY_MODEL_KEY = "memory_model"
+
+
+def _resolve_data_dir(data_dir=None) -> str:
+    """Resolve the data dir — mirrors ``taosmd.api._resolve_data_dir``."""
+    if data_dir is not None:
+        return os.fspath(data_dir)
+    env = os.environ.get("TAOSMD_DATA_DIR")
+    if env:
+        return env
+    return _DEFAULT_DATA_DIR
+
+
+def _config_path(data_dir=None) -> Path:
+    return Path(_resolve_data_dir(data_dir)) / "config.json"
+
+
+def _read(data_dir=None) -> dict:
+    """Load the config dict. Missing/corrupt file → empty dict (unset)."""
+    path = _config_path(data_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("taosmd: failed to read %s: %s", path, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write(data: dict, data_dir=None) -> None:
+    """Persist the config dict atomically (tmp + rename)."""
+    path = _config_path(data_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(path)
+
+
+def get_memory_model(data_dir=None) -> str | None:
+    """Return the configured global memory model, or ``None`` if unset.
+
+    The value is a ``provider:model`` string such as ``"ollama:qwen3:4b"``.
+    """
+    model = _read(data_dir).get(_MEMORY_MODEL_KEY)
+    if isinstance(model, str) and model.strip():
+        return model
+    return None
+
+
+def set_memory_model(model: str, clear: bool = False, data_dir=None) -> None:
+    """Persist the global memory model.
+
+    Args:
+        model: ``provider:model`` string. Ignored when ``clear`` is True.
+        clear: when True, remove the setting (unset → ``get`` returns None).
+
+    Raises:
+        ValueError: when ``clear`` is False and ``model`` is not a
+            non-empty string.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_MEMORY_MODEL_KEY, None)
+    else:
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError("model must be a non-empty string (or pass clear=True)")
+        data[_MEMORY_MODEL_KEY] = model.strip()
+    _write(data, data_dir)
+
+
+def resolve_memory_model(fallback: str | None = None, data_dir=None) -> str | None:
+    """Return the global memory model if set, else ``fallback``.
+
+    Consumers call this so an unset global transparently falls back to
+    their existing default — standalone installs that never set a model
+    keep working exactly as before.
+    """
+    model = get_memory_model(data_dir)
+    return model if model is not None else fallback
+
+
+__all__ = [
+    "get_memory_model",
+    "set_memory_model",
+    "resolve_memory_model",
+]

--- a/taosmd/emem_event_lift.py
+++ b/taosmd/emem_event_lift.py
@@ -110,7 +110,7 @@ def _system_prompt() -> str:
 async def lift_edu_to_triples(
     edu_text: str,
     *,
-    model: str,
+    model: str | None = None,
     ollama_url: str,
     http_client: httpx.AsyncClient,
     timeout: float = 120.0,
@@ -128,7 +128,16 @@ async def lift_edu_to_triples(
     Returns ``{"event_type": "none", "triples": []}`` on transport / JSON
     error — caller can treat empty as "nothing extracted" without needing
     to differentiate "nothing there" from "extractor failed".
+
+    ``model`` is a ``provider:model`` (or bare model) string. When omitted
+    it resolves to the system-wide memory model (see :mod:`taosmd.config`),
+    falling back to ``llama3.1:8b`` — the prior pass-2 default — when no
+    global is configured.
     """
+    if not model:
+        from .config import resolve_memory_model  # noqa: PLC0415
+
+        model = resolve_memory_model("llama3.1:8b")
     messages = [
         {"role": "system", "content": _system_prompt()},
         {"role": "user", "content": _ONESHOT_INPUT},
@@ -165,7 +174,7 @@ async def lift_edu_to_triples(
 async def lift_edus_to_events(
     edus: list[dict],
     *,
-    model: str,
+    model: str | None = None,
     ollama_url: str,
     http_client: httpx.AsyncClient,
     timeout: float = 120.0,

--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -246,10 +246,19 @@ async def process_conversation_turn(
         )
         use_llm = False
     if use_llm and llm_url and http_client:
+        # The memory model is a system-wide setting. When the caller didn't
+        # pin a model (unset or the literal "default" sentinel), defer to the
+        # global config; if that's also unset, fall back to the prior
+        # "default" behaviour so standalone installs are unchanged.
+        from .config import get_memory_model  # noqa: PLC0415
+
+        resolved_model = extraction_model
+        if not resolved_model or resolved_model == "default":
+            resolved_model = get_memory_model() or "default"
         facts = await extract_facts_with_llm(
             text, llm_url, http_client,
             agent_name=agent_name or "default",
-            model=extraction_model,
+            model=resolved_model,
         )
         if facts:
             method = "llm"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -225,7 +225,8 @@ def test_register_seeds_default_librarian(registry):
     registry.register_agent("alice")
     lib = registry.get_librarian("alice")
     assert lib["enabled"] is True
-    assert lib["model"] is None
+    # Model is now a system-wide setting — no per-agent "model" key.
+    assert "model" not in lib
     assert set(lib["tasks"].keys()) == set(LIBRARIAN_TASKS)
     assert all(lib["tasks"].values())
 
@@ -243,12 +244,22 @@ def test_set_librarian_master_switch(registry):
     assert registry.get_librarian("alice")["enabled"] is False
 
 
-def test_set_librarian_model_override_and_clear(registry):
+def test_set_librarian_model_redirects_to_global(registry, tmp_path, monkeypatch):
+    # The per-agent model is deprecated: set_librarian(model=...) now writes
+    # the system-wide config and never stores a per-agent "model" key.
+    import taosmd.config as config
+
+    monkeypatch.setenv("TAOSMD_DATA_DIR", str(tmp_path / "cfg"))
     registry.register_agent("alice")
-    registry.set_librarian("alice", model="ollama:qwen3:4b")
-    assert registry.get_librarian("alice")["model"] == "ollama:qwen3:4b"
-    registry.set_librarian("alice", clear_model=True)
-    assert registry.get_librarian("alice")["model"] is None
+
+    with pytest.warns(DeprecationWarning):
+        registry.set_librarian("alice", model="ollama:qwen3:4b")
+    assert "model" not in registry.get_librarian("alice")
+    assert config.get_memory_model() == "ollama:qwen3:4b"
+
+    with pytest.warns(DeprecationWarning):
+        registry.set_librarian("alice", clear_model=True)
+    assert config.get_memory_model() is None
 
 
 def test_set_librarian_per_task_toggles(registry):

--- a/tests/test_config_memory_model.py
+++ b/tests/test_config_memory_model.py
@@ -1,0 +1,141 @@
+"""Tests for the system-wide memory model config (taosmd.config).
+
+All tests pin ``TAOSMD_DATA_DIR`` to a temp dir so the real ``~/.taosmd``
+is never touched.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+import taosmd.config as config
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    d = tmp_path / "taosmd-data"
+    monkeypatch.setenv("TAOSMD_DATA_DIR", str(d))
+    return d
+
+
+# --- config round-trip ------------------------------------------------------
+
+
+def test_set_then_get_round_trip(data_dir):
+    config.set_memory_model("ollama:qwen3:4b")
+    assert config.get_memory_model() == "ollama:qwen3:4b"
+
+
+def test_clear_returns_none(data_dir):
+    config.set_memory_model("ollama:qwen3:4b")
+    config.set_memory_model("", clear=True)
+    assert config.get_memory_model() is None
+
+
+def test_unset_is_none(data_dir):
+    assert config.get_memory_model() is None
+
+
+def test_set_empty_string_raises(data_dir):
+    with pytest.raises(ValueError):
+        config.set_memory_model("")
+    with pytest.raises(ValueError):
+        config.set_memory_model("   ")
+
+
+def test_persists_across_fresh_read(data_dir):
+    config.set_memory_model("ollama:qwen3:4b")
+    # Re-import the module to simulate a fresh process reading the file.
+    fresh = importlib.reload(config)
+    assert fresh.get_memory_model() == "ollama:qwen3:4b"
+
+
+def test_corrupt_file_treated_as_unset(data_dir):
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "config.json").write_text("{ this is not valid json")
+    assert config.get_memory_model() is None
+    # And we can still set on top of it (overwrites the corrupt file).
+    config.set_memory_model("ollama:qwen3:4b")
+    assert config.get_memory_model() == "ollama:qwen3:4b"
+    on_disk = json.loads((data_dir / "config.json").read_text())
+    assert on_disk["memory_model"] == "ollama:qwen3:4b"
+
+
+# --- resolve precedence -----------------------------------------------------
+
+
+def test_resolve_prefers_global_over_fallback(data_dir):
+    config.set_memory_model("ollama:qwen3:4b")
+    assert config.resolve_memory_model("fallback-model") == "ollama:qwen3:4b"
+
+
+def test_resolve_uses_fallback_when_unset(data_dir):
+    assert config.resolve_memory_model("fallback-model") == "fallback-model"
+
+
+def test_resolve_none_fallback_when_unset(data_dir):
+    assert config.resolve_memory_model() is None
+
+
+# --- top-level exports ------------------------------------------------------
+
+
+def test_top_level_exports(data_dir):
+    import taosmd
+
+    taosmd.set_memory_model("ollama:qwen3:4b")
+    assert taosmd.get_memory_model() == "ollama:qwen3:4b"
+
+
+# --- migration: per-agent model is stripped ---------------------------------
+
+
+def test_legacy_per_agent_model_stripped_on_read(data_dir):
+    from taosmd.agents import LIBRARIAN_TASKS, AgentRegistry
+
+    registry = AgentRegistry(data_dir)
+    # Hand-write an agents.json carrying a legacy per-agent model key.
+    legacy = {
+        "agents": [
+            {
+                "name": "old-agent",
+                "display_name": "Old Agent",
+                "created_at": 1700000000,
+                "last_ingest_at": 0,
+                "total_chunks": 0,
+                "librarian": {
+                    "enabled": True,
+                    "model": "ollama:legacy-model",
+                    "tasks": {t: True for t in LIBRARIAN_TASKS},
+                    "fanout": {"default": "low", "auto_scale": True},
+                },
+            }
+        ]
+    }
+    (data_dir).mkdir(parents=True, exist_ok=True)
+    (data_dir / "agents.json").write_text(json.dumps(legacy))
+
+    lib = registry.get_librarian("old-agent")
+    assert "model" not in lib
+    assert lib["enabled"] is True
+
+
+def test_set_librarian_model_redirects_and_warns(data_dir):
+    from taosmd.agents import AgentRegistry
+
+    registry = AgentRegistry(data_dir)
+    registry.register_agent("alice")
+
+    with pytest.warns(DeprecationWarning):
+        registry.set_librarian("alice", model="ollama:qwen3:4b")
+
+    # Nothing stored per-agent; the global config now carries the model.
+    assert "model" not in registry.get_librarian("alice")
+    assert config.get_memory_model() == "ollama:qwen3:4b"
+
+    with pytest.warns(DeprecationWarning):
+        registry.set_librarian("alice", clear_model=True)
+    assert config.get_memory_model() is None


### PR DESCRIPTION
## Summary

Moves the memory/Librarian model from a per-agent value to a single install-wide setting, per the contract confirmed on #81.

## Contract

- **New module `taosmd/config.py`** persisted at `~/.taosmd/config.json` (honors `TAOSMD_DATA_DIR`, stdlib only, corrupt/missing file → treated as unset):
  - `get_memory_model() -> str | None` — the configured `provider:model` string, or `None` when unset.
  - `set_memory_model(model, clear=False)` — persist the model; `clear=True` unsets it. Empty/blank model raises `ValueError`.
  - `resolve_memory_model(fallback=None)` — global if set, else `fallback`.
- Re-exported at the top level: `taosmd.get_memory_model` / `taosmd.set_memory_model` (and `taosmd.config`), added to `__all__`.

## Per-agent model dropped (migration auto-strips it)

- `_default_librarian()` no longer carries a `model` key.
- The legacy `librarian.model` field is ignored on load and removed on next write (`_strip_legacy_model` on the `from_dict` / `get_librarian` / `set_librarian` read paths) — `get_librarian` no longer returns a `model` key.
- `set_librarian(model=..., clear_model=...)` is kept as a **deprecated** backward-compat shim: it redirects to the global `set_memory_model(...)` and emits a `DeprecationWarning`; nothing is stored on the agent. `enabled` / `tasks` / `fanout` are unchanged. Disabling per agent stays `set_librarian(slug, enabled=False)`.

## Consumers wired to the global

- `memory_extractor.process_conversation_turn`: when `extraction_model` is falsy or the literal `"default"`, resolves to the global, falling back to the prior `"default"` behaviour when unset.
- `emem_event_lift.lift_edu_to_triples` / `lift_edus_to_events`: `model` now defaults to `None` and resolves to the global, falling back to the prior pass-2 default `llama3.1:8b` when unset.
- `catalog_pipeline.index_day`: the global model overrides the auto-detected tier model when configured; when unset, the detected model (prior behaviour) is kept. Tier gating is unchanged.

Prior default behaviour is preserved when no global is set, so standalone installs are unaffected.

## CLI

- New `taosmd memory-model get` (prints current or `(default)`) and `taosmd memory-model set --model <provider:model> | --clear`.
- The `librarian` command no longer surfaces or sets a per-agent model (`--model` / `--clear-model` removed; no Model line in `librarian show`).

## Standalone

Pure taOSmd config/API/CLI — no taOS import or dependency.

## Tests

New `tests/test_config_memory_model.py` covers set→get round-trip, clear→None, persistence across a fresh read, `resolve_memory_model` precedence, corrupt-file handling, top-level exports, the legacy-`model` migration via `get_librarian`, and the deprecated `set_librarian(model=...)` redirect + warning. Existing `tests/test_agents.py` updated for the new contract.

Full suite: **204 passed**.