### PR TITLE
docs(readme): correct integration-surface claim + sharpen archive/correction bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,11 @@ hits = await retrieve(
 
 - **97.0% end-to-end Judge accuracy** on LongMemEval-S benchmark (SOTA)
 - **Zero cloud dependencies** — runs entirely on local hardware
-- **Framework-agnostic** — HTTP API works with any agent framework
+- **Framework-agnostic** — Python API + CLI work with any agent framework (MCP and local HTTP API in progress)
 - **Hybrid search** — semantic similarity + keyword overlap boosting
 - **Temporal facts** — validity windows, point-in-time queries
-- **Contradiction detection** — auto-resolve conflicting facts
-- **Zero-loss archive** — append-only, never modified, gzip compressed
+- **Contradiction detection** — corrected facts supersede the old value; recall returns only the active fact, so corrections stop resurfacing
+- **Zero-loss archive** — append-only, read-only transcript of the full picture (user + agent messages, tool calls and results, decisions, errors, plus opt-in user activity); the librarian derives memory from it, never over it
 - **Intent-aware retrieval** — routes queries to optimal memory layer
 - **0.3ms embeddings** — ONNX Runtime on CPU (ARM or x86)
 - **Opt-in user tracking** — browsing history, app usage, search queries


### PR DESCRIPTION
## Summary
Small README correctness fixes in Key Features:

- **Fix an overclaim:** it said *"Framework-agnostic — HTTP API works with any agent framework,"* but there is no HTTP API yet. taOSmd exposes a **Python API + CLI** today; **MCP (#84)** and a **local HTTP/REST API (#85)** are work in progress. Updated to say so.
- **Sharpen the contradiction bullet:** corrected facts supersede the old value and recall returns only the active fact (so corrections stop resurfacing) — verified in `knowledge_graph.py` (`detect_contradictions` + invalidation; `query_entity`/`query_predicate` filter `valid_to`).
- **Sharpen the zero-loss archive bullet:** it's a full read-only transcript of both sides (user + agent messages, tool calls and results, decisions, errors, plus opt-in user activity), and the librarian derives memory from it rather than over it — verified in `archive.py` (append-only event log) + `catalog_pipeline.py`.

No code changes; docs only.