### PR TITLE
feat(api): local inspection UI (search + review) on taosmd serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ All components expose HTTP endpoints when used with the taOS server:
 | `GET /api/archive/events` | Search archived events |
 | `POST /api/kg/classify` | Classify memory type |
 
+`taosmd serve` also exposes a minimal, read-only local inspection UI at the root URL (e.g. `http://127.0.0.1:7833/`) — a single self-contained, stdlib-only page (no JS frameworks, no CDNs, works offline) for searching memory and viewing the pending-review queue for an agent.
+
 ## Running Benchmarks
 
 ```bash

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -32,12 +32,24 @@ result is marshalled back to the calling request thread.
 
 Endpoints
 ---------
+``GET  /``                 -> the read-only inspection UI (``text/html``)
+``GET  /ui``               -> alias of ``GET /``
 ``GET  /health``           -> ``{"status": "ok", "version": <str>}``
 ``POST /ingest``           ``{"text", "agent"}``           -> ingest result
 ``POST /search``           ``{"query", "agent", "limit"?}`` -> ``{"hits": [...]}``
 ``GET  /search?q=&agent=&limit=``                          -> ``{"hits": [...]}``
 ``GET  /pending?agent=``                                   -> ``{"pending": [...]}``
 ``POST /pending/resolve``  ``{"id", "decision", "note"?}`` -> resolve result
+
+Inspection UI
+-------------
+``GET /`` (and ``GET /ui``) serves a single self-contained HTML page — one
+inline ``<style>`` and one inline vanilla ``<script>``, no external requests
+or CDNs — so it works fully offline. It is a **read-only** inspector: it lets
+you search memory and view the pending-review queue for an agent and read the
+server health/version, all by consuming the JSON endpoints above via ``fetch``.
+It exposes no destructive actions (no ingest, no resolve). The JSON endpoints
+remain the integration surface; the page is just a thin local viewer.
 """
 
 from __future__ import annotations
@@ -55,6 +67,198 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 7833
+
+
+# A single self-contained page: one inline <style> and one inline vanilla
+# <script>, no external requests, so it works fully offline. Read-only — it
+# only calls the GET /health, POST /search and GET /pending endpoints and
+# renders the results. No ingest/resolve/destructive actions are exposed.
+_INSPECTION_UI_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>taOSmd inspector</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #181b22; --border: #2a2f3a; --text: #e6e8ec;
+    --muted: #9aa3b2; --accent: #6ea8fe; --chip: #232834;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  }
+  header {
+    padding: 16px 20px; border-bottom: 1px solid var(--border);
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+  }
+  header h1 { font-size: 18px; margin: 0; font-weight: 600; }
+  header .tag { color: var(--muted); font-size: 13px; }
+  #health { margin-left: auto; color: var(--muted); font-size: 13px; }
+  main { max-width: 860px; margin: 0 auto; padding: 20px; }
+  .card {
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: 10px; padding: 16px; margin-bottom: 20px;
+  }
+  .card h2 { font-size: 15px; margin: 0 0 12px; font-weight: 600; }
+  .row { display: flex; gap: 8px; flex-wrap: wrap; }
+  label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+  input {
+    background: var(--bg); color: var(--text); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 10px; font: inherit; width: 100%;
+  }
+  input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+  .field { flex: 1 1 160px; }
+  .field.grow { flex: 3 1 320px; }
+  button {
+    background: var(--accent); color: #0b1020; border: 0; border-radius: 6px;
+    padding: 8px 16px; font: inherit; font-weight: 600; cursor: pointer;
+    align-self: flex-end;
+  }
+  button:hover { filter: brightness(1.08); }
+  button:disabled { opacity: .5; cursor: default; }
+  .results { margin-top: 14px; }
+  .hit {
+    border: 1px solid var(--border); border-radius: 8px; padding: 12px;
+    margin-bottom: 10px; background: var(--bg);
+  }
+  .hit .text { white-space: pre-wrap; word-break: break-word; }
+  .meta { margin-top: 8px; display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip {
+    background: var(--chip); color: var(--muted); font-size: 12px;
+    padding: 2px 8px; border-radius: 999px;
+  }
+  .empty, .err { color: var(--muted); font-size: 14px; padding: 6px 0; }
+  .err { color: #ff8c8c; }
+  .note { color: var(--muted); font-size: 12px; margin-top: 6px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>taOSmd inspector</h1>
+  <span class="tag">read-only local memory viewer</span>
+  <span id="health">checking…</span>
+</header>
+<main>
+  <section class="card" aria-labelledby="search-h">
+    <h2 id="search-h">Search memory</h2>
+    <div class="row">
+      <div class="field">
+        <label for="agent">Agent</label>
+        <input id="agent" placeholder="agent name" autocomplete="off" value="default">
+      </div>
+      <div class="field grow">
+        <label for="query">Query</label>
+        <input id="query" placeholder="what do you want to recall?" autocomplete="off">
+      </div>
+      <button id="searchBtn" type="button">Search</button>
+    </div>
+    <div class="results" id="searchResults"></div>
+  </section>
+
+  <section class="card" aria-labelledby="pending-h">
+    <h2 id="pending-h">Pending review queue</h2>
+    <div class="row">
+      <button id="pendingBtn" type="button">Load pending decisions</button>
+    </div>
+    <p class="note">Read-only. Resolve decisions from the CLI (<code>taosmd review</code>).</p>
+    <div class="results" id="pendingResults"></div>
+  </section>
+</main>
+<script>
+(function () {
+  "use strict";
+  var $ = function (id) { return document.getElementById(id); };
+
+  function esc(v) {
+    return String(v == null ? "" : v)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+  function chip(label, value) {
+    if (value === undefined || value === null || value === "") return "";
+    return '<span class="chip">' + esc(label) + ": " + esc(value) + "</span>";
+  }
+
+  function loadHealth() {
+    fetch("/health").then(function (r) { return r.json(); }).then(function (d) {
+      $("health").textContent = "ok · v" + (d.version || "?");
+    }).catch(function () {
+      $("health").textContent = "unreachable";
+    });
+  }
+
+  function search() {
+    var agent = $("agent").value.trim();
+    var query = $("query").value.trim();
+    var out = $("searchResults");
+    if (!agent || !query) {
+      out.innerHTML = '<div class="err">Enter both an agent and a query.</div>';
+      return;
+    }
+    out.innerHTML = '<div class="empty">Searching…</div>';
+    fetch("/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent: agent, query: query, limit: 10 })
+    }).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, body: d }; });
+    }).then(function (res) {
+      if (!res.ok) {
+        out.innerHTML = '<div class="err">' + esc(res.body.error || "search failed") + "</div>";
+        return;
+      }
+      var hits = res.body.hits || [];
+      if (!hits.length) { out.innerHTML = '<div class="empty">No matches.</div>'; return; }
+      out.innerHTML = hits.map(function (h) {
+        return '<div class="hit"><div class="text">' + esc(h.text) + "</div>" +
+          '<div class="meta">' +
+          chip("source", h.source) +
+          chip("confidence", typeof h.confidence === "number" ? h.confidence.toFixed(3) : h.confidence) +
+          chip("when", h.timestamp) +
+          "</div></div>";
+      }).join("");
+    }).catch(function (e) {
+      out.innerHTML = '<div class="err">' + esc(e.message || e) + "</div>";
+    });
+  }
+
+  function loadPending() {
+    var agent = $("agent").value.trim();
+    var out = $("pendingResults");
+    out.innerHTML = '<div class="empty">Loading…</div>';
+    var url = "/pending" + (agent ? "?agent=" + encodeURIComponent(agent) : "");
+    fetch(url).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, body: d }; });
+    }).then(function (res) {
+      if (!res.ok) {
+        out.innerHTML = '<div class="err">' + esc(res.body.error || "request failed") + "</div>";
+        return;
+      }
+      var rows = res.body.pending || [];
+      if (!rows.length) { out.innerHTML = '<div class="empty">Nothing pending.</div>'; return; }
+      out.innerHTML = rows.map(function (p) {
+        var triple = [p.subject, p.predicate, p.object].filter(Boolean).join(" → ");
+        return '<div class="hit"><div class="text">' + esc(triple || p.id) + "</div>" +
+          '<div class="meta">' +
+          chip("kind", p.kind) +
+          chip("id", p.id) +
+          "</div></div>";
+      }).join("");
+    }).catch(function (e) {
+      out.innerHTML = '<div class="err">' + esc(e.message || e) + "</div>";
+    });
+  }
+
+  $("searchBtn").addEventListener("click", search);
+  $("query").addEventListener("keydown", function (e) { if (e.key === "Enter") search(); });
+  $("pendingBtn").addEventListener("click", loadPending);
+  loadHealth();
+})();
+</script>
+</body>
+</html>
+"""
 
 
 class _BadRequest(Exception):
@@ -110,6 +314,15 @@ def _make_handler(data_dir, runner: _ServiceLoop):
             if self.command != "HEAD":
                 self.wfile.write(body)
 
+        def _send_html(self, status: int, html: str) -> None:
+            body = html.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+
         def _read_json_body(self) -> dict:
             length = int(self.headers.get("Content-Length") or 0)
             if length <= 0:
@@ -138,7 +351,9 @@ def _make_handler(data_dir, runner: _ServiceLoop):
             path = parts.path.rstrip("/") or "/"
             query = parse_qs(parts.query)
             try:
-                if method == "GET" and path == "/health":
+                if method == "GET" and path in ("/", "/ui"):
+                    self._send_html(200, _INSPECTION_UI_HTML)
+                elif method == "GET" and path == "/health":
                     self._send_json(200, {"status": "ok", "version": __version__})
                 elif method == "GET" and path == "/search":
                     self._handle_search_get(query)
@@ -258,6 +473,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     bound_host, bound_port = httpd.server_address[:2]
     where = "localhost only" if bound_host in {"127.0.0.1", "::1"} else "LAN-reachable (no auth)"
     print(f"taosmd HTTP API listening on http://{bound_host}:{bound_port} ({where})")
+    print(f"Inspection UI (read-only): http://{bound_host}:{bound_port}/")
     print("Endpoints: GET /health, POST /ingest, GET|POST /search, "
           "GET /pending, POST /pending/resolve")
     try:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -87,6 +87,15 @@ def _send(req) -> tuple[int, dict]:
         return exc.code, json.loads(exc.read().decode())
 
 
+def _get_raw(url: str) -> tuple[int, str, str]:
+    """GET returning (status, content_type, body_text) — for the HTML UI."""
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, method="GET"), timeout=10) as resp:
+            return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers.get("Content-Type", ""), exc.read().decode()
+
+
 def test_health(live_server):
     status, body = _get(f"{live_server}/health")
     assert status == 200
@@ -156,3 +165,57 @@ def test_pending_resolve_bad_decision_returns_400(live_server):
     )
     assert status == 400
     assert "decision" in body["error"]
+
+
+# ----- inspection UI ------------------------------------------------------
+
+
+def test_root_serves_inspection_ui_html(live_server):
+    status, ctype, html = _get_raw(f"{live_server}/")
+    assert status == 200
+    assert "text/html" in ctype
+    # App title + the markers the UI is built from (search box, query field).
+    assert "taOSmd inspector" in html
+    assert 'id="query"' in html
+    assert 'id="searchResults"' in html
+    assert 'id="pendingResults"' in html
+
+
+def test_ui_alias_serves_same_page(live_server):
+    status, ctype, html = _get_raw(f"{live_server}/ui")
+    assert status == 200
+    assert "text/html" in ctype
+    assert "taOSmd inspector" in html
+
+
+def test_inspection_ui_is_fully_offline(live_server):
+    """No external requests: no <script src>, no CDN/http(s) links, no @import."""
+    _, _, html = _get_raw(f"{live_server}/")
+    assert "src=" not in html
+    assert "http://" not in html
+    assert "https://" not in html
+    assert "@import" not in html
+    # Everything is inline.
+    assert "<style>" in html
+    assert "<script>" in html
+
+
+def test_ui_backing_endpoints_still_work(live_server):
+    """The JSON endpoints the UI consumes (search + pending) still respond."""
+    status, body = _post(
+        f"{live_server}/ingest",
+        {"text": "The inspection UI consumes the search endpoint.", "agent": "ui-test"},
+    )
+    assert status == 200, body
+
+    status, body = _post(
+        f"{live_server}/search",
+        {"query": "The inspection UI consumes the search endpoint.", "agent": "ui-test"},
+    )
+    assert status == 200, body
+    assert body["hits"]
+    assert "inspection UI" in body["hits"][0]["text"]
+
+    status, body = _get(f"{live_server}/pending?agent=ui-test")
+    assert status == 200
+    assert body["pending"] == []


### PR DESCRIPTION
Adds a minimal, read-only local inspection UI to the stdlib HTTP server, addressing the "no GUI" gap and the ui-inspection capability.

## What it shows
A new `GET /` (with `GET /ui` alias) returns a single self-contained HTML page that lets you, in the browser:

- **Search memory** — enter an agent name + query; calls the existing `POST /search` via fetch and renders the hits (text, source, confidence, timestamp) in a readable list.
- **Pending review queue** — load the pending-review decisions for an agent via `GET /pending`, shown **read-only** (subject → predicate → object, kind, id). No resolve/destructive actions are exposed; resolving stays in `taosmd review`.
- **Health/version** — pulls `GET /health` into the header.

## How it fits the vision
- **stdlib only** — no new deps, no JS frameworks, no CDNs. One inline `<style>` + one inline vanilla `<script>` in a single HTML string.
- **Offline** — no external requests at all; the page functions with no internet.
- **local-first** — served by `taosmd serve`, which binds `127.0.0.1` by default.
- **additive / opt-in** — only runs when you start the server; standalone use, Python API, and CLI are untouched.
- **read-only** — the UI only consumes existing JSON endpoints; it never writes or deletes. Those JSON endpoints remain the integration surface and are unchanged.

Serves correct `Content-Type: text/html; charset=utf-8`.

## Tests
Extends `tests/test_http_server.py` (offline, patched embedder, tmp data dir): `GET /` returns 200 `text/html` with the app title + search-box markers; `/ui` aliases the same page; the page is verified fully offline (no `src=`, no `http(s)`, no `@import`); and the JSON endpoints the UI relies on (search + pending) still work after an ingest. Full suite green: 328 passed.

Also adds a one-line note in the README HTTP/REST API section.