### PR TITLE
feat(vector): correction-supersede in the vector layer (zero-loss)

### DIFF
--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -344,8 +344,29 @@ async def resolve_pending_decision(
             kg = TemporalKnowledgeGraph(db_path=kg_path)
             await kg.init()
             try:
+                # Resolve the old object names before invalidating so we can
+                # mirror the correction into the vector layer (soft-supersede
+                # the chunk(s) carrying the stale value). Best-effort and
+                # zero-loss: raw rows are retained, only hidden from recall.
+                stores = await _ensure_stores(data_dir)
+                vmem = stores.get("vector")
+                old_objects = [
+                    row["object_name"]
+                    for old_id in decision["old_triple_ids"]
+                    if (row := kg._conn.execute(
+                        "SELECT o.name AS object_name FROM kg_triples t "
+                        "JOIN kg_entities o ON o.id = t.object_id WHERE t.id = ?",
+                        (old_id,),
+                    ).fetchone()) is not None
+                ]
                 for old_id in decision["old_triple_ids"]:
                     await kg.invalidate(old_id)
+                if vmem is not None:
+                    for obj_name in old_objects:
+                        try:
+                            await vmem.supersede_matching(obj_name)
+                        except Exception as e:  # pragma: no cover - defensive
+                            logger.debug("vector supersede skipped: %s", e)
                 await kg.add_triple(
                     subject=decision["subject"],
                     predicate=decision["predicate"],
@@ -363,4 +384,23 @@ async def resolve_pending_decision(
         await store.close()
 
 
-__all__ = ["ingest", "search", "list_pending_decisions", "resolve_pending_decision"]
+async def supersede_vectors(match: str, *, data_dir=None) -> int:
+    """Soft-supersede vector chunk(s) whose stored text contains ``match``.
+
+    The manual counterpart to the automatic KG->vector link: lets a caller
+    retire a stale fact from vector recall directly (e.g. when a correction
+    arrives outside the KG contradiction path). Zero-loss — the matched rows
+    are retained, only stamped ``valid_to`` so ``search()`` skips them.
+    Returns the number of rows superseded.
+    """
+    stores = await _ensure_stores(data_dir)
+    return await stores["vector"].supersede_matching(match)
+
+
+__all__ = [
+    "ingest",
+    "search",
+    "list_pending_decisions",
+    "resolve_pending_decision",
+    "supersede_vectors",
+]

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -449,6 +449,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Free-form note attached to the resolution",
     )
 
+    # ----- supersede subcommand (retire stale chunks from vector recall) -
+    supersede_p = sub.add_parser(
+        "supersede",
+        help="Soft-hide vector chunk(s) whose text contains --match from active "
+             "recall (zero-loss: raw rows are retained, only excluded from search)",
+    )
+    supersede_p.add_argument(
+        "--agent", default=None,
+        help="Agent name (accepted for symmetry; the vector store is per data dir)",
+    )
+    supersede_p.add_argument(
+        "--match", required=True,
+        help="Substring; every active chunk whose stored text contains it is superseded",
+    )
+
     # ----- serve subcommand (local HTTP/REST API) -----------------------
     serve_p = sub.add_parser(
         "serve",
@@ -493,6 +508,15 @@ def main(argv: list[str] | None = None) -> int:
         except mcp_server.MissingMCPDependencyError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
+
+    if args.cmd == "supersede":
+        import asyncio  # noqa: PLC0415
+        from . import service  # noqa: PLC0415
+        result = asyncio.run(
+            service.supersede(args.match, agent=args.agent, data_dir=args.data_dir)
+        )
+        print(f"superseded {result['superseded']} chunk(s) matching {result['match']!r}")
+        return 0
 
     registry = AgentRegistry(args.data_dir)
 

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -11,11 +11,14 @@ from the raw memory store (UserMemoryStore) and ingested content (KnowledgeStore
 from __future__ import annotations
 
 import hashlib
+import logging
 import sqlite3
 import time
 from pathlib import Path
 
 from . import _db
+
+logger = logging.getLogger(__name__)
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS kg_entities (
@@ -410,6 +413,7 @@ class TemporalKnowledgeGraph:
         pending_store=None,
         defer_below_confidence: float = 0.0,
         evidence: str = "",
+        vmem=None,
     ) -> dict:
         """Add a triple, checking for contradictions first.
 
@@ -425,6 +429,17 @@ class TemporalKnowledgeGraph:
           4. Contradictions and ``auto_resolve`` is False -> write the new
              triple but leave the old one(s) active too. Caller decides
              what to do with them.
+
+        ``vmem`` (optional): a :class:`~taosmd.vector_memory.VectorMemory`. When
+        supplied AND a contradiction is auto-resolved (policy 3), the raw vector
+        chunk(s) whose stored text contains the *old* object value are
+        opportunistically soft-superseded too (``valid_to`` stamped), so a
+        corrected fact stops resurfacing in vector recall as well as in the
+        typed KG. This closes the gap where corrections only superseded in the
+        KG layer. Default None preserves the legacy KG-only behaviour exactly —
+        nothing about the vector store is touched. The supersede is best-effort:
+        any failure is swallowed so a vmem hiccup can never block the KG write,
+        and it never deletes a row (zero-loss).
 
         Returns a dict whose ``status`` field is one of ``written``,
         ``deferred``, or ``written_with_conflicts``. ``triple_id`` is empty
@@ -464,6 +479,15 @@ class TemporalKnowledgeGraph:
         if contradictions and auto_resolve:
             for c in contradictions:
                 await self.invalidate(c["id"])
+                # Mirror the invalidation into the vector layer when a store is
+                # available: soft-hide chunk(s) carrying the old object value so
+                # the corrected fact leaves vector recall too. Raw rows are kept
+                # (zero-loss); failures must never block the KG write.
+                if vmem is not None:
+                    try:
+                        await vmem.supersede_matching(c["object_name"])
+                    except Exception as e:  # pragma: no cover - defensive
+                        logger.debug("vector supersede skipped: %s", e)
 
         tid = await self.add_triple(
             subject=subject, predicate=predicate, obj=obj,

--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -208,6 +208,7 @@ async def process_conversation_turn(
     pending_store=None,
     defer_below_confidence: float = 0.0,
     default_fact_confidence: float = 1.0,
+    vmem=None,
 ) -> dict:
     """Extract facts from a conversation turn and store in the KG.
 
@@ -229,6 +230,11 @@ async def process_conversation_turn(
         catalog pass, a summary of a summary) should pass a lower
         value -- e.g. 0.6 for regex on a session summary -- so the
         deferral threshold can actually fire.
+      - ``vmem``: an optional :class:`~taosmd.vector_memory.VectorMemory`.
+        When provided, an auto-resolved contradiction also soft-supersedes
+        the raw vector chunk(s) carrying the old object value, so a corrected
+        fact stops resurfacing in vector recall as well as in the KG. When
+        None (default), the vector store is left completely untouched.
 
     Returns ``{facts_extracted, triples_created, contradictions_resolved,
     deferred, deferred_ids, triple_ids, method}``.
@@ -289,6 +295,7 @@ async def process_conversation_turn(
                 pending_store=pending_store,
                 defer_below_confidence=defer_below_confidence,
                 evidence=text[:500],
+                vmem=vmem,
             )
             if result.get("status") == "deferred":
                 deferred_ids.append(result["pending_id"])

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -69,6 +69,20 @@ async def pending_resolve(
     )
 
 
+async def supersede(match: str, *, agent: str | None = None, data_dir=None) -> dict:
+    """Soft-supersede vector chunk(s) whose stored text contains ``match``.
+
+    Thin wrapper over :func:`taosmd.api.supersede_vectors`. Used to wire a
+    correction into the vector layer by content: matching chunks leave active
+    recall while the raw rows + archive entries are retained (zero-loss),
+    mirroring how the typed KG invalidates a corrected triple. ``agent`` is
+    accepted for adapter symmetry; the vector store is keyed per data dir.
+    Returns ``{"superseded": int, "match": str}``.
+    """
+    count = await _api.supersede_vectors(match, data_dir=data_dir)
+    return {"superseded": count, "match": match}
+
+
 async def stats(*, agent: str, data_dir=None) -> dict:
     """Return lightweight stats for an agent.
 
@@ -106,4 +120,4 @@ async def stats(*, agent: str, data_dir=None) -> dict:
     return out
 
 
-__all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats"]
+__all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats", "supersede"]

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS vector_memory (
     text TEXT NOT NULL,
     embedding TEXT NOT NULL,
     metadata_json TEXT NOT NULL DEFAULT '{}',
-    created_at REAL NOT NULL
+    created_at REAL NOT NULL,
+    valid_to REAL
 );
 CREATE INDEX IF NOT EXISTS idx_vm_created ON vector_memory(created_at DESC);
 """
@@ -95,6 +96,7 @@ class VectorMemory:
         self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
+        self._migrate()
         self._conn.commit()
         self._http = http_client
 
@@ -121,6 +123,23 @@ class VectorMemory:
             except Exception as e:
                 logger.warning("ONNX model failed to load: %s, falling back to QMD", e)
                 self._embed_mode = "qmd"
+
+    def _migrate(self) -> None:
+        """Bring an existing DB up to the current schema without data loss.
+
+        Adds the nullable ``valid_to`` column to stores created before the
+        correction-supersede feature. ``ALTER TABLE ... ADD COLUMN`` only
+        appends a NULL-defaulted column — no rows are rewritten or dropped, so
+        every existing vector survives and stays active (valid_to IS NULL).
+        """
+        cols = {row["name"] for row in self._conn.execute("PRAGMA table_info(vector_memory)")}
+        if "valid_to" not in cols:
+            self._conn.execute("ALTER TABLE vector_memory ADD COLUMN valid_to REAL")
+        # Index creation is deferred to here (not in SCHEMA) so it runs *after*
+        # the column is guaranteed to exist — a legacy table only gains the
+        # column via the ALTER above, and CREATE INDEX in SCHEMA would fire
+        # before that on the no-op CREATE TABLE IF NOT EXISTS path.
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_vm_valid ON vector_memory(valid_to)")
 
     async def close(self) -> None:
         if self._conn:
@@ -274,8 +293,17 @@ class VectorMemory:
                 "when", "where", "which", "who", "whom", "many", "much", "long"}
         keywords = [w.lower().strip("?.,!") for w in query.split() if len(w) > 2 and w.lower() not in stop]
 
-        # Load all embeddings and compute similarity using numpy batch operations
-        rows = self._conn.execute("SELECT id, text, embedding, metadata_json, created_at FROM vector_memory").fetchall()
+        # Load all *active* embeddings and compute similarity. Superseded rows
+        # (valid_to IS NOT NULL) are soft-hidden from recall — mirroring the
+        # KG's active-triple filter — but the raw row is never deleted, so
+        # zero-loss is preserved. This active filter covers every scoring path
+        # below (cosine, binary-quant, and the pure-Python fallback) because
+        # they all consume this single row set. No behaviour change when
+        # nothing has been superseded.
+        rows = self._conn.execute(
+            "SELECT id, text, embedding, metadata_json, created_at FROM vector_memory "
+            "WHERE valid_to IS NULL"
+        ).fetchall()
         if not rows:
             return []
 
@@ -471,7 +499,7 @@ class VectorMemory:
         """
         sql = (
             "SELECT id, text, metadata_json, created_at FROM vector_memory "
-            "WHERE json_extract(metadata_json, ?) = ?"
+            "WHERE valid_to IS NULL AND json_extract(metadata_json, ?) = ?"
         )
         params: list = [f"$.{position_key}", position_value]
         if group_key is not None and group_value is not None:
@@ -495,6 +523,52 @@ class VectorMemory:
     async def stats(self) -> dict:
         """Overall vector-memory statistics."""
         return {"count": await self.count()}
+
+    async def supersede(self, row_id: int, ended_at: float | None = None) -> bool:
+        """Soft-hide a single vector row from active recall.
+
+        Sets ``valid_to`` on the row so ``search()`` (and the adjacent-neighbour
+        lookup) no longer return it, mirroring the KG's
+        :meth:`TemporalKnowledgeGraph.invalidate`. The raw row — text, embedding,
+        and metadata — is *retained*; it is only excluded from recall, never
+        deleted. The append-only archive entry is likewise untouched, so
+        zero-loss is preserved.
+
+        Already-superseded rows are left as-is (the guard mirrors the KG's
+        ``valid_to IS NULL`` condition). Returns True if a row was affected.
+        """
+        end = ended_at if ended_at is not None else time.time()
+        cursor = self._conn.execute(
+            "UPDATE vector_memory SET valid_to = ? WHERE id = ? AND valid_to IS NULL",
+            (end, row_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    async def supersede_matching(self, text_or_substring: str, ended_at: float | None = None) -> int:
+        """Soft-hide every active row whose stored text contains the substring.
+
+        Used to wire corrections by content: when a fact is corrected, the
+        chunk(s) still carrying the *old* value are excluded from active recall
+        so the stale fact stops resurfacing in vector search too. As with
+        :meth:`supersede`, the raw rows are retained (zero-loss) — only their
+        ``valid_to`` is stamped. Matching is a plain case-sensitive substring
+        test on the stored (already secret-redacted) text. An empty/blank
+        ``text_or_substring`` is a no-op (returns 0) so a missing correction
+        value can never sweep the whole store. Returns the number of rows
+        superseded.
+        """
+        needle = (text_or_substring or "").strip()
+        if not needle:
+            return 0
+        end = ended_at if ended_at is not None else time.time()
+        cursor = self._conn.execute(
+            "UPDATE vector_memory SET valid_to = ? "
+            "WHERE valid_to IS NULL AND instr(text, ?) > 0",
+            (end, text_or_substring),
+        )
+        self._conn.commit()
+        return cursor.rowcount
 
     async def clear(self) -> int:
         cursor = self._conn.execute("DELETE FROM vector_memory")

--- a/tests/test_vector_supersede.py
+++ b/tests/test_vector_supersede.py
@@ -1,0 +1,257 @@
+"""Tests for correction-supersede in the vector layer.
+
+A superseded vector row must leave active recall (``search()`` skips it,
+mirroring the KG's ``valid_to IS NULL`` filter) while the raw row is *retained*
+in the table — zero-loss is the whole point. Supersede is additive/opt-in: with
+nothing superseded, behaviour is identical to before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from taosmd.knowledge_graph import TemporalKnowledgeGraph
+from taosmd.vector_memory import SCHEMA, VectorMemory
+
+
+def _deterministic_embedder(vmem: VectorMemory) -> None:
+    """Patch embed() with a deterministic 16-dim hash vector (no ONNX/QMD)."""
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFFFFFFFFFF
+        return [((h >> (i * 3)) & 0xFF) / 255.0 - 0.5 for i in range(16)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+def _make_store(tmp_path, *, binary_quant: bool = False) -> VectorMemory:
+    vmem = VectorMemory(
+        db_path=str(tmp_path / "vec.db"),
+        embed_mode="onnx",  # falls through; we patch embed() directly
+        binary_quant=binary_quant,
+    )
+    asyncio.run(vmem.init())
+    _deterministic_embedder(vmem)
+    return vmem
+
+
+def _row_count(db_path) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute("SELECT COUNT(*) FROM vector_memory").fetchone()[0]
+    finally:
+        con.close()
+
+
+def test_default_nothing_superseded_returns_all(tmp_path):
+    """Opt-in: with nothing superseded, every added row is recallable."""
+    vmem = _make_store(tmp_path)
+    try:
+        for t in ("jay works on project alpha", "the cat sat on the mat", "grocery list eggs milk"):
+            asyncio.run(vmem.add(t))
+        hits = asyncio.run(vmem.search("jay works on project alpha", limit=5, hybrid=False, fusion="none"))
+        texts = {h["text"] for h in hits}
+        assert "jay works on project alpha" in texts
+        assert len(texts) == 3
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_supersede_by_id_excludes_from_search_but_keeps_row(tmp_path):
+    """supersede(id) soft-hides from recall; the raw row STILL exists."""
+    vmem = _make_store(tmp_path)
+    try:
+        rid = asyncio.run(vmem.add("jay works on project alpha"))
+        asyncio.run(vmem.add("jay lives in berlin"))
+
+        # Present before supersede.
+        hits = asyncio.run(vmem.search("jay works on project alpha", limit=5, hybrid=False, fusion="none"))
+        assert any(h["id"] == rid for h in hits)
+
+        affected = asyncio.run(vmem.supersede(rid))
+        assert affected is True
+
+        # Absent from active recall.
+        hits = asyncio.run(vmem.search("jay works on project alpha", limit=5, hybrid=False, fusion="none"))
+        assert all(h["id"] != rid for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+
+    # Raw row retained in the table (zero-loss) — both rows still present.
+    assert _row_count(tmp_path / "vec.db") == 2
+
+
+def test_supersede_idempotent_returns_false_second_time(tmp_path):
+    """A second supersede of the same row is a no-op (mirrors KG invalidate)."""
+    vmem = _make_store(tmp_path)
+    try:
+        rid = asyncio.run(vmem.add("stale fact"))
+        assert asyncio.run(vmem.supersede(rid)) is True
+        assert asyncio.run(vmem.supersede(rid)) is False
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_supersede_matching_by_text(tmp_path):
+    """supersede_matching hides every active row containing the substring."""
+    vmem = _make_store(tmp_path)
+    try:
+        asyncio.run(vmem.add("jay works on ProjectAlpha"))
+        asyncio.run(vmem.add("we discussed ProjectAlpha at length"))
+        keep = asyncio.run(vmem.add("jay works on ProjectBeta"))
+
+        n = asyncio.run(vmem.supersede_matching("ProjectAlpha"))
+        assert n == 2
+
+        hits = asyncio.run(vmem.search("project work", limit=10, hybrid=False, fusion="none"))
+        texts = {h["text"] for h in hits}
+        assert "jay works on ProjectAlpha" not in texts
+        assert "we discussed ProjectAlpha at length" not in texts
+        # The non-matching row survives recall.
+        assert any(h["id"] == keep for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+
+    # All three raw rows retained.
+    assert _row_count(tmp_path / "vec.db") == 3
+
+
+def test_supersede_matching_blank_is_noop(tmp_path):
+    """A blank match never sweeps the store (defensive guard)."""
+    vmem = _make_store(tmp_path)
+    try:
+        asyncio.run(vmem.add("alpha"))
+        asyncio.run(vmem.add("beta"))
+        assert asyncio.run(vmem.supersede_matching("")) == 0
+        assert asyncio.run(vmem.supersede_matching("   ")) == 0
+        hits = asyncio.run(vmem.search("alpha", limit=5, hybrid=False, fusion="none"))
+        assert len(hits) == 2
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_supersede_excludes_from_binary_quant_path(tmp_path):
+    """The active filter applies to the binary-quant scoring path too."""
+    vmem = _make_store(tmp_path, binary_quant=True)
+    try:
+        rid = asyncio.run(vmem.add("alpha alpha alpha"))
+        asyncio.run(vmem.add("beta beta beta"))
+        asyncio.run(vmem.supersede(rid))
+        hits = asyncio.run(vmem.search("alpha alpha alpha", limit=5, hybrid=False, fusion="none"))
+        assert all(h["id"] != rid for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_migration_adds_valid_to_to_legacy_db(tmp_path):
+    """A DB created WITHOUT valid_to upgrades in init() with no data loss."""
+    db_path = tmp_path / "legacy.db"
+
+    # Build a legacy schema (no valid_to column) and seed a row.
+    con = sqlite3.connect(db_path)
+    con.execute(
+        """CREATE TABLE vector_memory (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            text TEXT NOT NULL,
+            embedding TEXT NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at REAL NOT NULL
+        )"""
+    )
+    con.execute(
+        "INSERT INTO vector_memory (text, embedding, metadata_json, created_at) VALUES (?, ?, ?, ?)",
+        ("legacy fact", "[0.1, 0.2]", "{}", 123.0),
+    )
+    con.commit()
+    con.close()
+
+    # Sanity: column absent before migration.
+    con = sqlite3.connect(db_path)
+    cols = {r[1] for r in con.execute("PRAGMA table_info(vector_memory)")}
+    con.close()
+    assert "valid_to" not in cols
+
+    # init() should migrate in place.
+    vmem = VectorMemory(db_path=str(db_path))
+    asyncio.run(vmem.init())
+    try:
+        # Column now present, legacy row preserved and active.
+        cols = {r["name"] for r in vmem._conn.execute("PRAGMA table_info(vector_memory)")}
+        assert "valid_to" in cols
+        row = vmem._conn.execute(
+            "SELECT text, valid_to FROM vector_memory WHERE text = 'legacy fact'"
+        ).fetchone()
+        assert row is not None
+        assert row["valid_to"] is None  # default NULL = active
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_kg_contradiction_supersedes_matching_vector_chunk(tmp_path):
+    """The auto-resolve KG path opportunistically supersedes vector chunks.
+
+    Wires a correction end-to-end: an auto-resolved contradiction invalidates
+    the old triple AND soft-hides the vector chunk carrying the old value.
+    """
+    vmem = _make_store(tmp_path)
+    kg = TemporalKnowledgeGraph(db_path=str(tmp_path / "kg.db"))
+    asyncio.run(kg.init())
+    try:
+        old_chunk = asyncio.run(vmem.add("jay works on ProjectAlpha"))
+        asyncio.run(vmem.add("jay enjoys hiking"))
+
+        # First fact.
+        asyncio.run(kg.add_triple_with_contradiction_check(
+            subject="jay", predicate="works_on", obj="ProjectAlpha", vmem=vmem,
+        ))
+        # Correction — contradicts the singular works_on fact, auto-resolves.
+        result = asyncio.run(kg.add_triple_with_contradiction_check(
+            subject="jay", predicate="works_on", obj="ProjectBeta", vmem=vmem,
+        ))
+        assert result["contradictions_resolved"] == 1
+
+        # The old chunk is gone from recall...
+        hits = asyncio.run(vmem.search("jay project", limit=10, hybrid=False, fusion="none"))
+        assert all(h["id"] != old_chunk for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+        asyncio.run(kg.close())
+
+    # ...but retained in the table (zero-loss).
+    assert _row_count(tmp_path / "vec.db") == 2
+
+
+def test_kg_contradiction_without_vmem_unchanged(tmp_path):
+    """vmem=None (default) leaves the vector store completely untouched."""
+    vmem = _make_store(tmp_path)
+    kg = TemporalKnowledgeGraph(db_path=str(tmp_path / "kg.db"))
+    asyncio.run(kg.init())
+    try:
+        asyncio.run(vmem.add("jay works on ProjectAlpha"))
+        asyncio.run(kg.add_triple_with_contradiction_check(
+            subject="jay", predicate="works_on", obj="ProjectAlpha",
+        ))
+        # No vmem passed — KG-only behaviour.
+        asyncio.run(kg.add_triple_with_contradiction_check(
+            subject="jay", predicate="works_on", obj="ProjectBeta",
+        ))
+        # Chunk still recallable; nothing superseded.
+        hits = asyncio.run(vmem.search("jay works on ProjectAlpha", limit=5, hybrid=False, fusion="none"))
+        assert any(h["text"] == "jay works on ProjectAlpha" for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+        asyncio.run(kg.close())
+
+
+def test_schema_constant_includes_valid_to(tmp_path):
+    """Fresh stores carry the column from the SCHEMA, not just migration."""
+    assert "valid_to" in SCHEMA
+    vmem = _make_store(tmp_path)
+    try:
+        cols = {r["name"] for r in vmem._conn.execute("PRAGMA table_info(vector_memory)")}
+        assert "valid_to" in cols
+    finally:
+        asyncio.run(vmem.close())


### PR DESCRIPTION
## What

Extends taOSmd's correction-supersede mechanism to the **vector layer**. Until now only the typed knowledge graph invalidated corrected facts (via `valid_to`); raw vector chunks carrying the stale value stayed searchable, so a corrected fact could still resurface in semantic recall. This closes that gap.

## Mechanism

Mirrors the KG's temporal-validity approach exactly:

- **Schema**: adds a nullable `valid_to REAL` column to the `vector_memory` table (default `NULL` = active), plus an `idx_vm_valid` index. A guarded migration in `init()` (`PRAGMA table_info` + `ALTER TABLE ... ADD COLUMN`) upgrades existing DBs in place — no rows rewritten or dropped. The index is created after the column is guaranteed present (deferred out of `SCHEMA`) so legacy tables migrate cleanly.
- **`search()`**: now loads only active rows (`WHERE valid_to IS NULL`), mirroring the KG's `valid_to IS NULL` filter. This single row query feeds every scoring path — cosine, binary-quant, and the pure-Python fallback — and the adjacent-neighbour lookup (`get_by_position`) is filtered too. No behaviour change when nothing is superseded.
- **New methods** on `VectorMemory`:
  - `supersede(row_id, ended_at=None) -> bool` — soft-hide one row.
  - `supersede_matching(text_or_substring, ended_at=None) -> int` — soft-hide every active row whose stored text contains the substring (blank match is a no-op so a missing value can't sweep the store).

## Wiring (auto KG -> vector link, preferred path)

`TemporalKnowledgeGraph.add_triple_with_contradiction_check` gains an optional `vmem=None` param. When a contradiction is auto-resolved (the existing invalidate-old path), and a vmem is supplied, it opportunistically supersedes vector chunk(s) containing the **old** object value — best-effort, swallowing any failure so a vmem hiccup can never block the KG write. `vmem=None` (default) preserves the legacy KG-only behaviour exactly. Threaded through `process_conversation_turn(vmem=...)` so the full extraction flow can opt in.

The deferred-review path is covered too: `api.resolve_pending_decision` accept now resolves old object names and supersedes matching vector chunks. Manual entry points are also exposed: `taosmd.service.supersede(match, ...)`, `taosmd.api.supersede_vectors(match, ...)`, and a small CLI `taosmd supersede --match "old text"`.

## Zero-loss preserved

Supersede only stamps `valid_to`. The raw row (text + embedding + metadata) and the append-only archive entry are **never** deleted — they are only excluded from active recall. Verified by tests asserting row counts are unchanged after supersede.

## Properties

- Local-first, offline, stdlib-only — no new deps.
- Additive / opt-in — default behaviour unchanged; no benchmark surface touched.
- Standalone never breaks — `vmem=None` is the default everywhere.

## Tests

`tests/test_vector_supersede.py` (10 tests): deterministic-embed add/search; supersede by id and by matching text; excluded-from-recall-but-row-retained; idempotent re-supersede; binary-quant path filtered; blank-match no-op; legacy-DB migration (column added, row preserved, stays active); auto KG->vector link end-to-end; `vmem=None` unchanged; SCHEMA carries the column.

Full suite green: **334 passed**.