### PR TITLE
docs: conservative benchmark framing + fix Recall@5 mislabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ If you're using Claude Code, OpenClaw, Cursor, or any AI coding agent, paste thi
 
 **97.0% end-to-end Judge accuracy on LongMemEval-S** (500 questions, standard test set). Harness: `benchmarks/longmemeval_runner.py`.
 
+> These are our own reproducible measurements, not a third-party-audited landscape ranking. Every number pins its generator, judge, dataset, and commit so you can re-run it on your own hardware — and we deliberately report under a strict local judge (`qwen3:4b`) alongside the lenient frontier-judge number that other systems publish, so the comparison is honest about what's being measured. See the [judge-sensitivity analysis](docs/benchmarks.md#judge-sensitivity--what-we-are-really-measuring).
+
 See [docs/benchmarks.md](docs/benchmarks.md) for the full LongMemEval-S breakdown, the LoCoMo (1540-QA multi-session) measurements with retrieval-architecture ablations, methodology, and per-hardware-tier configuration recommendations (12 / 8 / 4 GB GPU, Orange Pi NPU, RPi 4).
 
 ### Per-Category Breakdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "taosmd"
 version = "0.2.0"
-description = "Framework-agnostic AI memory system. 97.0% Recall@5 on LongMemEval-S."
+description = "Framework-agnostic, local-first AI memory system. 97.0% end-to-end Judge accuracy on LongMemEval-S, measured on a low-end reference stack."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"


### PR DESCRIPTION
Addresses the benchmark-framing + precision feedback from an external reviewer (and our positioning guidance):
- **Fix mislabel:** pyproject said `97.0% Recall@5` — the headline is end-to-end **Judge accuracy** (retrieve→generate→LLM-grade), not Recall@5.
- **Conservative framing:** add an explicit note that the numbers are our own reproducible measurements (commit/judge/dataset pinned; strict local judge reported alongside the lenient frontier judge others use), not a third-party landscape ranking.
No code changes.