### PR TITLE
fix(audit): token estimate heuristic + explicit intent tie-break (#104 #109)

### DIFF
--- a/taosmd/context_assembler.py
+++ b/taosmd/context_assembler.py
@@ -32,21 +32,91 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Rough token estimation: 1 token ≈ 4 chars
-CHARS_PER_TOKEN = 4
+# Rough token estimation. A flat 4 chars/token under-counts dense content
+# (code, JSON) and badly under-counts CJK, where each glyph is roughly its
+# own token. We keep a cheap, deterministic, dependency-free heuristic:
+#   - CJK glyphs count as ~1 token each
+#   - punctuation/symbol-heavy text uses fewer chars/token (denser)
+#   - plain prose uses the classic ~4 chars/token
+CHARS_PER_TOKEN = 4          # prose default (kept public/back-compatible)
+CHARS_PER_TOKEN_DENSE = 3    # code / JSON / symbol-heavy text
+_DENSE_PUNCT_RATIO = 0.18    # punctuation share above which text is "dense"
+
+
+def _is_cjk(ch: str) -> bool:
+    """True for CJK / Japanese / Korean glyphs (roughly one token each)."""
+    cp = ord(ch)
+    return (
+        0x3000 <= cp <= 0x303F        # CJK symbols and punctuation
+        or 0x3040 <= cp <= 0x30FF     # Hiragana + Katakana
+        or 0x3400 <= cp <= 0x4DBF     # CJK Ext A
+        or 0x4E00 <= cp <= 0x9FFF     # CJK Unified Ideographs
+        or 0xF900 <= cp <= 0xFAFF     # CJK Compatibility Ideographs
+        or 0xFF00 <= cp <= 0xFFEF     # Halfwidth/Fullwidth forms
+        or 0xAC00 <= cp <= 0xD7AF     # Hangul syllables
+        or 0x20000 <= cp <= 0x2FA1F   # CJK Ext B-F + supplement
+    )
+
+
+def _chars_per_token(non_cjk_text: str) -> int:
+    """Pick chars-per-token for the non-CJK part based on symbol density."""
+    if not non_cjk_text:
+        return CHARS_PER_TOKEN
+    punct = sum(1 for ch in non_cjk_text if not ch.isalnum() and not ch.isspace())
+    if punct / len(non_cjk_text) >= _DENSE_PUNCT_RATIO:
+        return CHARS_PER_TOKEN_DENSE
+    return CHARS_PER_TOKEN
 
 
 def estimate_tokens(text: str) -> int:
-    """Rough token count estimate."""
-    return len(text) // CHARS_PER_TOKEN
+    """Content-aware token count estimate (heuristic, no tokenizer).
+
+    CJK glyphs are counted as ~1 token each; the remaining text is divided
+    by a chars-per-token factor that shrinks for punctuation/symbol-heavy
+    content (code, JSON) and stays at ~4 for prose.
+    """
+    if not text:
+        return 0
+    cjk = 0
+    other_chars: list[str] = []
+    for ch in text:
+        if _is_cjk(ch):
+            cjk += 1
+        else:
+            other_chars.append(ch)
+    non_cjk = "".join(other_chars)
+    return cjk + len(non_cjk) // _chars_per_token(non_cjk)
 
 
 def truncate_to_tokens(text: str, max_tokens: int) -> str:
-    """Truncate text to approximately max_tokens."""
-    max_chars = max_tokens * CHARS_PER_TOKEN
-    if len(text) <= max_chars:
+    """Truncate text to approximately max_tokens.
+
+    Uses the same content-aware estimate as ``estimate_tokens`` so that a
+    truncated string lands near ``max_tokens`` for both prose and dense or
+    CJK content. Returns ``text`` unchanged when it already fits.
+    """
+    if estimate_tokens(text) <= max_tokens:
         return text
-    return text[:max_chars] + "..."
+    # Walk the string accumulating the estimated token cost char-by-char,
+    # stopping just before the budget is exceeded. Single pass, O(n).
+    chars_per_token = _chars_per_token("".join(ch for ch in text if not _is_cjk(ch)))
+    tokens = 0
+    non_cjk_run = 0
+    cut = 0
+    for i, ch in enumerate(text):
+        if _is_cjk(ch):
+            tokens += 1
+        else:
+            non_cjk_run += 1
+            if non_cjk_run == chars_per_token:
+                tokens += 1
+                non_cjk_run = 0
+        if tokens > max_tokens:
+            break
+        cut = i + 1
+    if cut <= 0:
+        cut = 1
+    return text[:cut] + "..."
 
 
 class ContextAssembler:

--- a/taosmd/context_assembler.py
+++ b/taosmd/context_assembler.py
@@ -47,7 +47,9 @@ def _is_cjk(ch: str) -> bool:
     """True for CJK / Japanese / Korean glyphs (roughly one token each)."""
     cp = ord(ch)
     return (
-        0x3000 <= cp <= 0x303F        # CJK symbols and punctuation
+        0x2E80 <= cp <= 0x2EFF        # CJK Radicals Supplement
+        or 0x2F00 <= cp <= 0x2FDF     # Kangxi Radicals
+        or 0x3000 <= cp <= 0x303F     # CJK symbols and punctuation
         or 0x3040 <= cp <= 0x30FF     # Hiragana + Katakana
         or 0x3400 <= cp <= 0x4DBF     # CJK Ext A
         or 0x4E00 <= cp <= 0x9FFF     # CJK Unified Ideographs
@@ -97,6 +99,13 @@ def truncate_to_tokens(text: str, max_tokens: int) -> str:
     """
     if estimate_tokens(text) <= max_tokens:
         return text
+    # Reserve budget for the trailing ellipsis so the returned string —
+    # marker included — still lands within max_tokens.
+    ellipsis = "..."
+    budget = max_tokens - estimate_tokens(ellipsis)
+    if budget <= 0:
+        # No room for content alongside the marker; emit just the marker.
+        return ellipsis
     # Walk the string accumulating the estimated token cost char-by-char,
     # stopping just before the budget is exceeded. Single pass, O(n).
     chars_per_token = _chars_per_token("".join(ch for ch in text if not _is_cjk(ch)))
@@ -111,12 +120,12 @@ def truncate_to_tokens(text: str, max_tokens: int) -> str:
             if non_cjk_run == chars_per_token:
                 tokens += 1
                 non_cjk_run = 0
-        if tokens > max_tokens:
+        if tokens > budget:
             break
         cut = i + 1
     if cut <= 0:
         cut = 1
-    return text[:cut] + "..."
+    return text[:cut] + ellipsis
 
 
 class ContextAssembler:

--- a/taosmd/intent_classifier.py
+++ b/taosmd/intent_classifier.py
@@ -87,6 +87,21 @@ SEARCH_STRATEGIES = {
     },
 }
 
+# Explicit tie-break priority, most-specific first. When two intents score
+# equally, the one earlier in this tuple wins. Previously the winner was just
+# whichever intent appeared first in INTENT_PATTERNS — deterministic, but an
+# implicit side effect of dict order. Codifying it here makes the intended
+# precedence explicit and decouples it from pattern declaration order.
+INTENT_PRIORITY = (
+    INTENT_TIMELINE,     # date/session phrasing is very specific
+    INTENT_RELATIONAL,   # explicit relationships ("depends on", "manages")
+    INTENT_PREFERENCE,   # preference phrasing ("usually", "favourite")
+    INTENT_RECENT,       # recency phrasing ("yesterday", "latest")
+    INTENT_TECHNICAL,    # "how does X work", "architecture"
+    INTENT_FACTUAL,      # generic "what is" — least specific signal
+    INTENT_EXPLORATORY,  # fallback when nothing else matches
+)
+
 # Keyword patterns for intent classification
 INTENT_PATTERNS = {
     INTENT_FACTUAL: [
@@ -168,8 +183,14 @@ def classify_intent(query: str) -> str:
             if re.search(pattern, query_lower):
                 scores[intent] += boost.get(intent, 1)
 
-    # Find best match
-    best_intent = max(scores, key=scores.get)
+    # Find best match. On a score tie, break it by the explicit priority
+    # order rather than relying on dict insertion order. A lower priority
+    # index means more specific / higher precedence.
+    priority_rank = {intent: i for i, intent in enumerate(INTENT_PRIORITY)}
+    best_intent = max(
+        scores,
+        key=lambda intent: (scores[intent], -priority_rank.get(intent, len(INTENT_PRIORITY))),
+    )
     if scores[best_intent] > 0:
         return best_intent
 

--- a/taosmd/intent_classifier.py
+++ b/taosmd/intent_classifier.py
@@ -102,6 +102,10 @@ INTENT_PRIORITY = (
     INTENT_EXPLORATORY,  # fallback when nothing else matches
 )
 
+# Precomputed rank lookup for tie-breaking (lower index = higher precedence).
+# Built once at import rather than rebuilt on every classify_intent call.
+_PRIORITY_RANK = {intent: i for i, intent in enumerate(INTENT_PRIORITY)}
+
 # Keyword patterns for intent classification
 INTENT_PATTERNS = {
     INTENT_FACTUAL: [
@@ -186,10 +190,9 @@ def classify_intent(query: str) -> str:
     # Find best match. On a score tie, break it by the explicit priority
     # order rather than relying on dict insertion order. A lower priority
     # index means more specific / higher precedence.
-    priority_rank = {intent: i for i, intent in enumerate(INTENT_PRIORITY)}
     best_intent = max(
         scores,
-        key=lambda intent: (scores[intent], -priority_rank.get(intent, len(INTENT_PRIORITY))),
+        key=lambda intent: (scores[intent], -_PRIORITY_RANK.get(intent, len(INTENT_PRIORITY))),
     )
     if scores[best_intent] > 0:
         return best_intent

--- a/tests/test_intent_timeline.py
+++ b/tests/test_intent_timeline.py
@@ -1,9 +1,13 @@
 """Tests for the timeline intent type in the intent classifier."""
 
+import re
+
 import pytest
 from taosmd.intent_classifier import (
     classify_intent,
     get_search_strategy,
+    INTENT_PATTERNS,
+    INTENT_PRIORITY,
     INTENT_TIMELINE,
     INTENT_FACTUAL,
     INTENT_TECHNICAL,
@@ -40,3 +44,45 @@ def test_non_timeline_queries_unchanged():
     assert classify_intent("What is taOS?") == INTENT_FACTUAL
     assert classify_intent("How does embedding work?") == INTENT_TECHNICAL
     assert classify_intent("What does Jay prefer?") == INTENT_PREFERENCE
+
+
+def _scores(query: str) -> dict:
+    """Replicate the classifier's scoring for tie inspection in tests."""
+    ql = query.lower().strip()
+    boost = {"recent": 2, "preference": 2, "timeline": 2}
+    out = {}
+    for intent, patterns in INTENT_PATTERNS.items():
+        s = sum(boost.get(intent, 1) for p in patterns if re.search(p, ql))
+        if s:
+            out[intent] = s
+    return out
+
+
+def test_tie_resolves_by_explicit_priority():
+    """A genuine score tie must resolve to the higher-priority intent.
+
+    "What is the architecture" matches one factual pattern ("what is") and
+    one technical pattern ("architecture") — a 1-1 tie. Technical outranks
+    factual in INTENT_PRIORITY, so technical must win.
+    """
+    query = "What is the architecture"
+    scores = _scores(query)
+    assert scores.get(INTENT_FACTUAL) == scores.get(INTENT_TECHNICAL) == 1
+    assert INTENT_PRIORITY.index(INTENT_TECHNICAL) < INTENT_PRIORITY.index(
+        INTENT_FACTUAL
+    )
+    assert classify_intent(query) == INTENT_TECHNICAL
+
+
+def test_priority_independent_of_pattern_decl_order():
+    """Tie-break must follow INTENT_PRIORITY, not dict declaration order."""
+    # Every pattern-bearing intent appears in the explicit priority list.
+    for intent in INTENT_PATTERNS:
+        assert intent in INTENT_PRIORITY
+    # Priority is intentionally different from declaration order (factual is
+    # declared first but is near-last in priority).
+    decl_order = list(INTENT_PATTERNS.keys())
+    assert decl_order[0] == INTENT_FACTUAL
+    assert INTENT_PRIORITY.index(INTENT_FACTUAL) > INTENT_PRIORITY.index(
+        INTENT_TECHNICAL
+    )

--- a/tests/test_token_estimate.py
+++ b/tests/test_token_estimate.py
@@ -1,0 +1,69 @@
+"""Tests for the content-aware token estimate heuristic.
+
+These are pure-function, offline checks of estimate_tokens / truncate_to_tokens.
+No models, no tokenizer dependency.
+"""
+
+from taosmd.context_assembler import (
+    CHARS_PER_TOKEN,
+    estimate_tokens,
+    truncate_to_tokens,
+)
+
+
+def test_empty_string_is_zero_tokens():
+    assert estimate_tokens("") == 0
+
+
+def test_prose_matches_classic_estimate():
+    """Plain prose should stay at roughly the old ~4 chars/token rate."""
+    prose = "the quick brown fox jumps over the lazy dog every single morning"
+    assert estimate_tokens(prose) == len(prose) // CHARS_PER_TOKEN
+
+
+def test_cjk_counts_higher_than_flat_quarter():
+    """CJK glyphs are ~1 token each, far more than a flat len//4 would give."""
+    cjk = "这是一个测试" * 3  # 18 CJK glyphs
+    flat = len(cjk) // CHARS_PER_TOKEN
+    est = estimate_tokens(cjk)
+    assert est > flat
+    # Each glyph counts as ~1 token.
+    assert est == len(cjk)
+
+
+def test_mixed_cjk_and_ascii():
+    """Mixed text counts CJK per-glyph plus the ASCII part by chars/token."""
+    text = "user 名前 is 太郎"
+    est = estimate_tokens(text)
+    # 4 CJK glyphs counted individually, so the estimate must exceed the
+    # number of CJK glyphs alone.
+    assert est >= 4
+    assert est > len(text) // CHARS_PER_TOKEN
+
+
+def test_dense_json_denser_than_prose_rate():
+    """Punctuation-heavy JSON should estimate more tokens than a flat len//4."""
+    code = '{"a":1,"b":[2,3],"c":{"d":true}}'
+    assert estimate_tokens(code) > len(code) // CHARS_PER_TOKEN
+
+
+def test_truncate_keeps_short_text_unchanged():
+    text = "short enough"
+    assert truncate_to_tokens(text, 100) == text
+
+
+def test_truncate_long_prose_fits_budget():
+    text = "word " * 200
+    out = truncate_to_tokens(text, 10)
+    assert out.endswith("...")
+    assert len(out) < len(text)
+    # Result lands near the budget (allow the trailing-ellipsis overhead).
+    assert estimate_tokens(out) <= 12
+
+
+def test_truncate_cjk_respects_budget():
+    cjk = "测试" * 100
+    out = truncate_to_tokens(cjk, 5)
+    assert out.endswith("...")
+    # ~5 glyphs plus the ellipsis overhead, nowhere near the full 200 glyphs.
+    assert estimate_tokens(out) <= 7


### PR DESCRIPTION
Two small, isolated correctness fixes surfaced by the audit. Stdlib-only, no new dependencies, no benchmark-path behaviour change for the common cases.

## #104 — content-aware token estimate (`taosmd/context_assembler.py`)
`estimate_tokens` / `truncate_to_tokens` used a flat `len(text) // 4`. That silently under-counts dense content (code, JSON) and badly under-counts CJK, where each glyph is roughly its own token — risking context overflow.

The heuristic is now content-aware but still cheap, deterministic, and dependency-free:
- CJK / Japanese / Korean glyphs count as ~1 token each (Unicode-range check).
- Punctuation/symbol-heavy text (code, JSON) uses ~3 chars/token.
- Plain prose stays at the classic ~4 chars/token, so prose estimates are unchanged.

`truncate_to_tokens` walks the string with the same cost model so a truncated string lands near `max_tokens` for prose, dense, and CJK input. Public API/signatures are unchanged (`CHARS_PER_TOKEN` is still exported).

**Deliberately NOT tiktoken.** taOSmd targets offline / SBC / multi-machine deployments; tiktoken is a heavyweight, GPT-specific dependency that doesn't match our local-model tokenizers anyway. A good heuristic is the right tool here.

## #109 — explicit intent tie-break (`taosmd/intent_classifier.py`)
On a score tie, `max(scores, key=scores.get)` resolved the winner by whichever intent appeared first in `INTENT_PATTERNS` — deterministic, but an implicit side effect of dict order.

> Note: the audit labelled this "non-deterministic". It was actually deterministic-but-implicit. This change codifies the intended priority; it does not fix randomness.

Tie-break now follows an explicit `INTENT_PRIORITY` tuple (most-specific first). Non-tie routing is unchanged. The one behaviour change is intentional: a genuine factual/technical tie (e.g. "What is the architecture") now routes to `technical` rather than falling through to generic `factual`.

## Tests
- `tests/test_token_estimate.py` (new): CJK estimates exceed flat `//4`, JSON is denser than prose rate, prose is unchanged, truncation respects the budget for prose and CJK.
- `tests/test_intent_timeline.py`: added tie-break tests asserting the explicit priority wins and that priority is independent of pattern declaration order.

Full suite: 219 passed (was 209). No existing test asserted exact token counts, so none needed updating.
