### PR TITLE
feat(a2a): agent-to-agent message bus over the archive layer (REST + SSE + inspector tab)

### DIFF
--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -37,11 +37,12 @@ EVENT_CONTENT_VIEW = "content_view"       # User viewed a post, page, thread, vi
 EVENT_SEARCH = "search"                   # User searched for something
 EVENT_INGEST = "ingest"                   # Content ingested into knowledge base
 EVENT_MONITOR = "monitor"                 # Monitoring event (poll, change detected)
+EVENT_A2A = "a2a"                         # Agent-to-agent message bus message
 
 ALL_EVENT_TYPES = [
     EVENT_CONVERSATION, EVENT_TOOL_CALL, EVENT_API_CALL, EVENT_DECISION,
     EVENT_ERROR, EVENT_SYSTEM, EVENT_APP_USAGE, EVENT_CONTENT_VIEW,
-    EVENT_SEARCH, EVENT_INGEST, EVENT_MONITOR,
+    EVENT_SEARCH, EVENT_INGEST, EVENT_MONITOR, EVENT_A2A,
 ]
 
 # User activity events are opt-in
@@ -175,7 +176,7 @@ class ArchiveStore:
         # Redact secrets before storage
         from .secret_filter import redact_secrets
         summary, _ = redact_secrets(summary)
-        for key in ("content", "text", "msg", "query"):
+        for key in ("content", "text", "msg", "query", "body"):
             if key in data and isinstance(data[key], str):
                 data[key], _ = redact_secrets(data[key])
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -40,6 +40,9 @@ Endpoints
 ``GET  /search?q=&agent=&limit=``                          -> ``{"hits": [...]}``
 ``GET  /pending?agent=``                                   -> ``{"pending": [...]}``
 ``POST /pending/resolve``  ``{"id", "decision", "note"?}`` -> resolve result
+``POST /a2a/send``         ``{"from", "body", "thread"?, "reply_to"?}`` -> send receipt
+``GET  /a2a/messages``     ``?thread=&since=&limit=``      -> ``{"messages": [...]}``
+``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream)
 
 Inspection UI
 -------------
@@ -58,6 +61,7 @@ import asyncio
 import json
 import logging
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlsplit
 
@@ -132,6 +136,22 @@ _INSPECTION_UI_HTML = """<!doctype html>
   .empty, .err { color: var(--muted); font-size: 14px; padding: 6px 0; }
   .err { color: #ff8c8c; }
   .note { color: var(--muted); font-size: 12px; margin-top: 6px; }
+  /* A2A bus */
+  .a2a-list {
+    margin-top: 14px; max-height: 340px; overflow-y: auto;
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  .a2a-msg {
+    border-radius: 8px; padding: 8px 12px; max-width: 85%;
+    background: var(--chip); word-break: break-word;
+  }
+  .a2a-msg.left  { align-self: flex-start; border-left: 3px solid var(--accent); }
+  .a2a-msg.right { align-self: flex-end;   border-right: 3px solid #a78bfa; }
+  .a2a-msg .sender { font-size: 12px; color: var(--accent); font-weight: 600; margin-bottom: 2px; }
+  .a2a-msg.right .sender { color: #a78bfa; }
+  .a2a-msg .body { white-space: pre-wrap; }
+  .a2a-msg .ts { font-size: 11px; color: var(--muted); margin-top: 4px; text-align: right; }
+  .a2a-status { color: var(--muted); font-size: 13px; margin-top: 8px; }
 </style>
 </head>
 <body>
@@ -164,6 +184,20 @@ _INSPECTION_UI_HTML = """<!doctype html>
     </div>
     <p class="note">Read-only. Resolve decisions from the CLI (<code>taosmd review</code>).</p>
     <div class="results" id="pendingResults"></div>
+  </section>
+
+  <section class="card" aria-labelledby="a2a-h">
+    <h2 id="a2a-h">A2A bus</h2>
+    <div class="row">
+      <div class="field">
+        <label for="a2aThread">Thread</label>
+        <input id="a2aThread" value="general" autocomplete="off">
+      </div>
+      <button id="a2aConnectBtn" type="button">Connect</button>
+    </div>
+    <p class="note">Read-only live view. Agents write via <code>POST /a2a/send</code>.</p>
+    <div class="a2a-list" id="a2aList" aria-live="polite" aria-label="A2A messages"></div>
+    <div class="a2a-status" id="a2aStatus"></div>
   </section>
 </main>
 <script>
