### PR TITLE
feat(a2a): channel/member discovery, MCP tools, and agent-readable setup guide

### DIFF
--- a/.claude/skills/taosmd-a2a/SKILL.md
+++ b/.claude/skills/taosmd-a2a/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: taosmd-a2a
+description: Set up agent-to-agent comms and named channels via the taOSmd A2A bus.
+user-invocable: true
+---
+
+Read the setup guide from the taosmd package and execute it:
+
+```
+python -c "import taosmd; print(taosmd.a2a_setup_guide())"
+```
+
+Follow every step in the guide in order. The guide is the source of truth for installing taOSmd, checking for an existing server, starting the bus, joining a channel, and generating the invite block for the user's other agents.

--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -78,8 +78,19 @@ def agent_rules() -> str:
     return files("taosmd").joinpath("docs/agent-rules.md").read_text(encoding="utf-8")
 
 
+def a2a_setup_guide() -> str:
+    """Return the verbatim `docs/a2a-comms.md` setup guide.
+
+    The guide is addressed to an agent and covers installing taOSmd, starting
+    the A2A bus, joining a channel, and inviting other agents. Works from both
+    editable and wheel installs.
+    """
+    return files("taosmd").joinpath("docs/a2a-comms.md").read_text(encoding="utf-8")
+
+
 __all__ = [
     "agent_rules",
+    "a2a_setup_guide",
     # Core memory layers
     "KnowledgeGraph",
     "VectorMemory",

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -1,0 +1,267 @@
+# A2A Comms — Agent-to-Agent Channels via taOSmd
+
+This guide is addressed to you, the agent reading it. Execute each step in order to set up agent-to-agent communication over taOSmd so multiple agents working on the same project can exchange messages over a named channel.
+
+---
+
+## What this does
+
+taOSmd's A2A bus lets any number of agents (Claude Code, Cursor, OpenClaw, or any agent that can make HTTP requests or call MCP tools) share a live message channel for a project. Messages are append-only archive events — nothing is lost. Channels are created implicitly on first message; membership is derived from who has posted. This guide has you install taOSmd if needed, check whether a server is already running (and reuse it if so), pick or create a channel, then emit a JOIN message and a ready-to-paste invite block the user can hand to their other agents.
+
+---
+
+## Step 1 — Ensure taOSmd is installed
+
+Run:
+
+```
+taosmd --version
+```
+
+If that fails, try:
+
+```
+python -c "import taosmd; print(taosmd.__version__)"
+```
+
+If neither succeeds, install it:
+
+```
+pip install git+https://github.com/jaylfc/taosmd
+```
+
+or, if the package is published to PyPI:
+
+```
+pip install taosmd
+```
+
+Verify the install succeeded before continuing. If installation fails, stop and report the error to the user.
+
+---
+
+## Step 2 — Check for a running instance first (do not double-start)
+
+Before starting anything, check whether a taOSmd HTTP server is already up:
+
+```
+curl -s http://127.0.0.1:7900/health
+```
+
+If that returns `{"status": "ok", ...}`, a server is already running. **Reuse it — do not start another.**
+
+You can also check the service status:
+
+```
+taosmd serve --service-status
+```
+
+And inspect which channels already exist on this server:
+
+```
+curl -s http://127.0.0.1:7900/a2a/channels
+```
+
+If a channel matching your project already exists, skip ahead to Step 4 to join it rather than creating a duplicate.
+
+---
+
+## Step 3 — Start the bus if none is running
+
+If no server is running on port 7900, start one.
+
+**Foreground (for a terminal session):**
+
+```
+taosmd serve --port 7900 --serve-data-dir ~/.taosmd/a2a
+```
+
+**Background service (persists across sessions):**
+
+```
+taosmd serve --install-service --port 7900 --serve-data-dir ~/.taosmd/a2a
+```
+
+Wait for the startup message confirming the server is listening, then verify:
+
+```
+curl -s http://127.0.0.1:7900/health
+```
+
+---
+
+## Step 4 — Create or choose a channel for the project
+
+Channels are created automatically on the first message sent to them. Name the channel after the project. Use the repository name or git remote basename if available:
+
+```
+git remote get-url origin 2>/dev/null | sed 's|.*/||; s|\.git$||'
+```
+
+Before creating a new channel, check whether one already matches:
+
+```
+curl -s http://127.0.0.1:7900/a2a/channels
+```
+
+If a matching channel exists, join it (Step 4b). If not, sending your first message creates it.
+
+**Step 4a — Announce yourself (creates the channel if new):**
+
+```
+curl -s -X POST http://127.0.0.1:7900/a2a/send \
+  -H "Content-Type: application/json" \
+  -d '{"from": "AGENT_NAME", "body": "[JOIN] AGENT_NAME joined the channel", "thread": "CHANNEL"}'
+```
+
+Replace `AGENT_NAME` with this agent's identifier and `CHANNEL` with the project channel name.
+
+**Step 4b — Via MCP (if the MCP server is in use):**
+
+```python
+a2a_join(channel="CHANNEL", agent="AGENT_NAME")
+```
+
+**Check who is already on the channel:**
+
+```
+curl -s "http://127.0.0.1:7900/a2a/members?channel=CHANNEL"
+```
+
+Read the existing message history before posting:
+
+```
+curl -s "http://127.0.0.1:7900/a2a/messages?thread=CHANNEL&limit=50"
+```
+
+---
+
+## Step 5 — Invite the user's other agents
+
+Give the user the following block to pass to each other agent. Fill in the three placeholders (`SERVER_URL`, `CHANNEL`, `AGENT_NAME`) before handing it over.
+
+---
+
+```
+=== taOSmd A2A channel invite ===
+
+Server : SERVER_URL          (e.g. http://127.0.0.1:7900)
+Channel: CHANNEL             (the project channel name)
+Your ID: AGENT_NAME          (replace with this agent's own name/identifier)
+
+--- Setup (do this once) ---
+
+1. Verify the server is up:
+   curl SERVER_URL/health
+
+2. Read existing history FIRST before posting anything:
+   curl "SERVER_URL/a2a/messages?thread=CHANNEL&limit=50"
+
+3. Check who is already here:
+   curl "SERVER_URL/a2a/members?channel=CHANNEL"
+
+4. Announce yourself:
+   curl -X POST SERVER_URL/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "AGENT_NAME", "body": "[JOIN] AGENT_NAME joined the channel", "thread": "CHANNEL"}'
+
+--- Sending messages ---
+
+   curl -X POST SERVER_URL/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "AGENT_NAME", "body": "your message here", "thread": "CHANNEL"}'
+
+   To reply to a specific message (use its id field):
+   curl -X POST SERVER_URL/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "AGENT_NAME", "body": "reply text", "thread": "CHANNEL", "reply_to": "MESSAGE_ID"}'
+
+--- Reading messages ---
+
+   All messages (oldest-first, up to 50):
+   curl "SERVER_URL/a2a/messages?thread=CHANNEL&limit=50"
+
+   New messages since a timestamp:
+   curl "SERVER_URL/a2a/messages?thread=CHANNEL&since=UNIX_TS"
+
+   Live stream (Server-Sent Events):
+   curl -N "SERVER_URL/a2a/stream?thread=CHANNEL"
+
+--- MCP tools (if the MCP server is configured) ---
+
+   a2a_join(channel="CHANNEL", agent="AGENT_NAME")
+   a2a_send(channel="CHANNEL", sender="AGENT_NAME", body="message text")
+   a2a_read(channel="CHANNEL", since=None, limit=50)
+   a2a_members(channel="CHANNEL")
+   a2a_channels()
+
+--- Etiquette ---
+
+- Prefix your messages with your agent name when the context is ambiguous.
+- Reply using reply_to so threads stay readable.
+- Stay on-channel; do not open side channels without telling the others.
+- Keep messages concise — other agents read the full history on join.
+- Do not post sensitive data (keys, tokens, IPs) onto the channel.
+
+=== end of invite ===
+```
+
+---
+
+## Querying the bus
+
+**What channels exist?**
+
+HTTP:
+```
+GET SERVER_URL/a2a/channels
+```
+Response: `{"channels": [{"channel": "...", "members": [...], "message_count": N, "created_ts": ..., "last_ts": ...}, ...]}`
+
+MCP:
+```python
+a2a_channels()
+```
+
+**Who is a member of a channel?**
+
+HTTP:
+```
+GET SERVER_URL/a2a/members?channel=CHANNEL
+```
+Response: `{"members": ["agentA", "agentB", ...]}`
+
+MCP:
+```python
+a2a_members(channel="CHANNEL")
+```
+
+---
+
+## Reference
+
+### HTTP endpoints
+
+| Method | Path | Parameters | Response |
+|--------|------|------------|----------|
+| `POST` | `/a2a/send` | body JSON `{"from", "body", "thread"?, "reply_to"?}` | `{"id", "from", "thread", "reply_to"}` |
+| `GET`  | `/a2a/messages` | `?thread=&since=&limit=` | `{"messages": [...]}` |
+| `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
+| `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
+| `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
+
+Each message in `/a2a/messages` and the SSE stream has shape:
+`{"id", "ts", "from", "body", "thread", "reply_to"}`
+
+Each channel in `/a2a/channels` has shape:
+`{"channel", "members", "message_count", "created_ts", "last_ts"}`
+
+### MCP tools
+
+| Tool | Arguments | Returns |
+|------|-----------|---------|
+| `a2a_channels` | — | `list[dict]` — channel summaries |
+| `a2a_members` | `channel` | `list[str]` — sorted sender names |
+| `a2a_send` | `channel, sender, body, reply_to=None` | send receipt dict |
+| `a2a_read` | `channel, since=None, limit=50` | `list[dict]` — messages oldest-first |
+| `a2a_join` | `channel, agent` | send receipt dict |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -43,6 +43,8 @@ Endpoints
 ``POST /a2a/send``         ``{"from", "body", "thread"?, "reply_to"?}`` -> send receipt
 ``GET  /a2a/messages``     ``?thread=&since=&limit=``      -> ``{"messages": [...]}``
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream)
+``GET  /a2a/channels``                                     -> ``{"channels": [...]}``
+``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 
 Inspection UI
 -------------
@@ -478,6 +480,10 @@ def _make_handler(data_dir, runner: _ServiceLoop):
                 elif method == "GET" and path == "/a2a/stream":
                     self._handle_a2a_stream(query)
                     return  # SSE response already sent; skip _send_json error path
+                elif method == "GET" and path == "/a2a/channels":
+                    self._handle_a2a_channels()
+                elif method == "GET" and path == "/a2a/members":
+                    self._handle_a2a_members(query)
                 else:
                     self._send_json(404, {"error": f"unknown route: {method} {path}"})
             except _BadRequest as exc:
@@ -555,6 +561,17 @@ def _make_handler(data_dir, runner: _ServiceLoop):
                 )
             )
             self._send_json(200, result)
+
+        def _handle_a2a_channels(self) -> None:
+            channels = runner.run(service.a2a_channels(data_dir=data_dir))
+            self._send_json(200, {"channels": channels})
+
+        def _handle_a2a_members(self, qs: dict) -> None:
+            channel = (qs.get("channel") or [None])[0]
+            if not channel:
+                raise _BadRequest("'channel' query parameter is required")
+            members = runner.run(service.a2a_members(channel=channel, data_dir=data_dir))
+            self._send_json(200, {"members": members})
 
         def _handle_a2a_send(self) -> None:
             body = self._read_json_body()
@@ -673,7 +690,8 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     print(f"Inspection UI (read-only): http://{bound_host}:{bound_port}/")
     print("Endpoints: GET /health, POST /ingest, GET|POST /search, "
           "GET /pending, POST /pending/resolve, "
-          "POST /a2a/send, GET /a2a/messages, GET /a2a/stream")
+          "POST /a2a/send, GET /a2a/messages, GET /a2a/stream, "
+          "GET /a2a/channels, GET /a2a/members")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/taosmd/mcp_server.py
+++ b/taosmd/mcp_server.py
@@ -1,10 +1,10 @@
-"""MCP server for taOSmd memory over stdio (#84).
+"""MCP server for taOSmd memory and A2A bus over stdio (#84).
 
 An activation surface so any MCP-capable agent (Claude, Cursor, Codex,
-OpenWebUI, …) can read and write taOSmd memory directly, without a custom
-integration. It is a thin shell over :mod:`taosmd.service` — the same shared
-core the local HTTP/REST server (#85) sits on — so behaviour matches the
-Python API and CLI exactly.
+OpenWebUI, …) can read and write taOSmd memory and the agent-to-agent bus
+directly, without a custom integration. It is a thin shell over
+:mod:`taosmd.service` — the same shared core the local HTTP/REST server (#85)
+sits on — so behaviour matches the Python API and CLI exactly.
 
 Design choices (matching the project's local-first, offline, additive vision):
 
@@ -65,8 +65,9 @@ def _require_fastmcp():
 def build_server(data_dir=None, *, runner: _ServiceLoop | None = None):
     """Build (but do not run) a FastMCP server bound to ``data_dir``.
 
-    Registers the five memory tools, each routing to :mod:`taosmd.service` on
-    the shared service-loop thread. Returns the configured ``FastMCP`` instance
+    Registers the memory tools and A2A bus tools, each routing to
+    :mod:`taosmd.service` on the shared service-loop thread. Returns the
+    configured ``FastMCP`` instance
     (its ``_taosmd_service_loop`` attribute holds the :class:`_ServiceLoop` so
     callers/tests can close it on teardown). ``runner`` lets a caller supply an
     existing loop (e.g. tests); otherwise one is created here.
@@ -145,6 +146,48 @@ def build_server(data_dir=None, *, runner: _ServiceLoop | None = None):
         ``registered=False`` with zeroed counters rather than erroring.
         """
         return await _dispatch(service.stats(agent=agent, data_dir=data_dir))
+
+    # ---- A2A bus tools -------------------------------------------------------
+
+    @mcp.tool()
+    async def a2a_channels() -> list[dict]:
+        """List all channels (named threads) on the A2A bus."""
+        return await _dispatch(service.a2a_channels(data_dir=data_dir))
+
+    @mcp.tool()
+    async def a2a_members(channel: str) -> list[str]:
+        """List distinct sender names observed on ``channel``."""
+        return await _dispatch(service.a2a_members(channel=channel, data_dir=data_dir))
+
+    @mcp.tool()
+    async def a2a_send(
+        channel: str, sender: str, body: str, reply_to: str | None = None
+    ) -> dict:
+        """Post a message to ``channel`` from ``sender``."""
+        return await _dispatch(
+            service.a2a_send(sender, body, thread=channel, reply_to=reply_to, data_dir=data_dir)
+        )
+
+    @mcp.tool()
+    async def a2a_read(
+        channel: str, since: float | None = None, limit: int = 50
+    ) -> list[dict]:
+        """Read messages from ``channel``, oldest-first, optionally filtered by ``since``."""
+        return await _dispatch(
+            service.a2a_feed(thread=channel, since=since, limit=limit, data_dir=data_dir)
+        )
+
+    @mcp.tool()
+    async def a2a_join(channel: str, agent: str) -> dict:
+        """Announce ``agent``'s presence on ``channel`` with a join marker."""
+        return await _dispatch(
+            service.a2a_send(
+                agent,
+                f"[JOIN] {agent} joined the channel",
+                thread=channel,
+                data_dir=data_dir,
+            )
+        )
 
     return mcp
 

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -202,5 +202,83 @@ async def a2a_feed(
     return result
 
 
+async def a2a_channels(*, data_dir=None) -> list[dict]:
+    """Return a summary of every channel (named thread) on the A2A bus.
+
+    Derived entirely from existing :data:`~taosmd.archive.EVENT_A2A` archive
+    events — no additional schema. Groups by ``app_id`` (which equals the
+    thread name) and aggregates membership, message count, and timestamps.
+
+    Each item has shape ``{"channel", "members", "message_count",
+    "created_ts", "last_ts"}``, sorted by ``last_ts`` descending (most
+    recently active channel first). ``members`` is a sorted list of unique
+    sender names observed on that channel.
+    """
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    rows = await archive.query(event_type=EVENT_A2A, limit=100_000)
+
+    channels: dict[str, dict] = {}
+    for row in rows:
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        thread = data.get("thread") or row.get("app_id") or "general"
+        sender = data.get("from") or ""
+        ts = row.get("timestamp", 0.0)
+
+        if thread not in channels:
+            channels[thread] = {
+                "channel": thread,
+                "_members": set(),
+                "message_count": 0,
+                "created_ts": ts,
+                "last_ts": ts,
+            }
+        ch = channels[thread]
+        if sender:
+            ch["_members"].add(sender)
+        ch["message_count"] += 1
+        if ts < ch["created_ts"]:
+            ch["created_ts"] = ts
+        if ts > ch["last_ts"]:
+            ch["last_ts"] = ts
+
+    result = []
+    for ch in channels.values():
+        result.append({
+            "channel": ch["channel"],
+            "members": sorted(ch["_members"]),
+            "message_count": ch["message_count"],
+            "created_ts": ch["created_ts"],
+            "last_ts": ch["last_ts"],
+        })
+    result.sort(key=lambda c: c["last_ts"], reverse=True)
+    return result
+
+
+async def a2a_members(*, channel: str, data_dir=None) -> list[str]:
+    """Return distinct sender names observed on ``channel``, sorted.
+
+    Derived from :data:`~taosmd.archive.EVENT_A2A` events whose ``app_id``
+    matches ``channel``. Returns an empty list (not an error) when the
+    channel has never received a message.
+    """
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    rows = await archive.query(event_type=EVENT_A2A, app_id=channel, limit=100_000)
+    members: set[str] = set()
+    for row in rows:
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        sender = data.get("from") or ""
+        if sender:
+            members.add(sender)
+    return sorted(members)
+
+
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats", "supersede",
-           "a2a_send", "a2a_feed"]
+           "a2a_send", "a2a_feed", "a2a_channels", "a2a_members"]

--- a/tests/test_a2a_channels.py
+++ b/tests/test_a2a_channels.py
@@ -1,0 +1,315 @@
+"""Tests for A2A channel/member discovery, HTTP endpoints, and the setup guide.
+
+Offline + fast: no ONNX/QMD model required; the vector embedder is patched
+using the same deterministic hash helper used by the existing A2A tests.
+The HTTP server is bound on port 0 (ephemeral) and torn down after each test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import taosmd
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    """Deterministic 8-dim hash embedder — no ONNX/QMD model required."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Isolated data dir with a clean stores cache for each test."""
+    data_dir = tmp_path / "taosmd-a2a-ch"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    yield data_dir
+    for s in list(taosmd_api._stores_cache.values()):
+        for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    """HTTP server on an ephemeral port against an isolated data dir."""
+    data_dir = tmp_path / "taosmd-a2a-ch-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+def _get(url: str) -> tuple[int, dict]:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# service.a2a_channels
+# ---------------------------------------------------------------------------
+
+def test_a2a_channels_groups_by_thread(isolated_data_dir):
+    """a2a_channels groups events by thread and returns one dict per channel."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("alice", "hi", thread="alpha", data_dir=dd))
+    time.sleep(0.01)
+    asyncio.run(service.a2a_send("bob", "hey", thread="alpha", data_dir=dd))
+    asyncio.run(service.a2a_send("carol", "hello", thread="beta", data_dir=dd))
+
+    channels = asyncio.run(service.a2a_channels(data_dir=dd))
+    names = [c["channel"] for c in channels]
+    assert "alpha" in names
+    assert "beta" in names
+
+
+def test_a2a_channels_members_sorted(isolated_data_dir):
+    """Members list is sorted and unique even when a sender posts multiple times."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("zara", "msg1", thread="gamma", data_dir=dd))
+    asyncio.run(service.a2a_send("alice", "msg2", thread="gamma", data_dir=dd))
+    asyncio.run(service.a2a_send("zara", "msg3", thread="gamma", data_dir=dd))
+
+    channels = asyncio.run(service.a2a_channels(data_dir=dd))
+    gamma = next(c for c in channels if c["channel"] == "gamma")
+    assert gamma["members"] == sorted(set(gamma["members"]))
+    assert gamma["members"] == ["alice", "zara"]
+
+
+def test_a2a_channels_message_count(isolated_data_dir):
+    """message_count matches the number of messages sent to that thread."""
+    dd = str(isolated_data_dir)
+
+    for i in range(3):
+        asyncio.run(service.a2a_send("agentA", f"msg{i}", thread="count-ch", data_dir=dd))
+
+    channels = asyncio.run(service.a2a_channels(data_dir=dd))
+    ch = next(c for c in channels if c["channel"] == "count-ch")
+    assert ch["message_count"] == 3
+
+
+def test_a2a_channels_created_and_last_ts(isolated_data_dir):
+    """created_ts <= last_ts and both are floats."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("agentA", "first", thread="ts-ch", data_dir=dd))
+    time.sleep(0.02)
+    asyncio.run(service.a2a_send("agentB", "second", thread="ts-ch", data_dir=dd))
+
+    channels = asyncio.run(service.a2a_channels(data_dir=dd))
+    ch = next(c for c in channels if c["channel"] == "ts-ch")
+    assert isinstance(ch["created_ts"], float)
+    assert isinstance(ch["last_ts"], float)
+    assert ch["created_ts"] <= ch["last_ts"]
+
+
+def test_a2a_channels_sorted_by_last_ts_desc(isolated_data_dir):
+    """Channels are returned most-recently-active first."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("a", "old", thread="older-ch", data_dir=dd))
+    time.sleep(0.02)
+    asyncio.run(service.a2a_send("b", "new", thread="newer-ch", data_dir=dd))
+
+    channels = asyncio.run(service.a2a_channels(data_dir=dd))
+    names = [c["channel"] for c in channels]
+    assert names.index("newer-ch") < names.index("older-ch")
+
+
+def test_a2a_channels_empty_store(isolated_data_dir):
+    """a2a_channels returns an empty list when no messages have been sent."""
+    channels = asyncio.run(service.a2a_channels(data_dir=str(isolated_data_dir)))
+    assert channels == []
+
+
+# ---------------------------------------------------------------------------
+# service.a2a_members
+# ---------------------------------------------------------------------------
+
+def test_a2a_members_distinct_senders(isolated_data_dir):
+    """a2a_members returns sorted distinct senders on that channel."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("carol", "hi", thread="mem-ch", data_dir=dd))
+    asyncio.run(service.a2a_send("alice", "hey", thread="mem-ch", data_dir=dd))
+    asyncio.run(service.a2a_send("carol", "again", thread="mem-ch", data_dir=dd))
+
+    members = asyncio.run(service.a2a_members(channel="mem-ch", data_dir=dd))
+    assert members == ["alice", "carol"]
+
+
+def test_a2a_members_ignores_other_channels(isolated_data_dir):
+    """a2a_members only counts senders on the requested channel."""
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send("only-here", "msg", thread="chan-a", data_dir=dd))
+    asyncio.run(service.a2a_send("other-agent", "msg", thread="chan-b", data_dir=dd))
+
+    members = asyncio.run(service.a2a_members(channel="chan-a", data_dir=dd))
+    assert members == ["only-here"]
+    assert "other-agent" not in members
+
+
+def test_a2a_members_unknown_channel_returns_empty(isolated_data_dir):
+    """a2a_members returns [] for a channel with no messages."""
+    members = asyncio.run(
+        service.a2a_members(channel="nonexistent", data_dir=str(isolated_data_dir))
+    )
+    assert members == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer — GET /a2a/channels
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_channels_empty(live_server):
+    """GET /a2a/channels returns an empty list when no messages exist."""
+    status, body = _get(f"{live_server}/a2a/channels")
+    assert status == 200, body
+    assert body == {"channels": []}
+
+
+def _http_post(url: str, payload: dict) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+def test_http_a2a_channels_after_sends(live_server):
+    """GET /a2a/channels returns correct channel entries after posting."""
+    _http_post(f"{live_server}/a2a/send",
+               {"from": "alice", "body": "hello", "thread": "proj-a"})
+    _http_post(f"{live_server}/a2a/send",
+               {"from": "bob", "body": "hi", "thread": "proj-a"})
+    _http_post(f"{live_server}/a2a/send",
+               {"from": "carol", "body": "hey", "thread": "proj-b"})
+
+    status, body = _get(f"{live_server}/a2a/channels")
+    assert status == 200, body
+    channels = body["channels"]
+    names = [c["channel"] for c in channels]
+    assert "proj-a" in names
+    assert "proj-b" in names
+
+    pa = next(c for c in channels if c["channel"] == "proj-a")
+    assert pa["message_count"] == 2
+    assert sorted(pa["members"]) == ["alice", "bob"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer — GET /a2a/members
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_members_returns_members(live_server):
+    """GET /a2a/members?channel= returns sorted member list."""
+    _http_post(f"{live_server}/a2a/send", {"from": "zara", "body": "yo", "thread": "m-ch"})
+    _http_post(f"{live_server}/a2a/send", {"from": "alice", "body": "hi", "thread": "m-ch"})
+
+    status, body = _get(f"{live_server}/a2a/members?channel=m-ch")
+    assert status == 200, body
+    assert body["members"] == ["alice", "zara"]
+
+
+def test_http_a2a_members_missing_channel_returns_400(live_server):
+    """GET /a2a/members without ?channel= returns 400."""
+    status, body = _get(f"{live_server}/a2a/members")
+    assert status == 400
+    assert "channel" in body["error"]
+
+
+def test_http_a2a_members_unknown_channel_empty(live_server):
+    """GET /a2a/members for an unknown channel returns empty list."""
+    status, body = _get(f"{live_server}/a2a/members?channel=ghost")
+    assert status == 200, body
+    assert body["members"] == []
+
+
+# ---------------------------------------------------------------------------
+# a2a_setup_guide()
+# ---------------------------------------------------------------------------
+
+def test_a2a_setup_guide_nonempty():
+    """a2a_setup_guide() returns non-empty text."""
+    text = taosmd.a2a_setup_guide()
+    assert isinstance(text, str) and text.strip()
+
+
+def test_a2a_setup_guide_contains_install_step():
+    """Guide mentions the install check."""
+    text = taosmd.a2a_setup_guide()
+    assert "taosmd --version" in text or "pip install" in text
+
+
+def test_a2a_setup_guide_contains_running_instance_check():
+    """Guide mentions checking for an already-running instance."""
+    text = taosmd.a2a_setup_guide()
+    assert "already" in text.lower() or "running" in text.lower()
+
+
+def test_a2a_setup_guide_contains_channel_step():
+    """Guide mentions channels."""
+    text = taosmd.a2a_setup_guide()
+    assert "channel" in text.lower()
+
+
+def test_a2a_setup_guide_contains_join_step():
+    """Guide mentions a JOIN message."""
+    text = taosmd.a2a_setup_guide()
+    assert "JOIN" in text or "join" in text.lower()


### PR DESCRIPTION
## Summary

- **service.py**: `a2a_channels()` and `a2a_members()` derived from existing `EVENT_A2A` archive events (no schema change); both added to `__all__`
- **http_server.py**: `GET /a2a/channels` → `{"channels": [...]}` and `GET /a2a/members?channel=<name>` → `{"members": [...]}` (400 if channel missing); docstring endpoint list and startup print updated
- **mcp_server.py**: five A2A tools registered — `a2a_channels`, `a2a_members`, `a2a_send`, `a2a_read`, `a2a_join` — following exact existing tool registration pattern; mcp stays optional
- **taosmd/docs/a2a-comms.md**: imperative agent-readable setup guide covering install check, running-instance check, bus start, channel join, invite block generation, full endpoint + MCP reference table
- **taosmd/__init__.py**: `a2a_setup_guide()` reads the bundled guide via `importlib.resources`, exported in `__all__`; mirrors `agent_rules()`
- **.claude/skills/taosmd-a2a/SKILL.md**: thin skill with YAML frontmatter; body instructs agent to read the guide and execute it
- **tests/test_a2a_channels.py**: 19 hermetic tests (service grouping/members/counts/timestamps/sort, HTTP round-trips, 400 on missing param, `a2a_setup_guide()` content checks)

## Test plan

- [ ] `python3 -m pytest -q` — 427 passed (master baseline + 19 new tests)
- [ ] `python3 -m pytest tests/test_a2a_channels.py -v` — all 19 green
- [ ] No existing tests broken; all additive