### PR TITLE
fix(audit): SQLite WAL mode for concurrent agents (#101)

### DIFF
--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -1,0 +1,39 @@
+"""Shared SQLite connection helper.
+
+Every persistent store in the package opens its own SQLite database. By
+default ``sqlite3.connect`` uses the rollback-journal mode, which takes an
+exclusive lock for the duration of a write and lets only a single writer
+touch the file at a time. When several agents (or several processes on the
+same machine) share a memory store, that serialisation surfaces as
+``SQLITE_BUSY`` errors.
+
+``connect`` centralises the fix: it enables write-ahead logging (WAL), which
+lets readers proceed concurrently with a writer, and sets a busy timeout so a
+contended writer waits and retries rather than failing immediately. Both are
+plain PRAGMAs with no extra dependencies; standalone behaviour is unchanged
+apart from the journal mode.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+# Allow a contended connection to block-and-retry for this many milliseconds
+# before raising ``sqlite3.OperationalError: database is locked``.
+BUSY_TIMEOUT_MS = 5000
+
+
+def connect(db_path: Union[str, Path]) -> sqlite3.Connection:
+    """Open a SQLite connection in WAL mode with a busy timeout.
+
+    Drop-in replacement for ``sqlite3.connect(db_path)``. Callers that need a
+    ``row_factory`` or other connection attributes should set them on the
+    returned connection as before.
+    """
+    conn = sqlite3.connect(db_path)
+    # WAL is harmless (silently stays "memory") on ``:memory:`` databases.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    return conn

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -17,6 +17,7 @@ apart from the journal mode.
 from __future__ import annotations
 
 import sqlite3
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -33,7 +34,26 @@ def connect(db_path: Union[str, Path]) -> sqlite3.Connection:
     returned connection as before.
     """
     conn = sqlite3.connect(db_path)
-    # WAL is harmless (silently stays "memory") on ``:memory:`` databases.
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    # ``PRAGMA journal_mode`` echoes the journal mode actually in effect. WAL
+    # can silently refuse to engage on filesystems without shared-memory/mmap
+    # support (notably some network mounts), where it falls back to the prior
+    # rollback journal. ``:memory:`` databases report "memory". We read the
+    # result so the fallback is observable rather than silent; the connection
+    # stays fully usable either way, so we deliberately do not raise.
+    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    mode = (row[0] if row else "") or ""
+    # The connection is fully usable whichever journal mode took effect, so we
+    # do not raise on a fallback. We surface it as a warning instead of letting
+    # it pass silently; ``:memory:`` legitimately reports "memory".
+    if mode.lower() not in ("wal", "memory"):
+        warnings.warn(
+            f"SQLite WAL mode not enabled for {db_path!r} "
+            f"(journal_mode={mode!r}); concurrent access may hit "
+            "'database is locked'.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    # busy_timeout takes an integer literal; SQLite does not allow bound
+    # parameters in PRAGMA statements, and the value is an internal constant.
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
     return conn

--- a/taosmd/access_tracker.py
+++ b/taosmd/access_tracker.py
@@ -15,6 +15,8 @@ import sqlite3
 import time
 from pathlib import Path
 
+from . import _db
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS access_log (
     memory_key TEXT NOT NULL,
@@ -49,7 +51,7 @@ class AccessTracker:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from . import _db
+
 logger = logging.getLogger(__name__)
 
 # Event types
@@ -95,7 +97,7 @@ class ArchiveStore:
     async def init(self) -> None:
         self._archive_dir.mkdir(parents=True, exist_ok=True)
         Path(self._index_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._index_path)
+        self._conn = _db.connect(self._index_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(INDEX_SCHEMA)
         self._conn.commit()

--- a/taosmd/browsing_history.py
+++ b/taosmd/browsing_history.py
@@ -10,6 +10,8 @@ import sqlite3
 import time
 from pathlib import Path
 
+from . import _db
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS browsing_history (
     url TEXT PRIMARY KEY,
@@ -34,7 +36,7 @@ class BrowsingHistoryStore:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/crystallize.py
+++ b/taosmd/crystallize.py
@@ -18,6 +18,8 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from . import _db
+
 if TYPE_CHECKING:
     from .knowledge_graph import TemporalKnowledgeGraph
 
@@ -67,7 +69,7 @@ class CrystalStore:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -15,6 +15,8 @@ import sqlite3
 import time
 from pathlib import Path
 
+from . import _db
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS kg_entities (
     id TEXT PRIMARY KEY,
@@ -80,7 +82,7 @@ class TemporalKnowledgeGraph:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/pending_decisions.py
+++ b/taosmd/pending_decisions.py
@@ -36,6 +36,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from . import _db
+
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS kg_pending_decisions (
@@ -87,7 +89,7 @@ class PendingDecisionsStore:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/reflect.py
+++ b/taosmd/reflect.py
@@ -18,6 +18,8 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from . import _db
+
 if TYPE_CHECKING:
     from .knowledge_graph import TemporalKnowledgeGraph
 
@@ -134,7 +136,7 @@ class InsightStore:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/session_catalog.py
+++ b/taosmd/session_catalog.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import httpx
 
-from taosmd import prompts
+from taosmd import _db, prompts
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ class SessionCatalog:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/taosmd/taosmd_backend.py
+++ b/taosmd/taosmd_backend.py
@@ -12,7 +12,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from . import __version__
+from . import __version__, _db
 from .backend import MemoryBackend
 
 SETTINGS_SCHEMA = """
@@ -82,7 +82,7 @@ class TaOSmdBackend(MemoryBackend):
     async def init(self) -> None:
         """Initialise settings database."""
         Path(self._settings_db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._settings_db_path)
+        self._conn = _db.connect(self._settings_db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SETTINGS_SCHEMA + AGENT_CONFIG_SCHEMA)
         self._conn.commit()
@@ -260,7 +260,7 @@ class TaOSmdBackend(MemoryBackend):
         """Ensure the settings DB connection is open (auto-init if needed)."""
         if self._conn is None:
             Path(self._settings_db_path).parent.mkdir(parents=True, exist_ok=True)
-            self._conn = sqlite3.connect(self._settings_db_path)
+            self._conn = _db.connect(self._settings_db_path)
             self._conn.row_factory = sqlite3.Row
             self._conn.executescript(SETTINGS_SCHEMA + AGENT_CONFIG_SCHEMA)
             self._conn.commit()

--- a/taosmd/taosmd_backend.py
+++ b/taosmd/taosmd_backend.py
@@ -81,6 +81,9 @@ class TaOSmdBackend(MemoryBackend):
 
     async def init(self) -> None:
         """Initialise settings database."""
+        # Guard against re-init leaking an already-open connection.
+        if self._conn is not None:
+            return
         Path(self._settings_db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = _db.connect(self._settings_db_path)
         self._conn.row_factory = sqlite3.Row

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -15,6 +15,8 @@ import sqlite3
 import time
 from pathlib import Path
 
+from . import _db
+
 logger = logging.getLogger(__name__)
 
 SCHEMA = """
@@ -90,7 +92,7 @@ class VectorMemory:
 
     async def init(self, http_client=None) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()


### PR DESCRIPTION
## What

Routes every `sqlite3.connect(...)` in the package through a new shared helper, `taosmd/_db.py:connect()`, which enables WAL journal mode and a 5s busy timeout on each connection.

## Why

By default `sqlite3.connect` opens databases in rollback-journal mode. That mode takes an exclusive lock for the duration of a write and permits only one writer at a time, so when multiple agents (or multiple processes on the same machine) share a memory store, contention surfaces as `SQLITE_BUSY` / "database is locked" errors.

- **WAL** (`PRAGMA journal_mode=WAL`) lets readers proceed concurrently with a writer instead of blocking, which is exactly the multi-machine / concurrent-agent access pattern taOSmd targets.
- **busy_timeout** (`PRAGMA busy_timeout=5000`) makes a contended writer block-and-retry for up to 5s rather than failing immediately.

Both are plain PRAGMAs: **no new dependencies, no benchmark impact**. Standalone single-process behaviour is unchanged apart from the journal mode (and WAL silently stays `memory` on `:memory:` databases, so it is harmless there).

## Call sites routed

`archive.py`, `vector_memory.py`, `knowledge_graph.py`, `access_tracker.py`, `browsing_history.py`, `crystallize.py`, `pending_decisions.py`, `reflect.py`, `session_catalog.py`, `taosmd_backend.py` (x2). Existing `row_factory` / other per-connection attributes are preserved (set on the returned connection as before).

## Tests

Full suite green: `209 passed`. Verified WAL + busy_timeout are actually applied on a real file DB and that `:memory:` stays in memory mode.