### PR TITLE
fix(packaging): ship docs/agent-rules.md as package data (#66)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "taosmd"
 version = "0.2.0"
@@ -18,6 +22,12 @@ benchmarks = ["mem0ai>=0.1.0", "mempalace"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]
+
+# Ship runtime data files (e.g. docs/agent-rules.md, read at runtime via
+# importlib.resources.files("taosmd")). Without this they are omitted from the
+# wheel and agent_rules() raises FileNotFoundError on a pip install (#66).
+[tool.setuptools.package-data]
+taosmd = ["docs/*.md"]
 
 [project.scripts]
 taosmd = "taosmd.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = ["taosmd*"]
 # importlib.resources.files("taosmd")). Without this they are omitted from the
 # wheel and agent_rules() raises FileNotFoundError on a pip install (#66).
 [tool.setuptools.package-data]
-taosmd = ["docs/*.md"]
+taosmd = ["docs/**/*.md"]
 
 [project.scripts]
 taosmd = "taosmd.cli:main"


### PR DESCRIPTION
## Summary
Fixes #66. `taosmd.agent_rules()` reads `docs/agent-rules.md` via `importlib.resources.files("taosmd")` at runtime, but the wheel didn't include it (no `package-data`, no `MANIFEST.in`), so a `pip install` raised `FileNotFoundError` — and the documented agent-install flow depends on `agent_rules()`.

## Fix
- Add `[tool.setuptools.package-data] taosmd = ["docs/*.md"]` so runtime data files ship in the wheel.
- Add an explicit `[build-system]` table (setuptools) for reproducible builds.

## Verification
Built a wheel (`pip wheel . --no-deps`) and confirmed `taosmd/docs/agent-rules.md` is now inside it (it was absent before this change).

Closes #66.