### PR TITLE
feat(serve): run taosmd serve as a persistent background service (systemd/launchd/Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,17 @@ All components expose HTTP endpoints when used with the taOS server:
 
 `taosmd serve` also exposes a minimal, read-only local inspection UI at the root URL (e.g. `http://127.0.0.1:7833/`) — a single self-contained, stdlib-only page (no JS frameworks, no CDNs, works offline) for searching memory and viewing the pending-review queue for an agent.
 
+To run the server persistently as a background service (systemd on Linux, launchd on macOS, or a Scheduled Task on Windows), use `--install-service`:
+
+```bash
+taosmd serve --install-service            # install with defaults
+taosmd serve --port 8080 --install-service  # custom port
+taosmd serve --service-status            # check running state
+taosmd serve --uninstall-service         # stop and remove
+```
+
+See [docs/serve-service.md](docs/serve-service.md) for platform-specific details, log locations, and how to change host/port/data-dir after installation.
+
 ## Running Benchmarks
 
 ```bash

--- a/docs/serve-service.md
+++ b/docs/serve-service.md
@@ -1,0 +1,187 @@
+# Running taosmd serve as a persistent background service
+
+`taosmd serve` starts the local HTTP/REST memory API and inspection UI on
+`http://127.0.0.1:7833` by default.  Running it in the foreground works fine
+for development, but for a live-always dashboard you want the process to
+survive logouts, restart after a crash, and start automatically at login.
+
+The `--install-service` flag handles this for you, using the native
+process-supervision mechanism on each platform.
+
+---
+
+## Linux (systemd user unit)
+
+No root or `sudo` required — this is a **user** unit that lives in
+`~/.config/systemd/user/`.
+
+### Install
+
+```bash
+taosmd serve --install-service
+# With a custom port or data directory:
+taosmd serve --host 127.0.0.1 --port 7833 --install-service
+taosmd serve --serve-data-dir /mnt/data/taosmd --install-service
+```
+
+This writes `~/.config/systemd/user/taosmd.service`, runs
+`systemctl --user daemon-reload`, then `systemctl --user enable --now taosmd.service`.
+
+### Status
+
+```bash
+taosmd serve --service-status
+# Or directly:
+systemctl --user status taosmd.service
+```
+
+### Logs
+
+```bash
+journalctl --user -u taosmd.service -f
+```
+
+### Uninstall
+
+```bash
+taosmd serve --uninstall-service
+```
+
+Runs `systemctl --user disable --now taosmd.service` and removes the unit file.
+
+### Change host / port / data-dir
+
+Uninstall and reinstall with the new flags:
+
+```bash
+taosmd serve --uninstall-service
+taosmd serve --port 8080 --install-service
+```
+
+---
+
+## macOS (launchd LaunchAgent)
+
+The service is registered as a LaunchAgent in `~/Library/LaunchAgents/` so it
+starts at login and restarts if it exits.
+
+### Install
+
+```bash
+taosmd serve --install-service
+# With a custom port or data directory:
+taosmd serve --port 7833 --install-service
+taosmd serve --serve-data-dir ~/.taosmd --install-service
+```
+
+This writes `~/Library/LaunchAgents/com.taosmd.serve.plist` and loads it with
+`launchctl load -w`.
+
+### Status
+
+```bash
+taosmd serve --service-status
+# Or directly:
+launchctl list | grep com.taosmd.serve
+```
+
+### Logs
+
+Stdout and stderr are written to `~/Library/Logs/taosmd/`:
+
+```bash
+tail -f ~/Library/Logs/taosmd/taosmd-serve.log
+tail -f ~/Library/Logs/taosmd/taosmd-serve-error.log
+```
+
+### Uninstall
+
+```bash
+taosmd serve --uninstall-service
+```
+
+Runs `launchctl unload -w` and removes the plist file.
+
+### Change host / port / data-dir
+
+```bash
+taosmd serve --uninstall-service
+taosmd serve --port 8080 --install-service
+```
+
+---
+
+## Windows (Scheduled Task via PowerShell)
+
+Python does not register Windows Scheduled Tasks directly.  Use the
+PowerShell script shipped at `scripts/install-service.ps1`.
+
+### Install
+
+Open an elevated PowerShell prompt in the taosmd repo directory:
+
+```powershell
+.\scripts\install-service.ps1
+# With a custom port or data directory:
+.\scripts\install-service.ps1 -Port 8080
+.\scripts\install-service.ps1 -DataDir C:\Users\you\.taosmd
+```
+
+The script registers a Scheduled Task named `taosmd-serve` that runs at logon
+and restarts automatically on failure.  It starts the task immediately so you
+do not need to log out.
+
+The CLI will print these instructions when you run `--install-service` on
+Windows rather than attempting the registration itself.
+
+### Status
+
+```powershell
+schtasks /Query /TN taosmd-serve
+```
+
+### Logs
+
+```powershell
+Get-Content "$env:LOCALAPPDATA\taosmd\logs\taosmd-serve.log" -Wait
+```
+
+### Uninstall
+
+```powershell
+.\scripts\install-service.ps1 -Uninstall
+```
+
+### Change host / port / data-dir
+
+Uninstall and reinstall with updated parameters:
+
+```powershell
+.\scripts\install-service.ps1 -Uninstall
+.\scripts\install-service.ps1 -Port 8080
+```
+
+---
+
+## Security note
+
+`taosmd serve` binds to `127.0.0.1` by default, which means only processes on
+the same machine can reach the API.  **There is no authentication.**  On
+localhost this is fine — any local process already has access to the Python API
+directly.
+
+If you bind to `0.0.0.0` (to expose the API on the LAN), you are responsible
+for network-level access controls.  Consider a firewall rule or a reverse proxy
+with authentication in front of it.  The same caveat applies whether you run
+`taosmd serve` in the foreground or as a background service.
+
+---
+
+## Checking the port is live
+
+```bash
+curl http://127.0.0.1:7833/health
+# Expected: {"status": "ok", "version": "..."}
+```
+
+The read-only inspection UI is at `http://127.0.0.1:7833/` in your browser.

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Install or uninstall the taosmd serve background service on Windows.
+
+.DESCRIPTION
+    Registers (or removes) a Windows Scheduled Task that runs
+    "python -m taosmd serve" at logon with automatic restart on failure.
+    The task runs under the current user account and does not require
+    elevation unless the task already exists with different permissions.
+
+.PARAMETER Host
+    Bind address passed to "taosmd serve" (default: 127.0.0.1).
+
+.PARAMETER Port
+    Bind port passed to "taosmd serve" (default: 7833).
+
+.PARAMETER DataDir
+    Data directory passed to "taosmd serve --serve-data-dir".
+    If omitted, the service inherits $env:TAOSMD_DATA_DIR or ~/.taosmd.
+
+.PARAMETER Uninstall
+    Remove the Scheduled Task instead of creating it.
+
+.EXAMPLE
+    .\install-service.ps1
+    .\install-service.ps1 -Port 8000 -Host 0.0.0.0
+    .\install-service.ps1 -DataDir C:\Users\jay\.taosmd
+    .\install-service.ps1 -Uninstall
+
+.NOTES
+    Logs are written to %LOCALAPPDATA%\taosmd\logs\.
+    To view them: Get-Content "$env:LOCALAPPDATA\taosmd\logs\taosmd-serve.log" -Wait
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$BindHost = "127.0.0.1",
+    [int]$Port = 7833,
+    [string]$DataDir = "",
+    [switch]$Uninstall
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$TaskName = "taosmd-serve"
+
+if ($Uninstall) {
+    Write-Host "Uninstalling taosmd Scheduled Task..."
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($null -eq $existing) {
+        Write-Host "Task '$TaskName' not found — nothing to remove."
+    } else {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Host "Task '$TaskName' removed."
+    }
+    exit 0
+}
+
+# Resolve the Python executable on PATH.
+$PythonExe = (Get-Command python -ErrorAction SilentlyContinue)?.Source
+if (-not $PythonExe) {
+    $PythonExe = (Get-Command python3 -ErrorAction SilentlyContinue)?.Source
+}
+if (-not $PythonExe) {
+    Write-Error ("python / python3 not found on PATH. " +
+                 "Install Python 3.10+ and make sure it is on your PATH.")
+    exit 1
+}
+
+# Build argument list.
+$Arguments = @("-m", "taosmd", "serve", "--host", $BindHost, "--port", "$Port")
+if ($DataDir -ne "") {
+    $Arguments += @("--serve-data-dir", $DataDir)
+}
+
+# Log directory.
+$LogDir = Join-Path $env:LOCALAPPDATA "taosmd\logs"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$LogOut = Join-Path $LogDir "taosmd-serve.log"
+
+# Build the scheduled task.
+# Trigger: at logon for the current user.
+$Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+# Action: run python with the serve arguments; redirect stdout+stderr to log
+# via cmd /c so the log file captures output without a visible console window.
+$CmdArgs = "/c `"$PythonExe`" " + ($Arguments -join " ") + " >> `"$LogOut`" 2>&1"
+$Action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument $CmdArgs
+
+# Settings: restart on failure (up to 3 times, 1 min apart), hidden.
+$Settings = New-ScheduledTaskSettingsSet `
+    -Hidden `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -ExecutionTimeLimit (New-TimeSpan -Hours 0)  # no time limit
+
+# Principal: interactive logon for the current user (no elevation needed for
+# localhost-only default bind).
+$Principal = New-ScheduledTaskPrincipal `
+    -UserId $env:USERNAME `
+    -LogonType Interactive `
+    -RunLevel Limited
+
+if ($PSCmdlet.ShouldProcess($TaskName, "Register Scheduled Task")) {
+    # Remove any existing instance first so re-registration is idempotent.
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($null -ne $existing) {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Host "Replaced existing task '$TaskName'."
+    }
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Trigger $Trigger `
+        -Action $Action `
+        -Settings $Settings `
+        -Principal $Principal | Out-Null
+
+    # Start it now so you don't have to log out and back in.
+    Start-ScheduledTask -TaskName $TaskName
+
+    Write-Host ""
+    Write-Host "taosmd Scheduled Task registered and started."
+    Write-Host "  Task name : $TaskName"
+    Write-Host "  Log file  : $LogOut"
+    Write-Host "  Status    : schtasks /Query /TN $TaskName"
+    Write-Host "  Uninstall : .\install-service.ps1 -Uninstall"
+}

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -482,6 +482,21 @@ def main(argv: list[str] | None = None) -> int:
         "--serve-data-dir", dest="serve_data_dir", default=None,
         help="Data dir for served memory (default: $TAOSMD_DATA_DIR or ~/.taosmd)",
     )
