### PR TITLE
fix(audit): cron-install quoting + secret-filter coverage + tests (#97 #98 #99)

### DIFF
--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -173,7 +174,29 @@ def _install_cron(data_dir: str):
     lessons, writes new KG triples, defers low-confidence contradictions
     to the pending-decisions queue).
     """
-    cron_cmd = f'0 3 * * * cd {data_dir} && python3 -c "import asyncio; from taosmd.archive import ArchiveStore; from taosmd.catalog_pipeline import CatalogPipeline; a = ArchiveStore(archive_dir=\\"{data_dir}/archive\\", index_path=\\"{data_dir}/archive-index.db\\"); asyncio.run(a.init()); asyncio.run(a.compress_old_files()); asyncio.run(a.close()); p = CatalogPipeline(archive_dir=\\"{data_dir}/archive\\", sessions_dir=\\"{data_dir}/sessions\\", catalog_db=\\"{data_dir}/session-catalog.db\\", crystals_db=\\"{data_dir}/crystals.db\\", kg_db=\\"{data_dir}/knowledge-graph.db\\"); asyncio.run(p.init()); asyncio.run(p.index_yesterday()); asyncio.run(p.close())" 2>/dev/null'
+    # All path/user values are passed through shlex.quote so a data_dir
+    # containing shell metacharacters (spaces, $, ;, &&, backticks, etc.)
+    # cannot break out of the command line that /bin/sh runs for cron. The
+    # quoted dir is assigned to a shell variable once and the Python snippet
+    # reads it from the TAOSMD_DATA_DIR environment variable, so the path is
+    # never re-interpolated inside the Python string literals.
+    q_dir = shlex.quote(data_dir)
+    py_snippet = (
+        "import asyncio, os; "
+        "from taosmd.archive import ArchiveStore; "
+        "from taosmd.catalog_pipeline import CatalogPipeline; "
+        "d = os.environ['TAOSMD_DATA_DIR']; "
+        "a = ArchiveStore(archive_dir=d + '/archive', index_path=d + '/archive-index.db'); "
+        "asyncio.run(a.init()); asyncio.run(a.compress_old_files()); asyncio.run(a.close()); "
+        "p = CatalogPipeline(archive_dir=d + '/archive', sessions_dir=d + '/sessions', "
+        "catalog_db=d + '/session-catalog.db', crystals_db=d + '/crystals.db', "
+        "kg_db=d + '/knowledge-graph.db'); "
+        "asyncio.run(p.init()); asyncio.run(p.index_yesterday()); asyncio.run(p.close())"
+    )
+    cron_cmd = (
+        f"0 3 * * * cd {q_dir} && TAOSMD_DATA_DIR={q_dir} "
+        f"python3 -c {shlex.quote(py_snippet)} 2>/dev/null"
+    )
 
     try:
         existing = subprocess.run(["crontab", "-l"], capture_output=True, text=True)

--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -183,14 +183,15 @@ def _install_cron(data_dir: str):
     q_dir = shlex.quote(data_dir)
     py_snippet = (
         "import asyncio, os; "
+        "from os.path import join as j; "
         "from taosmd.archive import ArchiveStore; "
         "from taosmd.catalog_pipeline import CatalogPipeline; "
         "d = os.environ['TAOSMD_DATA_DIR']; "
-        "a = ArchiveStore(archive_dir=d + '/archive', index_path=d + '/archive-index.db'); "
+        "a = ArchiveStore(archive_dir=j(d, 'archive'), index_path=j(d, 'archive-index.db')); "
         "asyncio.run(a.init()); asyncio.run(a.compress_old_files()); asyncio.run(a.close()); "
-        "p = CatalogPipeline(archive_dir=d + '/archive', sessions_dir=d + '/sessions', "
-        "catalog_db=d + '/session-catalog.db', crystals_db=d + '/crystals.db', "
-        "kg_db=d + '/knowledge-graph.db'); "
+        "p = CatalogPipeline(archive_dir=j(d, 'archive'), sessions_dir=j(d, 'sessions'), "
+        "catalog_db=j(d, 'session-catalog.db'), crystals_db=j(d, 'crystals.db'), "
+        "kg_db=j(d, 'knowledge-graph.db')); "
         "asyncio.run(p.init()); asyncio.run(p.index_yesterday()); asyncio.run(p.close())"
     )
     cron_cmd = (

--- a/taosmd/secret_filter.py
+++ b/taosmd/secret_filter.py
@@ -4,8 +4,8 @@ Detects and redacts sensitive tokens (API keys, passwords, JWTs, etc.)
 before text is stored in any memory layer. Runs on every ingest path:
 vector memory, knowledge graph, and archive.
 
-14 pattern categories covering all major cloud providers, CI/CD tokens,
-and common secret formats.
+Covers all major cloud providers (AWS, GCP, Azure), payment and email
+providers (Stripe, SendGrid), CI/CD tokens, and common secret formats.
 """
 
 from __future__ import annotations
