### PR TITLE
feat(api): MCP server for memory (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,11 +308,53 @@ await vmem.init()
 
 Use it when the vector-store footprint or CPU distance cost is your binding constraint rather than recall — e.g. an Orange Pi / Rock 5 holding a large memory. Keep it off on a GPU box where full-precision cosine is effectively free.
 
+## MCP server
+
+taOSmd can expose its memory over the [Model Context Protocol](https://modelcontextprotocol.io) so any MCP-capable agent (Claude Desktop, Cursor, Codex, OpenWebUI, …) can read and write memory directly — no custom integration. The server is local-first and offline: it speaks the **stdio** transport (the standard for desktop MCP clients), with no network listener and no cloud dependency.
+
+The MCP SDK is an **optional dependency**, so the core install stays lean:
+
+```bash
+pip install taosmd[mcp]
+```
+
+Run the server over stdio:
+
+```bash
+taosmd mcp                       # serves $TAOSMD_DATA_DIR (or ~/.taosmd)
+taosmd mcp --mcp-data-dir ./mem  # or point it at a specific data dir
+```
+
+Point an MCP client at it by spawning that command. For example, in a Claude Desktop / Cursor MCP config:
+
+```json
+{
+  "mcpServers": {
+    "taosmd": {
+      "command": "taosmd",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Tools exposed (each takes an `agent` argument, honouring the same per-agent isolation as the Python API):
+
+| Tool | Purpose |
+| --- | --- |
+| `memory_ingest(text, agent)` | Store a transcript/note in an agent's memory |
+| `memory_search(query, agent, limit=5)` | Retrieve passages relevant to a query |
+| `memory_pending_list(agent)` | List KG-update decisions awaiting review |
+| `memory_pending_resolve(decision_id, decision, note="")` | Resolve a pending decision (`accept`/`reject`/`modify`) |
+| `memory_stats(agent)` | Lightweight per-agent stats |
+
+It reuses the same shared service layer as the [local HTTP/REST server](#api), so behaviour matches the Python API and CLI exactly. The MCP server is additive and opt-in — it only runs when you start it; standalone use is untouched, and `import taosmd` works whether or not the `mcp` SDK is installed.
+
 ## Key Features
 
 - **97.0% end-to-end Judge accuracy** on LongMemEval-S benchmark (SOTA)
 - **Zero cloud dependencies** — runs entirely on local hardware
-- **Framework-agnostic** — Python API + CLI work with any agent framework (MCP and local HTTP API in progress)
+- **Framework-agnostic** — Python API, CLI, [MCP server](#mcp-server), and local HTTP/REST API work with any agent framework
 - **Hybrid search** — semantic similarity + keyword overlap boosting
 - **Temporal facts** — validity windows, point-in-time queries
 - **Contradiction detection** — corrected facts supersede the old value; recall returns only the active fact, so corrections stop resurfacing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 dev = ["pytest", "pytest-asyncio"]
 local = ["sentence-transformers"]
 benchmarks = ["mem0ai>=0.1.0", "mempalace"]
+# MCP server surface (#84) — optional so the core install stays lean.
+# Install with: pip install taosmd[mcp]
+mcp = ["mcp"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]

--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -28,6 +28,11 @@ from .api import ingest, search, list_pending_decisions, resolve_pending_decisio
 # The MCP server (#84) reuses the same `service` core.
 from . import service
 from .http_server import serve
+
+# MCP server (#84). The module imports the `mcp` SDK lazily, so this import
+# never fails when the optional dependency is absent; only building/running a
+# server raises MissingMCPDependencyError. Importing `taosmd` stays lean.
+from . import mcp_server
 from .cross_encoder import CrossEncoderReranker
 from .access_tracker import AccessTracker
 from .preference_extractor import extract_preferences
@@ -94,6 +99,7 @@ __all__ = [
     # Activation surfaces
     "service",
     "serve",
+    "mcp_server",
     "CrossEncoderReranker",
     "classify_intent",
     "get_search_strategy",

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -468,6 +468,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Data dir for served memory (default: $TAOSMD_DATA_DIR or ~/.taosmd)",
     )
 
+    # ----- mcp subcommand (MCP server over stdio) -----------------------
+    mcp_p = sub.add_parser(
+        "mcp",
+        help="Run the MCP memory server over stdio (requires taosmd[mcp])",
+    )
+    mcp_p.add_argument(
+        "--mcp-data-dir", dest="mcp_data_dir", default=None,
+        help="Data dir for served memory (default: $TAOSMD_DATA_DIR or ~/.taosmd)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.cmd == "serve":
@@ -475,6 +485,14 @@ def main(argv: list[str] | None = None) -> int:
         return http_server.serve(
             host=args.host, port=args.port, data_dir=args.serve_data_dir,
         )
+
+    if args.cmd == "mcp":
+        from . import mcp_server  # noqa: PLC0415
+        try:
+            return mcp_server.serve_stdio(data_dir=args.mcp_data_dir)
+        except mcp_server.MissingMCPDependencyError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
 
     registry = AgentRegistry(args.data_dir)
 

--- a/taosmd/mcp_server.py
+++ b/taosmd/mcp_server.py
@@ -1,0 +1,170 @@
+"""MCP server for taOSmd memory over stdio (#84).
+
+An activation surface so any MCP-capable agent (Claude, Cursor, Codex,
+OpenWebUI, …) can read and write taOSmd memory directly, without a custom
+integration. It is a thin shell over :mod:`taosmd.service` — the same shared
+core the local HTTP/REST server (#85) sits on — so behaviour matches the
+Python API and CLI exactly.
+
+Design choices (matching the project's local-first, offline, additive vision):
+
+* **optional dependency** — the ``mcp`` Python SDK is imported lazily/guarded
+  here, so ``import taosmd`` (and standalone use) never fails when ``mcp`` is
+  not installed. Install with ``pip install taosmd[mcp]``.
+* **local-first / offline** — the server speaks the stdio transport (the
+  standard for desktop MCP clients); there is no network listener and no
+  cloud dependency.
+* **additive + opt-in** — the server only runs when you start it via
+  ``taosmd mcp`` (or :func:`serve_stdio`); the Python API, CLI, and HTTP
+  server are untouched.
+* **per-agent scoping** — every tool takes an ``agent`` argument and forwards
+  it to the service layer, honouring the same isolation as the Python API.
+
+Concurrency model
+-----------------
+FastMCP runs each tool call on its own asyncio event loop, but the underlying
+stores hold thread-affine SQLite connections (created and cached on first
+use). So rather than running service coroutines directly on FastMCP's loop —
+which would bind those connections to whichever loop happens to be live — every
+async service call is dispatched onto a single, long-lived background
+event-loop thread (the same :class:`taosmd.http_server._ServiceLoop` the HTTP
+server uses). All DB work therefore happens in one context, sequentially,
+exactly like the single-threaded Python API. The tools ``await`` the
+cross-thread result so FastMCP's loop is never blocked.
+"""
+
+from __future__ import annotations
+
+from . import service
+from .http_server import _ServiceLoop
+
+
+class MissingMCPDependencyError(RuntimeError):
+    """Raised when the optional ``mcp`` SDK is not installed.
+
+    The MCP server is an optional surface; the core package installs without
+    it. Install the extra with ``pip install taosmd[mcp]``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "the MCP server requires the optional 'mcp' SDK. "
+            "Install it with: pip install taosmd[mcp]"
+        )
+
+
+def _require_fastmcp():
+    """Import :class:`FastMCP` lazily, with a clear error if mcp is absent."""
+    try:
+        from mcp.server.fastmcp import FastMCP  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised when mcp absent
+        raise MissingMCPDependencyError() from exc
+    return FastMCP
+
+
+def build_server(data_dir=None, *, runner: _ServiceLoop | None = None):
+    """Build (but do not run) a FastMCP server bound to ``data_dir``.
+
+    Registers the five memory tools, each routing to :mod:`taosmd.service` on
+    the shared service-loop thread. Returns the configured ``FastMCP`` instance
+    (its ``_taosmd_service_loop`` attribute holds the :class:`_ServiceLoop` so
+    callers/tests can close it on teardown). ``runner`` lets a caller supply an
+    existing loop (e.g. tests); otherwise one is created here.
+
+    Raises :class:`MissingMCPDependencyError` if the ``mcp`` SDK is not
+    installed.
+    """
+    FastMCP = _require_fastmcp()
+
+    loop = runner if runner is not None else _ServiceLoop()
+    mcp = FastMCP("taosmd")
+    mcp._taosmd_service_loop = loop  # for teardown / introspection
+
+    async def _dispatch(coro):
+        """Run a service coroutine on the shared loop without blocking FastMCP."""
+        import asyncio  # noqa: PLC0415
+
+        return await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(coro, loop._loop)
+        )
+
+    @mcp.tool()
+    async def memory_ingest(text: str, agent: str) -> dict:
+        """Store a transcript or note in an agent's long-term memory.
+
+        Shelves ``text`` and embeds it so it can be retrieved later with
+        ``memory_search``. ``agent`` scopes the write to one agent's memory.
+        Returns ``{"archived", "agent", "data_dir"}``.
+        """
+        return await _dispatch(service.ingest(text, agent=agent, data_dir=data_dir))
+
+    @mcp.tool()
+    async def memory_search(query: str, agent: str, limit: int = 5) -> list[dict]:
+        """Search an agent's memory for passages relevant to ``query``.
+
+        Returns up to ``limit`` ranked hits, each with
+        ``text``/``source``/``timestamp``/``confidence``/``metadata``. Scoped
+        to ``agent``.
+        """
+        return await _dispatch(
+            service.search(query, agent=agent, data_dir=data_dir, limit=limit)
+        )
+
+    @mcp.tool()
+    async def memory_pending_list(agent: str) -> list[dict]:
+        """List unresolved knowledge-graph update decisions awaiting review.
+
+        These are KG updates the librarian deferred for a human (or agent) to
+        accept/reject. The queue is per install; ``agent`` is accepted for
+        symmetry with the other tools.
+        """
+        return await _dispatch(service.pending_list(agent=agent, data_dir=data_dir))
+
+    @mcp.tool()
+    async def memory_pending_resolve(
+        decision_id: str, decision: str, note: str = ""
+    ) -> dict:
+        """Resolve a pending decision with an explicit choice.
+
+        ``decision`` is one of ``accept`` / ``reject`` / ``modify``. ``note``
+        is an optional free-text justification. Returns
+        ``{"ok", "applied_kg", "resolution"}``.
+        """
+        return await _dispatch(
+            service.pending_resolve(
+                decision_id, decision, note=note, data_dir=data_dir
+            )
+        )
+
+    @mcp.tool()
+    async def memory_stats(agent: str) -> dict:
+        """Report lightweight stats for an agent's memory.
+
+        Returns ``{"agent", "data_dir", "registered", "created_at",
+        "last_ingest_at", "total_chunks"}``. Unknown agents report
+        ``registered=False`` with zeroed counters rather than erroring.
+        """
+        return await _dispatch(service.stats(agent=agent, data_dir=data_dir))
+
+    return mcp
+
+
+def serve_stdio(data_dir=None) -> int:
+    """Run the taOSmd MCP server over the stdio transport until the client exits.
+
+    This is the entry point for desktop MCP clients (Claude, Cursor, Codex):
+    they spawn ``taosmd mcp`` and speak MCP over stdin/stdout. Returns 0 on a
+    clean shutdown.
+
+    Raises :class:`MissingMCPDependencyError` if the ``mcp`` SDK is not
+    installed (the CLI turns this into a friendly message + non-zero exit).
+    """
+    mcp = build_server(data_dir)
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        mcp._taosmd_service_loop.close()
+    return 0
+
+
+__all__ = ["build_server", "serve_stdio", "MissingMCPDependencyError"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,139 @@
+"""Tests for taosmd.mcp_server — the MCP activation surface (#84).
+
+Skips cleanly when the optional ``mcp`` SDK is not installed. Offline + fast:
+the server is built against an isolated tmp data dir and the vector embedder is
+patched (same deterministic hash vector as tests/test_http_server.py and
+tests/test_api.py) so no ONNX/QMD model is needed.
+
+We don't spin up a full MCP client; instead we exercise the underlying tool
+callables that FastMCP registers, which is where all the service-layer routing
+lives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from taosmd import api as taosmd_api
+from taosmd import mcp_server
+
+
+def _patch_embedder(stores: dict) -> None:
+    """Deterministic 8-dim hash embedder so search finds matching text."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    """Build an MCP server against an isolated data dir with a patched embedder.
+
+    Yields the configured FastMCP instance. Initialises the stores on the
+    server's service-loop thread (so the thread-affine SQLite connections live
+    where the tools will use them), then tears everything down cleanly.
+    """
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    mcp = mcp_server.build_server(data_dir=str(data_dir))
+    loop = mcp._taosmd_service_loop
+
+    stores = loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    try:
+        yield mcp
+    finally:
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        loop.run(store.close())
+                    except Exception:
+                        pass
+        loop.close()
+
+
+async def _call(mcp, name: str, args: dict):
+    """Invoke a registered tool by name and return its decoded JSON result.
+
+    FastMCP returns either a list of content blocks (for dict results) or a
+    ``(content, {"result": ...})`` tuple (for list results) depending on the
+    return type. Prefer the structured tuple payload when present (clean list);
+    otherwise decode the JSON out of the single text content block (dict).
+    """
+    result = await mcp.call_tool(name, args)
+    if isinstance(result, tuple):
+        structured = result[1]
+        if isinstance(structured, dict) and "result" in structured:
+            return structured["result"]
+        return structured
+    if not result:
+        return []
+    return json.loads(result[0].text)
+
+
+def test_import_taosmd_without_touching_mcp():
+    """Importing the package works (mcp imported lazily, never at import time)."""
+    import taosmd  # noqa: PLC0415
+
+    assert hasattr(taosmd, "mcp_server")
+
+
+def test_registers_expected_tools(server):
+    tools = asyncio.run(server.list_tools())
+    names = {t.name for t in tools}
+    assert {
+        "memory_ingest",
+        "memory_search",
+        "memory_pending_list",
+        "memory_pending_resolve",
+        "memory_stats",
+    } <= names
+
+
+def test_ingest_then_search_roundtrip(server):
+    out = asyncio.run(_call(
+        server,
+        "memory_ingest",
+        {"text": "The MCP server ships on the feat/mcp-server branch.", "agent": "mcp-test"},
+    ))
+    assert out["archived"] == 1
+    assert out["agent"] == "mcp-test"
+
+    hits = asyncio.run(_call(
+        server,
+        "memory_search",
+        {"query": "The MCP server ships on the feat/mcp-server branch.", "agent": "mcp-test"},
+    ))
+    assert hits, "expected the ingested text to be retrievable"
+    assert "MCP server" in hits[0]["text"]
+
+
+def test_stats_reports_count(server):
+    asyncio.run(_call(
+        server,
+        "memory_ingest",
+        {"text": "Counting chunks for the stats tool.", "agent": "mcp-stats"},
+    ))
+    out = asyncio.run(_call(server, "memory_stats", {"agent": "mcp-stats"}))
+    assert out["agent"] == "mcp-stats"
+    assert out["registered"] is True
+    # ingest registers the agent and stamps last_ingest_at.
+    assert out["last_ingest_at"] >= 1
+
+
+def test_pending_list_empty(server):
+    out = asyncio.run(_call(server, "memory_pending_list", {"agent": "mcp-test"}))
+    assert out == []


### PR DESCRIPTION
Exposes taOSmd memory over the Model Context Protocol so any MCP-capable agent (Claude, Cursor, Codex, OpenWebUI, …) can read and write memory directly, without a custom integration.

## Tools (stdio)

| Tool | Purpose |
| --- | --- |
| `memory_ingest(text, agent)` | Store a transcript/note in an agent's memory |
| `memory_search(query, agent, limit=5)` | Retrieve passages relevant to a query |
| `memory_pending_list(agent)` | List KG-update decisions awaiting review |
| `memory_pending_resolve(decision_id, decision, note="")` | Resolve a pending decision (`accept`/`reject`/`modify`) |
| `memory_stats(agent)` | Lightweight per-agent stats |

Each tool has a clear name, description, and typed args so MCP clients render good schemas.

## Design

- **Optional dependency** — the `mcp` SDK is added under `[project.optional-dependencies]` as `mcp = ["mcp"]`, installed via `pip install taosmd[mcp]`. Imported lazily/guarded, so the core install stays lean and `import taosmd` never fails when `mcp` is absent. Standalone use is untouched.
- **stdio transport** — the standard for desktop MCP clients; no network listener, no cloud dependency. Local-first and offline. Entry point: `serve_stdio(data_dir=None)`.
- **Per-agent scoping** — every tool takes an `agent` argument forwarded to the service layer, honouring the same isolation as the Python API.
- **Reuses the shared service layer** — calls `taosmd.service.*` (same core the local HTTP/REST server #85 sits on), so behaviour matches the Python API and CLI exactly. DB work is dispatched onto the same long-lived `_ServiceLoop` event-loop thread the HTTP server uses, respecting SQLite thread-affinity; tools `await` the cross-thread result so FastMCP's loop is never blocked.
- **Additive + opt-in** — only runs when started via `taosmd mcp` (or `serve_stdio`).

## CLI

`taosmd mcp [--mcp-data-dir ...]` runs the stdio server. If the `mcp` package isn't installed it prints `pip install taosmd[mcp]` and exits non-zero.

## Tests

`tests/test_mcp_server.py` skips cleanly via `pytest.importorskip("mcp")` when the SDK isn't installed. It exercises the registered tool callables against a patched embedder + isolated tmp data dir (mirrors `test_http_server.py`/`test_api.py`): tool registration, ingest→search round-trip, stats, empty pending list, and that `import taosmd` works without touching `mcp`. Full suite green (324 passed) with the SDK installed in the worktree venv to validate.

Closes #84