+    _svc = serve_p.add_mutually_exclusive_group()
+    _svc.add_argument(
+        "--install-service", action="store_true",
+        help="Install taosmd serve as a persistent background service "
+             "(systemd user unit on Linux, LaunchAgent on macOS, "
+             "PowerShell instructions on Windows) and exit.",
+    )
+    _svc.add_argument(
+        "--uninstall-service", action="store_true",
+        help="Stop and remove the background service installed by --install-service.",
+    )
+    _svc.add_argument(
+        "--service-status", action="store_true",
+        help="Print the running status of the background service.",
+    )
 
     # ----- mcp subcommand (MCP server over stdio) -----------------------
     mcp_p = sub.add_parser(
@@ -496,6 +511,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cmd == "serve":
+        from . import service_install  # noqa: PLC0415
+        if args.install_service:
+            return service_install.install_service(
+                host=args.host, port=args.port, data_dir=args.serve_data_dir,
+            )
+        if args.uninstall_service:
+            return service_install.uninstall_service()
+        if args.service_status:
+            return service_install.service_status()
         from . import http_server  # noqa: PLC0415
         return http_server.serve(
             host=args.host, port=args.port, data_dir=args.serve_data_dir,

--- a/taosmd/service_install.py
+++ b/taosmd/service_install.py
@@ -1,0 +1,483 @@
+"""Process-supervision helpers for ``taosmd serve`` as a persistent service.
+
+Supports three platforms:
+
+* **Linux** — a systemd *user* unit (``~/.config/systemd/user/taosmd.service``),
+  no root required. The unit runs ``python -m taosmd serve`` with the
+  host/port/data-dir baked in, restarts automatically on failure, and starts
+  at login via ``WantedBy=default.target``.
+
+* **macOS** — a launchd LaunchAgent plist
+  (``~/Library/LaunchAgents/com.taosmd.serve.plist``). Loaded via
+  ``launchctl`` so it starts at login and keeps the process alive.
+
+* **Windows** — the CLI prints instructions pointing to
+  ``scripts/install-service.ps1``, which registers a Scheduled Task with
+  restart-on-failure via PowerShell. The Python side does not call
+  ``schtasks``/``sc.exe`` directly, because doing so reliably (correct quoting,
+  service account, restart policy) is simpler from a .ps1 module than from a
+  subprocess shim.
+
+All subprocess calls use explicit argument lists (never ``shell=True``).
+Missing system tools (``systemctl``, ``launchctl``) produce a clear error
+message instead of an unhandled exception.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ── constants ────────────────────────────────────────────────────────────────
+
+_SYSTEMD_UNIT_NAME = "taosmd.service"
+_LAUNCHD_PLIST_LABEL = "com.taosmd.serve"
+_LAUNCHD_PLIST_NAME = f"{_LAUNCHD_PLIST_LABEL}.plist"
+
+# ── systemd (Linux) ──────────────────────────────────────────────────────────
+
+_SYSTEMD_UNIT_TEMPLATE = """\
+[Unit]
+Description=taOSmd memory HTTP API
+After=network.target
+
+[Service]
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def render_systemd_unit(
+    python_exe: str,
+    host: str,
+    port: int,
+    data_dir: Optional[str] = None,
+) -> str:
+    """Return the text of a systemd user unit for ``taosmd serve``.
+
+    The invocation bakes in *host*, *port*, and *data_dir* (when provided)
+    so the service starts with the exact same parameters the user specified
+    at install time.
+
+    Parameters
+    ----------
+    python_exe:
+        Absolute path to the Python interpreter to use (normally
+        ``sys.executable``).
+    host:
+        Bind address (e.g. ``127.0.0.1``).
+    port:
+        Bind port (e.g. ``7833``).
+    data_dir:
+        Optional data directory.  When ``None`` the service inherits
+        ``$TAOSMD_DATA_DIR`` or the default ``~/.taosmd`` — the same
+        resolution the foreground server would apply.
+    """
+    args = [python_exe, "-m", "taosmd", "serve", "--host", host, "--port", str(port)]
+    if data_dir is not None:
+        args += ["--serve-data-dir", data_dir]
+    exec_start = " ".join(_shell_quote(a) for a in args)
+    return _SYSTEMD_UNIT_TEMPLATE.format(exec_start=exec_start)
+
+
+def install_systemd(
+    python_exe: str,
+    host: str,
+    port: int,
+    data_dir: Optional[str] = None,
+) -> int:
+    """Write the systemd user unit and enable+start the service.
+
+    Returns 0 on success, non-zero on error.
+    """
+    unit_dir = Path.home() / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    unit_path = unit_dir / _SYSTEMD_UNIT_NAME
+
+    unit_text = render_systemd_unit(python_exe, host, port, data_dir)
+    unit_path.write_text(unit_text, encoding="utf-8")
+    print(f"Wrote unit file: {unit_path}")
+
+    rc = _run_systemctl(["daemon-reload"])
+    if rc != 0:
+        return rc
+    rc = _run_systemctl(["enable", "--now", _SYSTEMD_UNIT_NAME])
+    if rc != 0:
+        return rc
+    print(
+        f"taosmd service enabled and started.\n"
+        f"  Check status: taosmd serve --service-status\n"
+        f"  View logs:    journalctl --user -u {_SYSTEMD_UNIT_NAME} -f"
+    )
+    return 0
+
+
+def uninstall_systemd() -> int:
+    """Disable+stop the systemd user unit and remove the unit file.
+
+    Returns 0 on success, non-zero on error.
+    """
+    rc = _run_systemctl(["disable", "--now", _SYSTEMD_UNIT_NAME])
+    # rc may be non-zero if the unit was never enabled — tolerate that.
+    unit_path = Path.home() / ".config" / "systemd" / "user" / _SYSTEMD_UNIT_NAME
+    if unit_path.exists():
+        unit_path.unlink()
+        print(f"Removed unit file: {unit_path}")
+        _run_systemctl(["daemon-reload"])
+    else:
+        print("Unit file not found — nothing to remove.")
+    print("taosmd service stopped and uninstalled.")
+    return 0
+
+
+def status_systemd() -> int:
+    """Print the systemd user unit status.
+
+    Returns the exit code from ``systemctl --user status``.
+    """
+    return _run_systemctl(["status", _SYSTEMD_UNIT_NAME])
+
+
+def _run_systemctl(args: list[str]) -> int:
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        print(
+            "error: systemctl not found. "
+            "Ensure systemd is running and systemctl is on your PATH.",
+            file=sys.stderr,
+        )
+        return 1
+    cmd = [systemctl, "--user"] + args
+    result = subprocess.run(cmd)  # noqa: S603 — explicit arg list, no shell=True
+    return result.returncode
+
+
+# ── launchd (macOS) ──────────────────────────────────────────────────────────
+
+_LAUNCHD_PLIST_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+{program_arguments}
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{log_out}</string>
+
+    <key>StandardErrorPath</key>
+    <string>{log_err}</string>
+</dict>
+</plist>
+"""
+
+
+def render_launchd_plist(
+    python_exe: str,
+    host: str,
+    port: int,
+    data_dir: Optional[str] = None,
+    log_dir: Optional[str] = None,
+) -> str:
+    """Return the text of a launchd LaunchAgent plist for ``taosmd serve``.
+
+    Parameters
+    ----------
+    python_exe:
+        Absolute path to the Python interpreter (normally ``sys.executable``).
+    host:
+        Bind address.
+    port:
+        Bind port.
+    data_dir:
+        Optional data directory.
+    log_dir:
+        Directory for stdout/stderr logs.  Defaults to
+        ``~/Library/Logs/taosmd``.
+    """
+    args = [python_exe, "-m", "taosmd", "serve", "--host", host, "--port", str(port)]
+    if data_dir is not None:
+        args += ["--serve-data-dir", data_dir]
+
+    pa_lines = "\n".join(
+        f"        <string>{_xml_escape(a)}</string>" for a in args
+    )
+
+    if log_dir is None:
+        log_dir = str(Path.home() / "Library" / "Logs" / "taosmd")
+
+    log_out = os.path.join(log_dir, "taosmd-serve.log")
+    log_err = os.path.join(log_dir, "taosmd-serve-error.log")
+
+    return _LAUNCHD_PLIST_TEMPLATE.format(
+        label=_LAUNCHD_PLIST_LABEL,
+        program_arguments=pa_lines,
+        log_out=log_out,
+        log_err=log_err,
+    )
+
+
+def install_launchd(
+    python_exe: str,
+    host: str,
+    port: int,
+    data_dir: Optional[str] = None,
+) -> int:
+    """Write the launchd plist and load+start the LaunchAgent.
+
+    Returns 0 on success, non-zero on error.
+    """
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    plist_path = agents_dir / _LAUNCHD_PLIST_NAME
+
+    log_dir = Path.home() / "Library" / "Logs" / "taosmd"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    plist_text = render_launchd_plist(
+        python_exe, host, port, data_dir, log_dir=str(log_dir)
+    )
+    plist_path.write_text(plist_text, encoding="utf-8")
+    print(f"Wrote plist: {plist_path}")
+
+    # Unload any previous instance silently before reloading.
+    _run_launchctl(["unload", str(plist_path)], check=False)
+
+    rc = _run_launchctl(["load", "-w", str(plist_path)])
+    if rc != 0:
+        return rc
+    print(
+        f"taosmd LaunchAgent loaded.\n"
+        f"  Logs: {log_dir}/taosmd-serve.log\n"
+        f"  Check status: taosmd serve --service-status"
+    )
+    return 0
+
+
+def uninstall_launchd() -> int:
+    """Unload the launchd LaunchAgent and remove the plist file.
+
+    Returns 0 on success, non-zero on error.
+    """
+    plist_path = Path.home() / "Library" / "LaunchAgents" / _LAUNCHD_PLIST_NAME
+    if plist_path.exists():
+        _run_launchctl(["unload", "-w", str(plist_path)], check=False)
+        plist_path.unlink()
+        print(f"Removed plist: {plist_path}")
+    else:
+        print("Plist not found — nothing to remove.")
+    print("taosmd LaunchAgent unloaded and uninstalled.")
+    return 0
+
+
+def status_launchd() -> int:
+    """Print launchd service status by grepping ``launchctl list``.
+
+    Returns 0 if the label is listed (running), 1 otherwise.
+    """
+    launchctl = shutil.which("launchctl")
+    if launchctl is None:
+        print(
+            "error: launchctl not found. Are you on macOS?",
+            file=sys.stderr,
+        )
+        return 1
+    result = subprocess.run(  # noqa: S603
+        [launchctl, "list"],
+        capture_output=True,
+        text=True,
+    )
+    found = any(
+        _LAUNCHD_PLIST_LABEL in line for line in result.stdout.splitlines()
+    )
+    if found:
+        matching = [l for l in result.stdout.splitlines() if _LAUNCHD_PLIST_LABEL in l]  # noqa: E741
+        print("\n".join(matching))
+        return 0
+    print(f"{_LAUNCHD_PLIST_LABEL}: not running")
+    return 1
+
+
+def _run_launchctl(args: list[str], *, check: bool = True) -> int:
+    launchctl = shutil.which("launchctl")
+    if launchctl is None:
+        print(
+            "error: launchctl not found. Are you on macOS?",
+            file=sys.stderr,
+        )
+        return 1
+    result = subprocess.run([launchctl] + args)  # noqa: S603
+    if check:
+        return result.returncode
+    return 0
+
+
+# ── Windows ──────────────────────────────────────────────────────────────────
+
+_WINDOWS_PS1_PATH = "scripts/install-service.ps1"
+
+_WINDOWS_INSTALL_HINT = """\
+Windows service installation is handled via PowerShell.
+
+Run the following in an elevated PowerShell prompt:
+
+    .\\{ps1}
+
+To uninstall:
+
+    .\\{ps1} -Uninstall
+
+The script registers a Scheduled Task that runs
+  python -m taosmd serve
+at logon with automatic restart on failure.
+
+See {ps1} for the full script and customisation options.
+"""
+
+
+def install_windows(host: str, port: int, data_dir: Optional[str] = None) -> int:
+    """Print installation instructions for Windows and exit without error.
+
+    Python does not attempt to register the Scheduled Task directly.
+    """
+    print(_WINDOWS_INSTALL_HINT.format(ps1=_WINDOWS_PS1_PATH))
+    return 0
+
+
+def uninstall_windows() -> int:
+    """Print uninstall instructions for Windows."""
+    print(
+        f"To uninstall the taosmd Scheduled Task on Windows, run:\n\n"
+        f"    .\\{_WINDOWS_PS1_PATH} -Uninstall\n"
+    )
+    return 0
+
+
+def status_windows() -> int:
+    """Print status instructions for Windows."""
+    print(
+        "To check the taosmd Scheduled Task status on Windows, run:\n\n"
+        "    schtasks /Query /TN taosmd-serve\n"
+    )
+    return 0
+
+
+# ── platform dispatch ─────────────────────────────────────────────────────────
+
+def install_service(
+    host: str,
+    port: int,
+    data_dir: Optional[str] = None,
+    python_exe: Optional[str] = None,
+) -> int:
+    """Install and start the ``taosmd serve`` background service.
+
+    Delegates to the platform-appropriate implementation:
+
+    * ``linux`` — systemd user unit
+    * ``darwin`` — launchd LaunchAgent
+    * ``win32`` — prints instructions for the PowerShell script
+
+    Parameters
+    ----------
+    host:
+        Bind address to bake into the service definition.
+    port:
+        Bind port.
+    data_dir:
+        Optional data directory.  When ``None`` the service inherits the
+        same default resolution as the foreground ``taosmd serve`` command
+        (``$TAOSMD_DATA_DIR`` or ``~/.taosmd``).
+    python_exe:
+        Python interpreter path.  Defaults to ``sys.executable``.
+    """
+    exe = python_exe or sys.executable
+    platform = sys.platform
+    if platform.startswith("linux"):
+        return install_systemd(exe, host, port, data_dir)
+    if platform == "darwin":
+        return install_launchd(exe, host, port, data_dir)
+    if platform == "win32":
+        return install_windows(host, port, data_dir)
+    print(
+        f"error: unsupported platform {platform!r}. "
+        "Install manually or open an issue at https://github.com/jaylfc/taosmd.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def uninstall_service() -> int:
+    """Stop and remove the ``taosmd serve`` background service."""
+    platform = sys.platform
+    if platform.startswith("linux"):
+        return uninstall_systemd()
+    if platform == "darwin":
+        return uninstall_launchd()
+    if platform == "win32":
+        return uninstall_windows()
+    print(
+        f"error: unsupported platform {platform!r}.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def service_status() -> int:
+    """Print the running status of the ``taosmd serve`` background service."""
+    platform = sys.platform
+    if platform.startswith("linux"):
+        return status_systemd()
+    if platform == "darwin":
+        return status_launchd()
+    if platform == "win32":
+        return status_windows()
+    print(
+        f"error: unsupported platform {platform!r}.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+# ── internal helpers ─────────────────────────────────────────────────────────
+
+def _shell_quote(s: str) -> str:
+    """Minimal POSIX-safe shell quoting for unit-file ``ExecStart`` lines.
+
+    Single-quotes the argument and escapes any embedded single-quotes.
+    This avoids a ``shlex`` import while producing the same result for the
+    paths and hostnames we encounter here.
+    """
+    escaped = s.replace("'", "'\\''")
+    return f"'{escaped}'"
+
+
+def _xml_escape(s: str) -> str:
+    """Escape the five XML special characters for plist string values."""
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -1,0 +1,541 @@
+"""Unit tests for taosmd.service_install.
+
+All tests are hermetic:
+
+* Rendering functions (``render_systemd_unit``, ``render_launchd_plist``)
+  are pure — they only return strings, so they are tested directly without
+  any mocking.
+* ``install_*`` / ``uninstall_*`` / ``status_*`` functions are NOT called;
+  only the platform-dispatch helpers are tested via ``monkeypatch`` on
+  ``sys.platform``.
+* The Windows path is verified by asserting that ``install_service`` on
+  ``win32`` prints the PowerShell pointer and does NOT call ``subprocess``.
+* No file is written to ``~/.config``, ``~/Library``, or any real system
+  directory — tmp_path is used wherever a real path is needed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taosmd import service_install
+
+
+# ── systemd unit rendering ────────────────────────────────────────────────────
+
+class TestRenderSystemdUnit:
+    def test_contains_exec_start(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "ExecStart=" in unit
+
+    def test_python_exe_in_exec_start(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/home/jay/.venv/bin/python",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "/home/jay/.venv/bin/python" in unit
+
+    def test_host_and_port_in_exec_start(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="0.0.0.0",
+            port=9000,
+        )
+        assert "--host" in unit
+        assert "0.0.0.0" in unit
+        assert "--port" in unit
+        assert "9000" in unit
+
+    def test_data_dir_included_when_provided(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            data_dir="/mnt/data/taosmd",
+        )
+        assert "--serve-data-dir" in unit
+        assert "/mnt/data/taosmd" in unit
+
+    def test_data_dir_absent_when_not_provided(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            data_dir=None,
+        )
+        assert "--serve-data-dir" not in unit
+
+    def test_restart_on_failure(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "Restart=on-failure" in unit
+
+    def test_wanted_by_default_target(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "WantedBy=default.target" in unit
+
+    def test_invokes_taosmd_serve_module(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "-m" in unit
+        assert "taosmd" in unit
+        assert "serve" in unit
+
+    def test_unit_file_sections_present(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "[Unit]" in unit
+        assert "[Service]" in unit
+        assert "[Install]" in unit
+
+    def test_path_with_spaces_is_shell_quoted(self):
+        unit = service_install.render_systemd_unit(
+            python_exe="/home/my user/.venv/bin/python",
+            host="127.0.0.1",
+            port=7833,
+        )
+        # The path must be quoted so the space doesn't split the argument.
+        assert "'/home/my user/.venv/bin/python'" in unit
+
+    def test_roundtrip_to_tmp_file(self, tmp_path):
+        unit = service_install.render_systemd_unit(
+            python_exe=sys.executable,
+            host="127.0.0.1",
+            port=7833,
+            data_dir=str(tmp_path / "data"),
+        )
+        unit_path = tmp_path / "taosmd.service"
+        unit_path.write_text(unit, encoding="utf-8")
+        assert unit_path.read_text(encoding="utf-8") == unit
+
+
+# ── launchd plist rendering ───────────────────────────────────────────────────
+
+class TestRenderLaunchdPlist:
+    def test_valid_xml_structure(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "<?xml" in plist
+        assert "<plist" in plist
+        assert "</plist>" in plist
+
+    def test_label_present(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert service_install._LAUNCHD_PLIST_LABEL in plist
+
+    def test_python_exe_in_program_arguments(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/opt/homebrew/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "/opt/homebrew/bin/python3" in plist
+
+    def test_host_and_port_in_program_arguments(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="0.0.0.0",
+            port=8080,
+        )
+        assert "0.0.0.0" in plist
+        assert "8080" in plist
+
+    def test_data_dir_included_when_provided(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            data_dir="/Users/jay/.taosmd",
+        )
+        assert "--serve-data-dir" in plist
+        assert "/Users/jay/.taosmd" in plist
+
+    def test_data_dir_absent_when_not_provided(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            data_dir=None,
+        )
+        assert "--serve-data-dir" not in plist
+
+    def test_run_at_load_true(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        # RunAtLoad must be <true/>
+        assert "<key>RunAtLoad</key>" in plist
+        assert "<true/>" in plist
+
+    def test_keep_alive_true(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "<key>KeepAlive</key>" in plist
+        # true/ appears at least twice (RunAtLoad + KeepAlive)
+        assert plist.count("<true/>") >= 2
+
+    def test_stdout_and_stderr_paths_present(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            log_dir="/tmp/taosmd-logs",
+        )
+        assert "StandardOutPath" in plist
+        assert "StandardErrorPath" in plist
+        assert "/tmp/taosmd-logs" in plist
+
+    def test_custom_log_dir_honoured(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+            log_dir="/custom/logs",
+        )
+        assert "/custom/logs/taosmd-serve.log" in plist
+        assert "/custom/logs/taosmd-serve-error.log" in plist
+
+    def test_invokes_taosmd_serve_module(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        assert "-m" in plist
+        assert "taosmd" in plist
+        assert "serve" in plist
+
+    def test_program_arguments_each_in_own_string_element(self):
+        plist = service_install.render_launchd_plist(
+            python_exe="/usr/bin/python3",
+            host="127.0.0.1",
+            port=7833,
+        )
+        # Each argument is wrapped in a separate <string> element.
+        assert "<string>-m</string>" in plist
+        assert "<string>taosmd</string>" in plist
+        assert "<string>serve</string>" in plist
+
+    def test_roundtrip_to_tmp_file(self, tmp_path):
+        plist = service_install.render_launchd_plist(
+            python_exe=sys.executable,
+            host="127.0.0.1",
+            port=7833,
+            log_dir=str(tmp_path / "logs"),
+        )
+        plist_path = tmp_path / "com.taosmd.serve.plist"
+        plist_path.write_text(plist, encoding="utf-8")
+        assert plist_path.read_text(encoding="utf-8") == plist
+
+
+# ── platform dispatch ─────────────────────────────────────────────────────────
+
+class TestPlatformDispatch:
+    """Verify that install_service / uninstall_service / service_status
+    call the right platform-specific function without actually invoking
+    systemctl or launchctl."""
+
+    def test_linux_dispatch_calls_install_systemd(self, monkeypatch):
+        called_with: list = []
+
+        def fake_install_systemd(exe, host, port, data_dir):
+            called_with.append(("install_systemd", exe, host, port, data_dir))
+            return 0
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(service_install, "install_systemd", fake_install_systemd)
+        rc = service_install.install_service("127.0.0.1", 7833)
+        assert rc == 0
+        assert called_with[0][0] == "install_systemd"
+
+    def test_darwin_dispatch_calls_install_launchd(self, monkeypatch):
+        called_with: list = []
+
+        def fake_install_launchd(exe, host, port, data_dir):
+            called_with.append(("install_launchd", exe, host, port, data_dir))
+            return 0
+
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(service_install, "install_launchd", fake_install_launchd)
+        rc = service_install.install_service("127.0.0.1", 7833)
+        assert rc == 0
+        assert called_with[0][0] == "install_launchd"
+
+    def test_win32_dispatch_calls_install_windows(self, monkeypatch, capsys):
+        called_with: list = []
+
+        def fake_install_windows(host, port, data_dir):
+            called_with.append(("install_windows", host, port, data_dir))
+            return 0
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(service_install, "install_windows", fake_install_windows)
+        rc = service_install.install_service("127.0.0.1", 7833)
+        assert rc == 0
+        assert called_with[0][0] == "install_windows"
+
+    def test_uninstall_linux_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(service_install, "uninstall_systemd", lambda: (called.append(1), 0)[1])
+        rc = service_install.uninstall_service()
+        assert rc == 0
+        assert called
+
+    def test_uninstall_darwin_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(service_install, "uninstall_launchd", lambda: (called.append(1), 0)[1])
+        rc = service_install.uninstall_service()
+        assert rc == 0
+        assert called
+
+    def test_uninstall_win32_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(service_install, "uninstall_windows", lambda: (called.append(1), 0)[1])
+        rc = service_install.uninstall_service()
+        assert rc == 0
+        assert called
+
+    def test_status_linux_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(service_install, "status_systemd", lambda: (called.append(1), 0)[1])
+        rc = service_install.service_status()
+        assert rc == 0
+        assert called
+
+    def test_status_darwin_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(service_install, "status_launchd", lambda: (called.append(1), 0)[1])
+        rc = service_install.service_status()
+        assert rc == 0
+        assert called
+
+    def test_status_win32_dispatch(self, monkeypatch):
+        called: list = []
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(service_install, "status_windows", lambda: (called.append(1), 0)[1])
+        rc = service_install.service_status()
+        assert rc == 0
+        assert called
+
+    def test_unsupported_platform_returns_nonzero(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "haiku")
+        rc = service_install.install_service("127.0.0.1", 7833)
+        assert rc != 0
+
+    def test_linux_with_linux2_variant(self, monkeypatch):
+        """sys.platform is 'linux' on modern kernels but was 'linux2' on older ones."""
+        called: list = []
+
+        def fake_install_systemd(exe, host, port, data_dir):
+            called.append(True)
+            return 0
+
+        monkeypatch.setattr(sys, "platform", "linux2")
+        monkeypatch.setattr(service_install, "install_systemd", fake_install_systemd)
+        rc = service_install.install_service("127.0.0.1", 7833)
+        assert rc == 0
+        assert called
+
+
+# ── Windows: no subprocess, prints ps1 pointer ────────────────────────────────
+
+class TestWindowsInstallPrintsInstructions:
+    """On win32, --install-service must print the .ps1 pointer and NOT call subprocess."""
+
+    def test_install_windows_prints_ps1_path(self, capsys):
+        rc = service_install.install_windows("127.0.0.1", 7833)
+        captured = capsys.readouterr()
+        assert "install-service.ps1" in captured.out
+        assert rc == 0
+
+    def test_install_windows_does_not_call_subprocess(self, monkeypatch):
+        calls: list = []
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: calls.append(a))
+        service_install.install_windows("127.0.0.1", 7833)
+        assert calls == [], "install_windows must not call subprocess.run"
+
+    def test_uninstall_windows_prints_ps1_path(self, capsys):
+        rc = service_install.uninstall_windows()
+        captured = capsys.readouterr()
+        assert "install-service.ps1" in captured.out
+        assert rc == 0
+
+    def test_status_windows_prints_schtasks_hint(self, capsys):
+        rc = service_install.status_windows()
+        captured = capsys.readouterr()
+        assert "schtasks" in captured.out
+        assert rc == 0
+
+
+# ── shell_quote helper ────────────────────────────────────────────────────────
+
+class TestShellQuote:
+    def test_simple_path_is_single_quoted(self):
+        assert service_install._shell_quote("/usr/bin/python3") == "'/usr/bin/python3'"
+
+    def test_path_with_space_is_safe(self):
+        quoted = service_install._shell_quote("/home/my user/bin/python")
+        # The whole result must be wrapped in single quotes so the shell
+        # treats the space as part of the argument, not a word separator.
+        assert quoted.startswith("'") and quoted.endswith("'")
+        # The inner content must contain the path unchanged.
+        assert "/home/my user/bin/python" in quoted
+
+    def test_embedded_single_quote_is_escaped(self):
+        quoted = service_install._shell_quote("it's")
+        # The result must not be broken by the embedded single-quote.
+        assert "'" in quoted
+        # Reconstructing: remove outer quotes and unescape.
+        assert "it" in quoted and "s" in quoted
+
+
+# ── xml_escape helper ─────────────────────────────────────────────────────────
+
+class TestXmlEscape:
+    def test_ampersand(self):
+        assert service_install._xml_escape("a&b") == "a&amp;b"
+
+    def test_less_than(self):
+        assert service_install._xml_escape("a<b") == "a&lt;b"
+
+    def test_greater_than(self):
+        assert service_install._xml_escape("a>b") == "a&gt;b"
+
+    def test_double_quote(self):
+        assert service_install._xml_escape('a"b') == "a&quot;b"
+
+    def test_single_quote(self):
+        assert service_install._xml_escape("a'b") == "a&apos;b"
+
+    def test_clean_string_unchanged(self):
+        assert service_install._xml_escape("/usr/bin/python3") == "/usr/bin/python3"
+
+
+# ── CLI integration (no subprocess side-effects) ──────────────────────────────
+
+class TestCliFlags:
+    """Verify that the CLI routes --install-service / --uninstall-service /
+    --service-status to service_install without starting a foreground server."""
+
+    def _run_cli(self, argv: list[str], monkeypatch) -> int:
+        from taosmd import cli
+        return cli.main(argv)
+
+    def test_install_service_flag_dispatches_install(self, monkeypatch):
+        called: list = []
+
+        def fake_install(host, port, data_dir, python_exe=None):
+            called.append((host, port, data_dir))
+            return 0
+
+        monkeypatch.setattr(service_install, "install_service", fake_install)
+        rc = self._run_cli(["serve", "--install-service"], monkeypatch)
+        assert rc == 0
+        assert called
+
+    def test_uninstall_service_flag_dispatches_uninstall(self, monkeypatch):
+        called: list = []
+
+        def fake_uninstall():
+            called.append(True)
+            return 0
+
+        monkeypatch.setattr(service_install, "uninstall_service", fake_uninstall)
+        rc = self._run_cli(["serve", "--uninstall-service"], monkeypatch)
+        assert rc == 0
+        assert called
+
+    def test_service_status_flag_dispatches_status(self, monkeypatch):
+        called: list = []
+
+        def fake_status():
+            called.append(True)
+            return 0
+
+        monkeypatch.setattr(service_install, "service_status", fake_status)
+        rc = self._run_cli(["serve", "--service-status"], monkeypatch)
+        assert rc == 0
+        assert called
+
+    def test_install_passes_host_port_data_dir(self, monkeypatch):
+        received: list = []
+
+        def fake_install(host, port, data_dir, python_exe=None):
+            received.append((host, port, data_dir))
+            return 0
+
+        monkeypatch.setattr(service_install, "install_service", fake_install)
+        rc = self._run_cli(
+            ["serve", "--host", "0.0.0.0", "--port", "8080",
+             "--serve-data-dir", "/tmp/data", "--install-service"],
+            monkeypatch,
+        )
+        assert rc == 0
+        assert received[0] == ("0.0.0.0", 8080, "/tmp/data")
+
+    def test_service_flags_are_mutually_exclusive(self, monkeypatch):
+        """argparse should refuse two service flags at once."""
+        import io
+        with pytest.raises(SystemExit) as exc:
+            self._run_cli(
+                ["serve", "--install-service", "--uninstall-service"],
+                monkeypatch,
+            )
+        assert exc.value.code != 0
+
+    def test_no_service_flags_calls_foreground_serve(self, monkeypatch):
+        """Without a service flag the CLI falls through to http_server.serve."""
+        called: list = []
+
+        def fake_serve(host, port, data_dir):
+            called.append((host, port, data_dir))
+            return 0
+
+        # Patch inside the already-imported http_server module.
+        from taosmd import http_server
+        monkeypatch.setattr(http_server, "serve", fake_serve)
+        rc = self._run_cli(["serve"], monkeypatch)
+        assert rc == 0
+        assert called


### PR DESCRIPTION
Lets users run the local memory HTTP API / dashboard as an always-on background service, so the live (SSE-backed) inspector is persistently available without manually launching `taosmd serve`.

## What
- New `taosmd serve` flags (mutually exclusive): `--install-service`, `--uninstall-service`, `--service-status`. They install/manage a service that runs `taosmd serve` with the same `--host/--port/--data-dir` you pass, then exit (no foreground server).
- New module `taosmd/service_install.py` with pure rendering functions + platform dispatch (`sys.platform`):
  - **Linux** — systemd *user* unit at `~/.config/systemd/user/taosmd.service` (`Restart=on-failure`, `RestartSec=5`), then `systemctl --user daemon-reload` + `enable --now`.
  - **macOS** — launchd LaunchAgent at `~/Library/LaunchAgents/com.taosmd.serve.plist` (`RunAtLoad`, `KeepAlive`, logs under `~/Library/Logs/taosmd/`), loaded via `launchctl`.
  - **Windows** — ships `scripts/install-service.ps1` (Scheduled Task at logon, `-Uninstall` switch); the CLI prints clear instructions pointing to it rather than attempting install from Python.
- `docs/serve-service.md` — per-platform install/uninstall/status, log locations, how to change host/port/data-dir, and the localhost-vs-LAN/no-auth security note.

## Notes
- Additive — foreground `taosmd serve` and all defaults unchanged. stdlib only, no new deps. `subprocess` called with explicit arg lists (never `shell=True`); graceful handling when systemctl/launchctl are absent.
- 392 tests pass (338 prior + 54 new in `tests/test_service_install.py`, all hermetic — rendering tested as pure functions, writes under tmp_path, no real `~/.config`/`~/Library` touched).