@@ -16,6 +16,11 @@ import re
 SECRET_PATTERNS: list[tuple[str, re.Pattern, str]] = [
     ("openai_key", re.compile(r"sk-[A-Za-z0-9]{20,}"), "[REDACTED:openai_key]"),
     ("anthropic_key", re.compile(r"sk-ant-[A-Za-z0-9\-]{20,}"), "[REDACTED:anthropic_key]"),
+    ("stripe_key", re.compile(r"sk_(?:live|test)_[0-9a-zA-Z]{24,}"), "[REDACTED:stripe_key]"),
+    ("sendgrid_key", re.compile(r"SG\.[\w-]{22}\.[\w-]{43}"), "[REDACTED:sendgrid_key]"),
+    ("gcp_service_account", re.compile(r'"type"\s*:\s*"service_account"'), "[REDACTED:gcp_service_account]"),
+    ("gcp_private_key", re.compile(r'"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----'), "[REDACTED:gcp_private_key]"),
+    ("azure_storage_key", re.compile(r"AccountKey=[A-Za-z0-9+/=]{40,}"), "[REDACTED:azure_storage_key]"),
     ("github_pat", re.compile(r"ghp_[A-Za-z0-9]{36,}"), "[REDACTED:github_pat]"),
     ("github_oauth", re.compile(r"gho_[A-Za-z0-9]{36,}"), "[REDACTED:github_oauth]"),
     ("github_app", re.compile(r"(?:ghu|ghs|ghr)_[A-Za-z0-9]{36,}"), "[REDACTED:github_token]"),

--- a/tests/test_secret_filter.py
+++ b/tests/test_secret_filter.py
@@ -1,0 +1,184 @@
+"""Tests for taosmd.secret_filter — detection, redaction, and filter modes.
+
+Behaviour-only, fully offline (no models, no network). Covers every existing
+pattern category plus the cloud/payment/email providers added in the audit
+batch (Stripe, SendGrid, GCP, Azure).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from taosmd.secret_filter import (
+    SECRET_PATTERNS,
+    contains_secrets,
+    filter_text,
+    redact_secrets,
+)
+
+
+# Synthetic Stripe-style key bodies, assembled at runtime so no contiguous
+# real-looking key literal sits in source (avoids tripping push/secret scanners
+# while still exercising the sk_(live|test)_ regex).
+_STRIPE_BODY = "0123456789abcdefABCDEFxyz"  # 25 chars, >= the required 24
+
+
+def _stripe(kind: str) -> str:
+    return "sk_" + kind + "_" + _STRIPE_BODY
+
+
+# Each case: (name, sample_text, expected_redaction_type)
+# The expected type is the placeholder fragment that should appear after
+# redaction (and the name reported by redact_secrets()).
+SECRET_CASES = [
+    # --- existing patterns ---
+    ("openai", "key is sk-ABCDEFGHIJKLMNOPQRSTUVWX here", "openai_key"),
+    ("anthropic", "sk-ant-ABCDEFGHIJKLMNOPQRSTUVWX1234", "anthropic_key"),
+    ("github_pat", "ghp_" + "A" * 36, "github_pat"),
+    ("github_oauth", "gho_" + "B" * 36, "github_oauth"),
+    ("github_app_ghu", "ghu_" + "C" * 36, "github_token"),
+    ("github_app_ghs", "ghs_" + "D" * 36, "github_token"),
+    ("github_app_ghr", "ghr_" + "E" * 36, "github_token"),
+    ("gitlab", "glpat-ABCDEFGHIJKLMNOPQRST", "gitlab_pat"),
+    ("aws_access_key", "AKIAIOSFODNN7EXAMPLE", "aws_key"),
+    ("aws_secret", "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws_secret"),
+    ("bearer", "Authorization: Bearer abc.def-ghi_jkl+mno/pqr=", "bearer"),
+    (
+        "jwt",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "jwt",
+    ),
+    ("npm", "npm_" + "Z" * 36, "npm_token"),
+    ("digitalocean", "dop_v1_" + "a" * 64, "do_token"),
+    ("slack", "xoxb-0123456789-ABCDEFGHIJ", "slack_token"),
+    ("generic_api_key", "api_key=ABCDEFGHIJKLMNOPQRSTUVWX", "api_key"),
+    (
+        "pem_private_key",
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIabc123\n-----END RSA PRIVATE KEY-----",
+        "private_key",
+    ),
+    ("password_field", "password: hunter2pass", "password"),
+    ("connection_string", "postgres://user:pw@host:5432/db", "connection_string"),
+    ("private_tag", "<private>my secret note</private>", "private"),
+    # --- new patterns (audit batch) ---
+    ("stripe_live", _stripe("live"), "stripe_key"),
+    ("stripe_test", _stripe("test"), "stripe_key"),
+    (
+        "sendgrid",
+        "SG." + "A" * 22 + "." + "B" * 43,
+        "sendgrid_key",
+    ),
+    (
+        "gcp_service_account",
+        '{"type": "service_account", "project_id": "demo"}',
+        "gcp_service_account",
+    ),
+    (
+        "gcp_private_key",
+        '{"private_key": "-----BEGIN PRIVATE KEY-----\\nMIIabc"}',
+        "gcp_private_key",
+    ),
+    (
+        "azure_account_key",
+        "AccountKey=" + "A" * 44 + "==",
+        "azure_storage_key",
+    ),
+    (
+        "azure_connection_string",
+        "DefaultEndpointsProtocol=https;AccountName=demo;"
+        "AccountKey=" + "B" * 44 + "==;EndpointSuffix=core.windows.net",
+        "azure_storage_key",
+    ),
+]
+
+
+@pytest.mark.parametrize("name, sample, _type", SECRET_CASES)
+def test_contains_secrets_detects(name, sample, _type):
+    assert contains_secrets(sample) is True, f"{name} not detected"
+
+
+@pytest.mark.parametrize("name, sample, expected_type", SECRET_CASES)
+def test_redact_secrets_redacts(name, sample, expected_type):
+    redacted, found = redact_secrets(sample)
+    placeholder = f"[REDACTED:{expected_type}]"
+    assert placeholder in redacted, f"{name}: {placeholder} missing from {redacted!r}"
+    # The redacted output must not contain the raw secret material that the
+    # placeholder replaced (sanity check that substitution actually happened).
+    assert redacted != sample, f"{name}: text unchanged after redaction"
+    assert found, f"{name}: no redaction types reported"
+
+
+def test_redact_reports_pattern_name():
+    _, found = redact_secrets("ghp_" + "A" * 36)
+    assert "github_pat" in found
+
+
+def test_redact_handles_multiple_secrets_at_once():
+    text = f"openai sk-ABCDEFGHIJKLMNOPQRSTUVWX and stripe {_stripe('live')} together"
+    redacted, found = redact_secrets(text)
+    assert "[REDACTED:openai_key]" in redacted
+    assert "[REDACTED:stripe_key]" in redacted
+    assert "openai_key" in found and "stripe_key" in found
+
+
+# --- clean text must pass untouched ---
+
+CLEAN_SAMPLES = [
+    "This is a perfectly normal sentence about cats and dogs.",
+    "The user prefers dark mode and lives in Berlin.",
+    "Meeting notes: discussed Q3 roadmap, no blockers.",
+    "I bought sketches for the new design (skateboarding theme).",
+    "",
+]
+
+
+@pytest.mark.parametrize("sample", CLEAN_SAMPLES)
+def test_clean_text_not_flagged(sample):
+    assert contains_secrets(sample) is False
+
+
+@pytest.mark.parametrize("sample", CLEAN_SAMPLES)
+def test_clean_text_unchanged_by_redact(sample):
+    redacted, found = redact_secrets(sample)
+    assert redacted == sample
+    assert found == []
+
+
+# --- filter_text modes ---
+
+def test_filter_text_redact_mode_redacts():
+    out = filter_text(f"token {_stripe('live')}", mode="redact")
+    assert "[REDACTED:stripe_key]" in out
+    assert _STRIPE_BODY not in out
+
+
+def test_filter_text_default_mode_is_redact():
+    out = filter_text(f"token {_stripe('live')}")
+    assert "[REDACTED:stripe_key]" in out
+
+
+def test_filter_text_warn_mode_returns_unchanged():
+    text = f"token {_stripe('live')}"
+    assert filter_text(text, mode="warn") == text
+
+
+def test_filter_text_reject_mode_raises_on_secret():
+    with pytest.raises(ValueError):
+        filter_text(f"token {_stripe('live')}", mode="reject")
+
+
+def test_filter_text_reject_mode_passes_clean_text():
+    text = "nothing secret here at all"
+    assert filter_text(text, mode="reject") == text
+
+
+def test_pattern_table_is_well_formed():
+    # Every entry is (name, compiled_pattern, replacement) and names are unique.
+    names = [name for name, _, _ in SECRET_PATTERNS]
+    assert len(names) == len(set(names)), "duplicate pattern names"
+    for name, pattern, replacement in SECRET_PATTERNS:
+        assert isinstance(name, str) and name
+        assert hasattr(pattern, "search")
+        assert replacement.startswith("[REDACTED:")


### PR DESCRIPTION
## Security audit batch (stdlib-only, standalone-safe)

Three verified-real fixes from the security audit. No new dependencies — pure stdlib (`shlex`, `re`). Behaviour matches existing module style.

### #97 — Shell injection in cron install (`taosmd/auto_setup.py`)
`_install_cron` f-stringed `data_dir` straight into the `/bin/sh` command line cron executes (`cd {data_dir} && python3 -c "..."`). A `data_dir` containing shell metacharacters (spaces, `;`, `&&`, `$`, backticks) could break out and run arbitrary commands.

Fix: import `shlex`, pass `data_dir` through `shlex.quote()` for the `cd` target and the `TAOSMD_DATA_DIR=` assignment, and have the Python `-c` snippet read the path from `os.environ['TAOSMD_DATA_DIR']` instead of re-interpolating it inside Python string literals. The path is now quoted exactly once, at the shell boundary. Verified: a `data_dir` of `/home/user/my data; rm -rf $HOME && evil` is fully neutralised (treated as a literal directory name); the generated line parses cleanly under `shlex` and the embedded snippet compiles as valid Python.

### #98 — secret_filter coverage gaps (`taosmd/secret_filter.py`)
Added patterns for providers the existing table missed (the existing `sk-` openai pattern uses a hyphen and does not catch `sk_` Stripe keys):
- **Stripe** — `sk_(live|test)_[0-9a-zA-Z]{24,}`
- **SendGrid** — `SG\.[\w-]{22}\.[\w-]{43}`
- **GCP service-account** — JSON markers `"type": "service_account"` and `"private_key": "-----BEGIN PRIVATE KEY-----`
- **Azure storage** — `AccountKey=[A-Za-z0-9+/=]{40,}` (also covers the `DefaultEndpointsProtocol=...AccountKey=...` connection-string form)

Both `redact_secrets` and `contains_secrets` pick these up (they iterate the shared `SECRET_PATTERNS` table). Existing GitHub-token and PEM coverage was left untouched — no duplication.

### #99 — secret_filter tests (`tests/test_secret_filter.py`)
New behaviour-only, fully offline test module (no models, no network):
- Every existing pattern (GitHub PAT/OAuth/app, AWS key/secret, openai, anthropic, gitlab, bearer, JWT, npm, DigitalOcean, slack, generic api key, PEM, password, connection string, private tag) and every new one (Stripe live/test, SendGrid, GCP service-account, GCP private key, Azure key + connection string) is asserted detected by `contains_secrets` and redacted by `redact_secrets`.
- Clean text passes untouched.
- `filter_text` modes: `redact` redacts, default == redact, `warn` returns unchanged, `reject` raises on a secret and passes clean text.
- Pattern-table well-formedness (unique names, valid replacements).

Stripe test fixtures are assembled at runtime via a small helper so no contiguous key-shaped literal sits in source (avoids tripping push/secret scanners) while still exercising the regex.

### Validation
- `python3 -m pytest -q` — **281 passed** (72 of them in the new `tests/test_secret_filter.py`).

### Notes
- The audit was **stale on GitHub tokens and SSH/PEM keys** — those are already covered by `secret_filter.py` and were intentionally not duplicated.
- All changes are stdlib-only and standalone-safe.
