### PR TITLE
fix(audit): silent-failure + bug quick-wins (#92 #95 #100 #91)

### DIFF
--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -91,6 +91,10 @@ class ArchiveStore:
         self._current_file: Any = None
         self._current_date: str = ""
         self._user_tracking_enabled: bool = False
+        # In-memory line counts per JSONL path, avoids re-reading the whole
+        # daily file on every write. Seeded from disk the first time a path
+        # is seen; reset naturally per path across daily rollover.
+        self._line_counts: dict[str, int] = {}
 
     async def init(self) -> None:
         self._archive_dir.mkdir(parents=True, exist_ok=True)
@@ -189,8 +193,18 @@ class ArchiveStore:
         f.write(line + "\n")
         f.flush()
 
-        # Count lines for line_number
-        line_count = sum(1 for _ in open(file_path, "r", encoding="utf-8"))
+        # Count lines for line_number. Track in memory rather than re-reading
+        # the whole daily JSONL on every write: seed from disk the first time
+        # we see a path (handles daily rollover -> fresh path), then increment.
+        if file_path not in self._line_counts:
+            try:
+                with open(file_path, "r", encoding="utf-8") as existing:
+                    self._line_counts[file_path] = sum(1 for _ in existing)
+            except FileNotFoundError:
+                self._line_counts[file_path] = 0
+        else:
+            self._line_counts[file_path] += 1
+        line_count = self._line_counts[file_path]
 
         # Index for fast lookup
         cursor = self._conn.execute(

--- a/taosmd/pending_decisions.py
+++ b/taosmd/pending_decisions.py
@@ -121,7 +121,8 @@ class PendingDecisionsStore:
             raise ValueError(f"unknown kind {kind!r}; must be one of {VALID_KINDS}")
         if suggested_action not in VALID_ACTIONS:
             raise ValueError(f"unknown suggested_action {suggested_action!r}; must be one of {VALID_ACTIONS}")
-        assert self._conn is not None
+        if self._conn is None:
+            raise RuntimeError("PendingDecisionsStore not initialized; call init() first")
 
         now = time.time()
         pid = _pending_id(subject, predicate, new_object, now)
@@ -154,7 +155,8 @@ class PendingDecisionsStore:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """Return unresolved decisions, newest first."""
-        assert self._conn is not None
+        if self._conn is None:
+            raise RuntimeError("PendingDecisionsStore not initialized; call init() first")
         if subject is not None:
             rows = self._conn.execute(
                 """SELECT * FROM kg_pending_decisions
@@ -172,7 +174,8 @@ class PendingDecisionsStore:
         return [self._row_to_dict(r) for r in rows]
 
     async def get(self, pending_id: str) -> dict[str, Any] | None:
-        assert self._conn is not None
+        if self._conn is None:
+            raise RuntimeError("PendingDecisionsStore not initialized; call init() first")
         row = self._conn.execute(
             "SELECT * FROM kg_pending_decisions WHERE id = ?",
             (pending_id,),
@@ -198,7 +201,8 @@ class PendingDecisionsStore:
             raise ValueError(
                 f"unknown resolution {resolution!r}; must be one of {VALID_RESOLUTIONS}"
             )
-        assert self._conn is not None
+        if self._conn is None:
+            raise RuntimeError("PendingDecisionsStore not initialized; call init() first")
         cur = self._conn.execute(
             """UPDATE kg_pending_decisions
                   SET resolved_at = ?, resolution = ?, resolution_note = ?
@@ -209,7 +213,8 @@ class PendingDecisionsStore:
         return cur.rowcount > 0
 
     async def stats(self) -> dict[str, int]:
-        assert self._conn is not None
+        if self._conn is None:
+            raise RuntimeError("PendingDecisionsStore not initialized; call init() first")
         total = self._conn.execute(
             "SELECT COUNT(*) AS n FROM kg_pending_decisions"
         ).fetchone()["n"]

--- a/taosmd/secret_filter.py
+++ b/taosmd/secret_filter.py
@@ -10,7 +10,10 @@ and common secret formats.
 
 from __future__ import annotations
 
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 # Each pattern: (name, regex, replacement)
 SECRET_PATTERNS: list[tuple[str, re.Pattern, str]] = [
@@ -71,7 +74,9 @@ def filter_text(text: str, mode: str = "redact") -> str:
         return text
 
     if mode == "warn":
-        # Caller should check contains_secrets() separately for logging
+        # warn = don't redact, just log when secrets are present.
+        if contains_secrets(text):
+            logger.warning("Secrets detected in text (warn mode): stored unredacted")
         return text
 
     # Default: redact

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -490,6 +490,10 @@ class VectorMemory:
         row = self._conn.execute("SELECT COUNT(*) as n FROM vector_memory").fetchone()
         return row["n"]
 
+    async def stats(self) -> dict:
+        """Overall vector-memory statistics."""
+        return {"count": await self.count()}
+
     async def clear(self) -> int:
         cursor = self._conn.execute("DELETE FROM vector_memory")
         self._conn.commit()

--- a/tests/test_archive_line_count.py
+++ b/tests/test_archive_line_count.py
@@ -1,0 +1,59 @@
+"""Tests for the in-memory archive line-count optimisation (issue #95).
+
+record() used to re-read the entire daily JSONL on every write to compute
+the line_number. It now keeps an in-memory counter (self._line_counts) seeded
+from disk once per path. These tests assert the counter stays consistent with
+the file and survives a daily-file rollover (a new path is seeded fresh).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from taosmd.archive import ArchiveStore
+
+
+# Two timestamps in different UTC months -> different daily paths. The
+# archive rolls its open file over by parent directory (year/month), so the
+# rollover case needs a month boundary, not just a day boundary.
+DAY_ONE = 1_700_000_000.0   # 2023-11-14
+DAY_TWO = 1_702_600_000.0   # 2023-12-15
+
+
+def _line_count_on_disk(path: str) -> int:
+    with open(path, "r", encoding="utf-8") as fh:
+        return sum(1 for _ in fh)
+
+
+def test_line_count_matches_file_and_survives_rollover(tmp_path, monkeypatch):
+    async def go():
+        store = ArchiveStore(
+            archive_dir=tmp_path / "archive",
+            index_path=tmp_path / "archive-index.db",
+        )
+        await store.init()
+
+        import taosmd.archive as archive_mod
+
+        # Day one: two records into the same daily file.
+        monkeypatch.setattr(archive_mod.time, "time", lambda: DAY_ONE)
+        await store.record("test_event", {"content": "first"})
+        _, day_one_path = store._ensure_file(DAY_ONE)
+        await store.record("test_event", {"content": "second"})
+
+        assert store._line_counts[day_one_path] == 2
+        assert store._line_counts[day_one_path] == _line_count_on_disk(day_one_path)
+
+        # Day two: rollover to a new daily path, counter seeds fresh.
+        monkeypatch.setattr(archive_mod.time, "time", lambda: DAY_TWO)
+        await store.record("test_event", {"content": "third"})
+        _, day_two_path = store._ensure_file(DAY_TWO)
+
+        assert day_two_path != day_one_path
+        assert store._line_counts[day_two_path] == 1
+        assert store._line_counts[day_two_path] == _line_count_on_disk(day_two_path)
+
+        return store
+
+    store = asyncio.run(go())
+    asyncio.run(store.close())

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -290,3 +290,27 @@ def test_kg_auto_resolves_high_confidence_even_with_pending_store(tmp_path):
     assert result["pending_id"] == ""
     assert result["contradictions_resolved"] == 1
     assert queue == []
+
+
+def test_raises_when_used_before_init(tmp_path):
+    """Calling store methods before init() raises RuntimeError, not AssertionError."""
+    store = PendingDecisionsStore(db_path=tmp_path / "kg.db")
+
+    async def go():
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.list_pending()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.get("deadbeef")
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.stats()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.defer(
+                kind="contradiction",
+                subject="user",
+                predicate="lives_in",
+                new_object="paris",
+                old_triple_ids=[],
+                suggested_action="invalidate_old_add_new",
+            )
+
+    _run(go())

--- a/tests/test_secret_filter_warn.py
+++ b/tests/test_secret_filter_warn.py
@@ -1,0 +1,34 @@
+"""Tests for secret_filter.filter_text warn/redact modes."""
+
+from __future__ import annotations
+
+import logging
+
+from taosmd.secret_filter import filter_text
+
+
+SECRET = "my key is sk-abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def test_warn_mode_logs_and_does_not_alter(caplog):
+    """warn mode logs a warning when secrets are present but returns text unchanged."""
+    with caplog.at_level(logging.WARNING, logger="taosmd.secret_filter"):
+        out = filter_text(SECRET, mode="warn")
+    assert out == SECRET  # unredacted
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_warn_mode_no_log_when_clean(caplog):
+    """warn mode stays silent when there are no secrets."""
+    clean = "just an ordinary sentence with no credentials"
+    with caplog.at_level(logging.WARNING, logger="taosmd.secret_filter"):
+        out = filter_text(clean, mode="warn")
+    assert out == clean
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_redact_mode_redacts():
+    """redact mode (default) still replaces the secret."""
+    out = filter_text(SECRET, mode="redact")
+    assert "sk-abcdefghijklmnopqrstuvwxyz0123456789" not in out
+    assert "[REDACTED:openai_key]" in out

--- a/tests/test_vector_memory_stats.py
+++ b/tests/test_vector_memory_stats.py
@@ -1,0 +1,36 @@
+"""Tests for VectorMemory.stats() (issue #92).
+
+stats() previously did not exist, so taosmd_backend.get_stats() silently
+returned an empty dict for the vector layer (wrapped in try/except). Verify
+stats() now returns a count.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from taosmd.vector_memory import VectorMemory
+
+
+def _deterministic_embedder(vmem: VectorMemory) -> None:
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFFFFFFFFFF
+        return [((h >> (i * 3)) & 0xFF) / 255.0 - 0.5 for i in range(16)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+def test_stats_returns_count(tmp_path):
+    async def go():
+        vmem = VectorMemory(db_path=str(tmp_path / "vec.db"), embed_mode="onnx")
+        await vmem.init()
+        _deterministic_embedder(vmem)
+        empty = await vmem.stats()
+        await vmem.add("the cat sat on the mat")
+        await vmem.add("grocery list: eggs milk")
+        full = await vmem.stats()
+        return empty, full
+
+    empty, full = asyncio.run(go())
+    assert isinstance(empty, dict) and empty["count"] == 0
+    assert full["count"] == 2


### PR DESCRIPTION
Small, focused batch of verified bug fixes from a code audit. All four are confirmed-real against `master`, vision-aligned, and benchmark-safe (no retrieval/scoring behavior changes).

## Fixes

- **#92 — `VectorMemory.stats()` missing.** `taosmd_backend.get_stats()` calls `self._vector.stats()`, but `VectorMemory` only had `count()`, so vector stats silently came back empty (swallowed by the surrounding try/except). Added `async def stats()` returning `{"count": <rows>}`, reusing `count()`, consistent with the other stores' `stats()`.

- **#95 — O(n) archive line-count per write.** `ArchiveStore.record()` re-read the entire daily JSONL (`sum(1 for _ in open(...))`) on every single write to compute `line_number`. Replaced with an in-memory `self._line_counts: dict[str, int]`, seeded from disk the first time a path is seen, then incremented per append. Correct across daily-file rollover (a new path seeds fresh). Append-only / zero-loss behavior unchanged.

- **#100 — `assert` as production invariant.** `PendingDecisionsStore` used `assert self._conn is not None` (5 sites) to guard against use-before-`init()`; asserts are stripped under `python -O`. Replaced each with `if self._conn is None: raise RuntimeError("PendingDecisionsStore not initialized; call init() first")`.

- **#91 — `filter_text(mode="warn")` no-op.** The `warn` branch returned text unchanged but never logged, despite the docstring promising a warning. Now emits `logger.warning(...)` (module logger) when `contains_secrets(text)` is true, and still returns the text unredacted.

## Tests

Added/extended offline (no-model) tests under `tests/`:
- `test_secret_filter_warn.py` — warn mode logs via `caplog` and leaves text intact; stays silent when clean; redact mode still redacts.
- `test_pending_decisions.py::test_raises_when_used_before_init` — methods raise `RuntimeError` before `init()`.
- `test_vector_memory_stats.py` — `stats()` returns a dict with a count (deterministic monkeypatched embed).
- `test_archive_line_count.py` — in-memory counter matches the on-disk line count and survives a daily-file rollover.

Full suite: **215 passed**.

## Audit corrections

A few items in the original audit were inaccurate and are intentionally NOT acted on here: #90, the "#92 causes a crash" claim (it's a silently-swallowed empty dict, not a crash), and the "#100 also affects reflect.py" claim (reflect.py has no such asserts).