@@ -249,6 +283,78 @@ _INSPECTION_UI_HTML = """<!doctype html>
       out.innerHTML = '<div class="err">' + esc(e.message || e) + "</div>";
     });
   }
+
+  // ----- A2A bus -----------------------------------------------------------
+  var _a2aEs = null;
+
+  function _a2aSenders() {
+    // Collect unique senders from existing messages to decide left/right alignment.
+    var items = $("a2aList").querySelectorAll(".a2a-msg");
+    var seen = [];
+    items.forEach(function (el) { var s = el.dataset.sender; if (s && seen.indexOf(s) === -1) seen.push(s); });
+    return seen;
+  }
+
+  function _renderMsg(msg, senderIndex) {
+    var side = (senderIndex % 2 === 0) ? "left" : "right";
+    var ts = msg.ts ? new Date(msg.ts * 1000).toLocaleTimeString() : "";
+    return '<div class="a2a-msg ' + side + '" data-sender="' + esc(msg.from || "") + '">' +
+      '<div class="sender">@' + esc(msg.from || "?") + '</div>' +
+      '<div class="body">' + esc(msg.body || "") + '</div>' +
+      '<div class="ts">' + esc(ts) + (msg.reply_to ? " · ↩ " + esc(String(msg.reply_to)) : "") + '</div>' +
+      '</div>';
+  }
+
+  function _appendMsg(msg) {
+    var list = $("a2aList");
+    var senders = _a2aSenders();
+    var idx = senders.indexOf(msg.from || "");
+    if (idx === -1) { idx = senders.length; }
+    list.insertAdjacentHTML("beforeend", _renderMsg(msg, idx));
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function a2aConnect() {
+    var thread = $("a2aThread").value.trim() || "general";
+    var list = $("a2aList");
+    var status = $("a2aStatus");
+
+    if (_a2aEs) { _a2aEs.close(); _a2aEs = null; }
+    list.innerHTML = "";
+    status.textContent = "Loading history…";
+
+    fetch("/a2a/messages?thread=" + encodeURIComponent(thread) + "&limit=200")
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        var msgs = d.messages || [];
+        var senderMap = {};
+        var senderCount = 0;
+        msgs.forEach(function (msg) {
+          var s = msg.from || "";
+          if (!(s in senderMap)) { senderMap[s] = senderCount++; }
+          list.insertAdjacentHTML("beforeend", _renderMsg(msg, senderMap[s]));
+        });
+        list.scrollTop = list.scrollHeight;
+        status.textContent = "Connected · thread: " + thread;
+        var es = new EventSource("/a2a/stream?thread=" + encodeURIComponent(thread));
+        _a2aEs = es;
+        es.onmessage = function (e) {
+          try {
+            var msg = JSON.parse(e.data);
+            _appendMsg(msg);
+          } catch (_) {}
+        };
+        es.onerror = function () {
+          status.textContent = "Disconnected from stream. Reload to reconnect.";
+        };
+      })
+      .catch(function (e) {
+        status.textContent = "Failed to load history: " + esc(e.message || e);
+      });
+  }
+
+  $("a2aConnectBtn").addEventListener("click", a2aConnect);
+  $("a2aThread").addEventListener("keydown", function (e) { if (e.key === "Enter") a2aConnect(); });
 
   $("searchBtn").addEventListener("click", search);
   $("query").addEventListener("keydown", function (e) { if (e.key === "Enter") search(); });
@@ -365,6 +471,13 @@ def _make_handler(data_dir, runner: _ServiceLoop):
                     self._handle_pending(query)
                 elif method == "POST" and path == "/pending/resolve":
                     self._handle_pending_resolve()
+                elif method == "POST" and path == "/a2a/send":
+                    self._handle_a2a_send()
+                elif method == "GET" and path == "/a2a/messages":
+                    self._handle_a2a_messages(query)
+                elif method == "GET" and path == "/a2a/stream":
+                    self._handle_a2a_stream(query)
+                    return  # SSE response already sent; skip _send_json error path
                 else:
                     self._send_json(404, {"error": f"unknown route: {method} {path}"})
             except _BadRequest as exc:
@@ -443,6 +556,90 @@ def _make_handler(data_dir, runner: _ServiceLoop):
             )
             self._send_json(200, result)
 
+        def _handle_a2a_send(self) -> None:
+            body = self._read_json_body()
+            from_ = body.get("from")
+            body_text = body.get("body")
+            thread = body.get("thread", "general") or "general"
+            reply_to = body.get("reply_to")
+            if not isinstance(from_, str) or not from_:
+                raise _BadRequest("'from' (non-empty string) is required")
+            if not isinstance(body_text, str) or not body_text:
+                raise _BadRequest("'body' (non-empty string) is required")
+            result = runner.run(
+                service.a2a_send(
+                    sender=from_, body=body_text,
+                    thread=thread, reply_to=reply_to,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_messages(self, qs: dict) -> None:
+            thread = (qs.get("thread") or [None])[0]
+            since_raw = (qs.get("since") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            try:
+                since = float(since_raw) if since_raw is not None else None
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'since' must be a float timestamp") from exc
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            messages = runner.run(
+                service.a2a_feed(thread=thread, since=since, limit=limit_i, data_dir=data_dir)
+            )
+            self._send_json(200, {"messages": messages})
+
+        def _handle_a2a_stream(self, qs: dict) -> None:
+            """Server-Sent Events stream for the A2A bus.
+
+            Runs in its own request thread (ThreadingHTTPServer); polls the
+            archive once per second via the service loop and pushes new
+            messages as ``data:`` SSE frames. Each ``runner.run(...)`` call
+            is a quick, bounded archive query — the sleep happens here in
+            the request thread, never inside the service loop. Disconnects
+            are detected via write errors and exit the loop cleanly.
+            """
+            thread = (qs.get("thread") or [None])[0]
+            since_raw = (qs.get("since") or [None])[0]
+            try:
+                last_ts = float(since_raw) if since_raw is not None else time.time()
+            except (TypeError, ValueError):
+                last_ts = time.time()
+
+            # Send SSE response headers before entering the poll loop.
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+
+            try:
+                while True:
+                    msgs = runner.run(
+                        service.a2a_feed(
+                            thread=thread, since=last_ts, limit=200, data_dir=data_dir,
+                        )
+                    )
+                    # Keep only messages strictly newer than last_ts to avoid
+                    # re-sending the boundary row on subsequent polls.
+                    new_msgs = [m for m in msgs if m["ts"] > last_ts]
+                    if new_msgs:
+                        for msg in new_msgs:
+                            frame = f"data: {json.dumps(msg)}\n\n"
+                            self.wfile.write(frame.encode("utf-8"))
+                            last_ts = msg["ts"]
+                        self.wfile.flush()
+                    else:
+                        self.wfile.write(b": keepalive\n\n")
+                        self.wfile.flush()
+                    time.sleep(1.0)
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                # Client disconnected; exit the thread cleanly.
+                return
+
     return TaosmdHandler
 
 
@@ -475,7 +672,8 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     print(f"taosmd HTTP API listening on http://{bound_host}:{bound_port} ({where})")
     print(f"Inspection UI (read-only): http://{bound_host}:{bound_port}/")
     print("Endpoints: GET /health, POST /ingest, GET|POST /search, "
-          "GET /pending, POST /pending/resolve")
+          "GET /pending, POST /pending/resolve, "
+          "POST /a2a/send, GET /a2a/messages, GET /a2a/stream")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -17,7 +17,10 @@ the only thing they add is a uniform, transport-friendly signature:
 
 from __future__ import annotations
 
+import json
+
 from . import api as _api
+from .archive import EVENT_A2A
 
 
 async def ingest(text, *, agent: str, data_dir=None, **opts) -> dict:
@@ -120,4 +123,84 @@ async def stats(*, agent: str, data_dir=None) -> dict:
     return out
 
 
-__all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats", "supersede"]
+async def a2a_send(
+    sender: str,
+    body: str,
+    *,
+    thread: str = "general",
+    reply_to: str | None = None,
+    data_dir=None,
+) -> dict:
+    """Post a message onto the agent-to-agent bus.
+
+    Stores the message as an append-only archive event of type
+    :data:`~taosmd.archive.EVENT_A2A` and returns a receipt with the
+    assigned row ID. ``sender`` and ``body`` must be non-empty strings;
+    ``thread`` defaults to ``"general"``; ``reply_to`` is optional and
+    should be the string ID of the message being replied to.
+
+    Returns ``{"id", "from", "thread", "reply_to"}``.
+    """
+    if not isinstance(sender, str) or not sender:
+        raise ValueError("sender must be a non-empty string")
+    if not isinstance(body, str) or not body:
+        raise ValueError("body must be a non-empty string")
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    row_id = await archive.record(
+        event_type=EVENT_A2A,
+        data={"from": sender, "body": body, "thread": thread, "reply_to": reply_to},
+        agent_name=sender,
+        app_id=thread,
+        summary=body[:200],
+    )
+    return {"id": row_id, "from": sender, "thread": thread, "reply_to": reply_to}
+
+
+async def a2a_feed(
+    *,
+    thread: str | None = None,
+    since: float | None = None,
+    limit: int = 50,
+    data_dir=None,
+) -> list[dict]:
+    """Return messages from the agent-to-agent bus, oldest-first.
+
+    Filters by ``thread`` (when given) and by ``since`` (Unix timestamp,
+    exclusive lower bound). ``limit`` caps the number of rows fetched from
+    the archive (applied before reversing, so it limits the most-recent N
+    messages when ``since`` is None). Returns chronological order (oldest
+    first) suitable for chat-style display.
+
+    Each item has shape ``{"id", "ts", "from", "body", "thread",
+    "reply_to"}``.
+    """
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    rows = await archive.query(
+        event_type=EVENT_A2A,
+        app_id=thread,
+        since=since,
+        limit=limit,
+    )
+    # archive.query returns newest-first; A2A feed is displayed oldest-first.
+    rows = list(reversed(rows))
+    result = []
+    for row in rows:
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        result.append({
+            "id": row["id"],
+            "ts": row["timestamp"],
+            "from": data.get("from"),
+            "body": data.get("body"),
+            "thread": data.get("thread"),
+            "reply_to": data.get("reply_to"),
+        })
+    return result
+
+
+__all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats", "supersede",
+           "a2a_send", "a2a_feed"]

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,390 @@
+"""Tests for the A2A (agent-to-agent) message bus.
+
+Covers the service-layer round-trips, thread/since filtering, the HTTP
+endpoints, SSE streaming, and secret redaction in A2A message bodies.
+All tests are offline — no ONNX/QMD model needed; the vector embedder is
+patched wherever stores are initialised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    """Deterministic 8-dim hash embedder — no ONNX/QMD model required."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Isolated data dir with a clean stores cache for each test."""
+    data_dir = tmp_path / "taosmd-a2a"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    """HTTP server on an ephemeral port against an isolated data dir."""
+    data_dir = tmp_path / "taosmd-a2a-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+def _post(url: str, payload) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    return _send(req)
+
+
+def _get(url: str) -> tuple[int, dict]:
+    return _send(urllib.request.Request(url, method="GET"))
+
+
+def _send(req) -> tuple[int, dict]:
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests
+# ---------------------------------------------------------------------------
+
+def test_a2a_send_feed_roundtrip(isolated_data_dir):
+    """send then feed returns the message oldest-first with correct fields."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    receipt = asyncio.run(service.a2a_send(
+        "taOSmd", "hello from the memory layer",
+        thread="dev", data_dir=dd,
+    ))
+    assert isinstance(receipt["id"], int) and receipt["id"] > 0
+    assert receipt["from"] == "taOSmd"
+    assert receipt["thread"] == "dev"
+    assert receipt["reply_to"] is None
+
+    msgs = asyncio.run(service.a2a_feed(thread="dev", data_dir=dd))
+    assert len(msgs) == 1
+    m = msgs[0]
+    assert m["from"] == "taOSmd"
+    assert m["body"] == "hello from the memory layer"
+    assert m["thread"] == "dev"
+    assert m["reply_to"] is None
+    assert isinstance(m["ts"], float)
+
+
+def test_a2a_feed_oldest_first(isolated_data_dir):
+    """feed returns messages in chronological (oldest-first) order."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("agentA", "first message", thread="order", data_dir=dd))
+    time.sleep(0.01)
+    asyncio.run(service.a2a_send("agentB", "second message", thread="order", data_dir=dd))
+
+    msgs = asyncio.run(service.a2a_feed(thread="order", data_dir=dd))
+    assert len(msgs) == 2
+    assert msgs[0]["body"] == "first message"
+    assert msgs[1]["body"] == "second message"
+    assert msgs[0]["ts"] < msgs[1]["ts"]
+
+
+def test_a2a_thread_filtering(isolated_data_dir):
+    """Messages in thread A must not appear when querying thread B."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("agentA", "alpha message", thread="alpha", data_dir=dd))
+    asyncio.run(service.a2a_send("agentB", "beta message", thread="beta", data_dir=dd))
+
+    alpha_msgs = asyncio.run(service.a2a_feed(thread="alpha", data_dir=dd))
+    beta_msgs = asyncio.run(service.a2a_feed(thread="beta", data_dir=dd))
+
+    assert len(alpha_msgs) == 1 and alpha_msgs[0]["body"] == "alpha message"
+    assert len(beta_msgs) == 1 and beta_msgs[0]["body"] == "beta message"
+
+
+def test_a2a_since_filtering(isolated_data_dir):
+    """since= returns only messages newer than the given timestamp."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("agentA", "old message", thread="since-test", data_dir=dd))
+    time.sleep(0.02)
+    pivot = time.time()
+    time.sleep(0.02)
+    asyncio.run(service.a2a_send("agentA", "new message", thread="since-test", data_dir=dd))
+
+    msgs = asyncio.run(service.a2a_feed(thread="since-test", since=pivot, data_dir=dd))
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "new message"
+
+
+def test_a2a_send_validates_empty_sender(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="sender"):
+        asyncio.run(service.a2a_send("", "body text", data_dir=str(isolated_data_dir)))
+
+
+def test_a2a_send_validates_empty_body(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="body"):
+        asyncio.run(service.a2a_send("agentA", "", data_dir=str(isolated_data_dir)))
+
+
+def test_a2a_reply_to_field_preserved(isolated_data_dir):
+    """reply_to is stored and returned correctly."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    r1 = asyncio.run(service.a2a_send("agentA", "original", thread="replies", data_dir=dd))
+    asyncio.run(service.a2a_send(
+        "agentB", "reply here", thread="replies",
+        reply_to=str(r1["id"]), data_dir=dd,
+    ))
+
+    msgs = asyncio.run(service.a2a_feed(thread="replies", data_dir=dd))
+    assert msgs[1]["reply_to"] == str(r1["id"])
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction
+# ---------------------------------------------------------------------------
+
+# Synthetic GitHub-style token: prefix + 36 alphanum chars assembled at
+# runtime so no contiguous real-looking secret sits in source.
+_GH_PREFIX = "ghp_"
+_GH_BODY = "A" * 36
+
+
+def test_a2a_body_secret_redacted(isolated_data_dir):
+    """A body containing a secret token is redacted before storage."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+    secret = _GH_PREFIX + _GH_BODY
+
+    asyncio.run(service.a2a_send("agentA", f"token is {secret}", thread="sec", data_dir=dd))
+    msgs = asyncio.run(service.a2a_feed(thread="sec", data_dir=dd))
+    assert len(msgs) == 1
+    assert secret not in msgs[0]["body"]
+    assert "[REDACTED" in msgs[0]["body"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer tests
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_send_then_messages(live_server):
+    """POST /a2a/send then GET /a2a/messages returns the message."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "taOSmd", "body": "http round-trip test", "thread": "http-t"},
+    )
+    assert status == 200, body
+    assert body["from"] == "taOSmd"
+    assert body["thread"] == "http-t"
+    assert isinstance(body["id"], int)
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=http-t")
+    assert status == 200, body
+    msgs = body["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "http round-trip test"
+    assert msgs[0]["from"] == "taOSmd"
+
+
+def test_http_a2a_send_missing_from_returns_400(live_server):
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"body": "no sender here"},
+    )
+    assert status == 400
+    assert "from" in body["error"]
+
+
+def test_http_a2a_send_missing_body_returns_400(live_server):
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "agentA"},
+    )
+    assert status == 400
+    assert "body" in body["error"]
+
+
+def test_http_a2a_messages_thread_filter(live_server):
+    """GET /a2a/messages?thread= filters correctly."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "thread-x msg", "thread": "x"})
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "thread-y msg", "thread": "y"})
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=x")
+    assert status == 200
+    assert len(body["messages"]) == 1
+    assert body["messages"][0]["body"] == "thread-x msg"
+
+
+def test_http_a2a_messages_since_filter(live_server):
+    """GET /a2a/messages?since= returns only newer messages."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "before pivot", "thread": "since-http"})
+    time.sleep(0.02)
+    pivot = time.time()
+    time.sleep(0.02)
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "after pivot", "thread": "since-http"})
+
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=since-http&since={pivot}"
+    )
+    assert status == 200
+    msgs = body["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "after pivot"
+
+
+# ---------------------------------------------------------------------------
+# SSE smoke test
+# ---------------------------------------------------------------------------
+
+def _read_sse_frames(host: str, port: int, path: str, timeout: float = 8.0) -> list[str]:
+    """Open a raw TCP connection, send a minimal HTTP GET, read lines until
+    at least one ``data:`` frame arrives or timeout expires. Returns the list
+    of ``data:`` payload strings received."""
+    frames: list[str] = []
+    deadline = time.monotonic() + timeout
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode()
+        )
+        buf = b""
+        # Discard the HTTP headers section first.
+        header_done = False
+        while time.monotonic() < deadline and not frames:
+            sock.settimeout(max(0.1, deadline - time.monotonic()))
+            try:
+                chunk = sock.recv(4096)
+            except (socket.timeout, TimeoutError):
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if not header_done:
+                sep = buf.find(b"\r\n\r\n")
+                if sep != -1:
+                    buf = buf[sep + 4:]
+                    header_done = True
+            if header_done:
+                # Parse SSE lines from what we have so far.
+                text = buf.decode("utf-8", errors="replace")
+                for line in text.splitlines():
+                    if line.startswith("data: "):
+                        frames.append(line[6:])
+    return frames
+
+
+def test_http_a2a_sse_delivers_message(live_server):
+    """GET /a2a/stream receives a data: frame after a message is posted."""
+    parsed = urllib.parse.urlsplit(live_server)
+    host = parsed.hostname
+    port = parsed.port
+
+    thread = "sse-smoke"
+    frames_received: list[str] = []
+    error_holder: list[Exception] = []
+
+    def _stream_reader():
+        try:
+            result = _read_sse_frames(
+                host, port,
+                f"/a2a/stream?thread={thread}",
+                timeout=8.0,
+            )
+            frames_received.extend(result)
+        except Exception as exc:
+            error_holder.append(exc)
+
+    reader = threading.Thread(target=_stream_reader, daemon=True)
+    reader.start()
+
+    # Give the SSE connection a moment to establish, then post a message.
+    time.sleep(1.5)
+    status, body = _post(
+        live_server + "/a2a/send",
+        {"from": "sse-sender", "body": "sse smoke payload", "thread": thread},
+    )
+    assert status == 200, f"send failed: {body}"
+
+    reader.join(timeout=10)
+    assert not error_holder, f"SSE reader raised: {error_holder[0]}"
+    assert frames_received, "expected at least one SSE data: frame"
+    payloads = [json.loads(f) for f in frames_received]
+    bodies = [p.get("body") for p in payloads]
+    assert "sse smoke payload" in bodies


### PR DESCRIPTION
Adds a lightweight agent-to-agent (A2A) message bus so two agents can exchange messages through a shared taOSmd instance, with a live read-only view in the inspector.

## What
- **Storage**: messages are append-only archive events (`EVENT_A2A`), so they inherit the archive's durability and secret redaction. Extended the `record()` redaction key set to cover the `body` field.
- **Service layer**: `service.a2a_send(sender, body, thread, reply_to)` and `service.a2a_feed(thread, since, limit)` (oldest-first, chronological).
- **HTTP/REST**:
  - `POST /a2a/send` `{from, body, thread?, reply_to?}`
  - `GET /a2a/messages?thread=&since=&limit=` — chronological feed
  - `GET /a2a/stream?thread=&since=` — **Server-Sent Events** live feed (polls once per second in the request thread, never holding the shared service loop; strict `ts > last` filter; clean disconnect handling)
- **Inspector UI**: a new read-only "A2A bus" card — backfills history, then live-updates via `EventSource`, with a thread filter and per-sender bubbles.

## Notes
- Additive only — existing endpoints, the Python API, CLI, and standalone behaviour are unchanged; server still defaults to localhost.
- stdlib only, no new dependencies.
- 352 tests pass (338 prior + 14 new in `tests/test_a2a.py`: send/feed round-trip, ordering, thread/since filtering, validation, secret redaction, HTTP round-trip, and an SSE smoke test).