### PR TITLE
fix(audit): Hermes audit batch 2 — 6 issues fixed

### DIFF
--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -12,6 +12,7 @@ Storage: data/archive/YYYY/MM/DD.jsonl (one JSON line per event, gzipped after d
 from __future__ import annotations
 
 import gzip
+import hashlib
 import json
 import logging
 import os
@@ -193,6 +194,13 @@ class ArchiveStore:
         # Write to JSONL
         f, file_path = self._ensure_file(ts)
         line = json.dumps(event, default=str)
+        # Append a per-entry SHA-256 content hash so bit-rot and truncated
+        # writes are detectable later with verify_entry() / verify_day().
+        # The checksum covers the serialised event line (excluding the
+        # newline), stored as a separate ``sha256`` key so readers that
+        # don't know about checksums can ignore it transparently.
+        event["sha256"] = hashlib.sha256(line.encode()).hexdigest()
+        line = json.dumps(event, default=str)
         f.write(line + "\n")
         f.flush()
 
@@ -364,6 +372,80 @@ class ArchiveStore:
             "events": {r["event_type"]: r["n"] for r in rows},
             "total": sum(r["n"] for r in rows),
         }
+
+    # ------------------------------------------------------------------
+    # Integrity verification
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def verify_entry(line: str) -> bool:
+        """Return True if the JSONL line passes its embedded SHA-256 check.
+
+        Lines without a ``sha256`` key (written before checksums were added)
+        are treated as valid — the check is additive and backwards-compatible.
+        A missing or blank line is considered invalid.
+        """
+        line = line.strip()
+        if not line:
+            return False
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        stored = record.get("sha256")
+        if stored is None:
+            # Legacy entry — no checksum, pass through.
+            return True
+        # Recompute over the line as it was written, i.e. without the sha256
+        # key.  Strip sha256 before reserialising to reconstruct the original
+        # line that was hashed.
+        original = dict(record)
+        del original["sha256"]
+        original_line = json.dumps(original, default=str)
+        expected = hashlib.sha256(original_line.encode()).hexdigest()
+        return stored == expected
+
+    async def verify_day(self, date: str) -> dict:
+        """Verify checksums for every entry in a day's JSONL file.
+
+        Returns ``{"date": date, "total": N, "ok": M, "bad": K, "legacy": L}``
+        where ``legacy`` counts entries without a checksum (pre-checksum rows).
+        Does not raise on individual failures — the caller decides how to
+        handle them.
+        """
+        parts = date.split("-")
+        path = self._archive_dir / parts[0] / parts[1] / f"{parts[2]}.jsonl"
+        gz_path = path.with_suffix(".jsonl.gz")
+
+        lines: list[str] = []
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+        elif gz_path.exists():
+            with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                lines = fh.readlines()
+
+        total = ok = bad = legacy = 0
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            total += 1
+            try:
+                record = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                bad += 1
+                continue
+            if record.get("sha256") is None:
+                legacy += 1
+                ok += 1
+                continue
+            if self.verify_entry(line):
+                ok += 1
+            else:
+                bad += 1
+
+        return {"date": date, "total": total, "ok": ok, "bad": bad, "legacy": legacy}
 
     # ------------------------------------------------------------------
     # Stats

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -17,6 +17,7 @@ import time
 from pathlib import Path
 
 from . import _db
+from .predicate_vocab import SINGULAR_PREDICATES
 
 logger = logging.getLogger(__name__)
 
@@ -364,11 +365,10 @@ class TemporalKnowledgeGraph:
     # Contradiction detection
     # ------------------------------------------------------------------
 
-    # Predicates where only one active value should exist per subject
-    SINGULAR_PREDICATES = {
-        "is_a", "works_on", "lives_in", "prefers", "uses_model",
-        "runs_on", "managed_by", "owned_by", "located_in",
-    }
+    # Predicates where only one active value should exist per subject.
+    # Sourced from the closed vocab in predicate_vocab.SINGULAR_PREDICATES
+    # so that the contradiction-detection set and the vocab stay in sync.
+    SINGULAR_PREDICATES = SINGULAR_PREDICATES
 
     async def detect_contradictions(
         self,

--- a/taosmd/predicate_vocab.py
+++ b/taosmd/predicate_vocab.py
@@ -273,9 +273,34 @@ def extract_with_vocab(text: str) -> list[dict]:
     return facts
 
 
+# ---------------------------------------------------------------------------
+# Singular predicates — for contradiction detection
+# ---------------------------------------------------------------------------
+
+# Predicates where only one active value per subject makes semantic sense.
+# Any (subject, predicate, new_object) triple where the same subject already
+# has a *different* active object for the same predicate is a contradiction.
+# Keep this set a subset of ALLOWED_PREDICATES and curate deliberately —
+# adding a predicate here means the detector will flag duplicates for it.
+SINGULAR_PREDICATES: frozenset[str] = frozenset({
+    "is_a",
+    "works_on",
+    "lives_in",
+    "prefers",
+    "uses_model",
+    "runs_on",
+    "managed_by",
+    "owned_by",
+    "located_in",
+    "works_at",
+    "moved_to",
+    "birth_place",
+})
+
 __all__ = [
     "ALLOWED_PREDICATES",
     "PREDICATE_CATEGORIES",
+    "SINGULAR_PREDICATES",
     "SYNONYMS",
     "INVERSE_DIRECTION",
     "RELATIONSHIP_PATTERNS",

--- a/taosmd/retrieval.py
+++ b/taosmd/retrieval.py
@@ -61,20 +61,32 @@ def _adapt_kg(results: list[dict]) -> list[dict]:
     for rank, r in enumerate(results):
         direction = r.get("direction", "outgoing")
         if direction == "outgoing":
+            # Anchor is the subject; predicate points toward the object.
+            # query_entity() for outgoing joins on object_id → object_name.
             subject = r.get("subject_name", r.get("subject_id", ""))
             obj = r.get("object_name", r.get("object_id", ""))
         else:
+            # Anchor is the object side of the triple; the far node is the
+            # subject.  query_entity() for incoming joins on subject_id →
+            # subject_name, so object_name is absent — use object_id (the
+            # normalised anchor key) as a readable fallback.
             subject = r.get("subject_name", r.get("subject_id", ""))
-            obj = r.get("object_name", r.get("object_id", ""))
+            obj = r.get("object_name") or r.get("object_id", "")
 
         predicate = r.get("predicate", "")
         text = f"{subject} {predicate} {obj}"
+        # source_id tracks the anchor entity: the subject for outgoing edges,
+        # the object (anchor that was queried) for incoming edges.
+        if direction == "outgoing":
+            source_id = str(r.get("subject_id", ""))
+        else:
+            source_id = str(r.get("object_id", ""))
 
         adapted.append(
             {
                 "text": text,
                 "source": "kg",
-                "source_id": str(r.get("subject_id", "")),
+                "source_id": source_id,
                 "rank": rank,
                 "source_score": float(r.get("confidence", 1.0)),
                 "metadata": r,
@@ -441,6 +453,51 @@ def _user_metadata(hit: dict) -> dict:
     return inner if isinstance(inner, dict) else meta
 
 
+async def _apply_llm_rerank(
+    query: str,
+    results: list[dict],
+    llm_reranker: dict,
+    top_k: int,
+) -> list[dict]:
+    """Apply the LLM listwise reranker if configured.
+
+    ``llm_reranker`` must be a dict with at least ``client``,
+    ``ollama_url``, and ``model`` keys (see :func:`retrieve` docstring).
+    On any failure the input list is returned truncated to ``top_k``.
+    """
+    if not llm_reranker or not results:
+        return results
+    try:
+        from taosmd.llm_rerank import llm_listwise_rerank  # noqa: PLC0415
+    except ImportError:
+        return results
+
+    client = llm_reranker.get("client")
+    ollama_url = llm_reranker.get("ollama_url", "")
+    model = llm_reranker.get("model", "")
+    if not client or not ollama_url or not model:
+        logger.debug("_apply_llm_rerank: missing required keys, skipping")
+        return results
+
+    no_think = llm_reranker.get("no_think_prefix", False)
+    timeout = float(llm_reranker.get("timeout", 60.0))
+
+    try:
+        return await llm_listwise_rerank(
+            client=client,
+            ollama_url=ollama_url,
+            rerank_model=model,
+            query=query,
+            candidates=results,
+            top_k=top_k,
+            timeout=timeout,
+            no_think_prefix=no_think,
+        )
+    except Exception as exc:
+        logger.debug("_apply_llm_rerank: failed (%s); using upstream order", exc)
+        return results[:top_k]
+
+
 async def _attach_neighbors(
     hits: list[dict],
     sources: dict,
@@ -545,6 +602,7 @@ async def retrieve(
     sources: dict | None = None,
     limit: int = 5,
     reranker: object | None = None,
+    llm_reranker: object | None = None,
     agent: str | None = None,
     worker_capabilities: dict | None = None,
     agent_name: str = "",
@@ -567,6 +625,31 @@ async def retrieve(
             so the per-agent fan-out setting controls the per-layer K.
         reranker: Optional CrossEncoderReranker instance. When provided and
             ``reranker.available`` is True, used for thorough/custom reranking.
+        llm_reranker: Optional dict enabling the LLM listwise reranker as an
+            opt-in second-pass stage.  Default ``None`` (off).
+
+            When supplied it must be a dict with the following keys:
+
+            * ``client``  — an ``httpx.AsyncClient`` already open for the
+              session lifetime.
+            * ``ollama_url`` — base URL of the Ollama server.
+            * ``model``  — Ollama model tag to use for reranking (e.g.
+              ``"qwen3:4b"``).
+
+            Optional keys:
+
+            * ``no_think_prefix`` (bool, default False) — prepend ``/no_think``
+              to suppress chain-of-thought tokens on models that support it.
+            * ``timeout`` (float, default 60.0) — per-call timeout in seconds.
+
+            The reranker is applied after the cross-encoder stage (when
+            ``reranker`` is also set) in "thorough" and "custom" strategies.
+            On any network or parse failure the stage is skipped silently and
+            the upstream ordering is preserved.
+
+            **Default is off** — full-scale validation on LoCoMo-1540 is still
+            pending.  Enabling this without benchmarking on your data is
+            discouraged.
         agent: Registered agent name. When given, ``effective_fanout`` is
             called to resolve the per-layer K from the agent's librarian
             fanout config and the supplied worker capabilities.
@@ -623,6 +706,9 @@ async def retrieve(
 
         if reranker is not None and getattr(reranker, "available", False):
             results = reranker.rerank(query, results, limit)
+
+        if llm_reranker is not None:
+            results = await _apply_llm_rerank(query, results, llm_reranker, limit)
 
         if verify and is_task_enabled(agent_name, "verification"):
             results = await _apply_verification(query, results, agent_name)
@@ -704,6 +790,9 @@ async def retrieve(
 
         if reranker is not None and getattr(reranker, "available", False):
             results = reranker.rerank(query, results, limit)
+
+        if llm_reranker is not None:
+            results = await _apply_llm_rerank(query, results, llm_reranker, limit)
 
         results = results[:limit]
         if adjacent_neighbors > 0:

--- a/taosmd/temporal_boost.py
+++ b/taosmd/temporal_boost.py
@@ -94,11 +94,24 @@ def temporal_rerank(results: list[dict], query: str, boost_factor: float = 0.2) 
             overlap = len(query_words & text_words) / max(len(query_words), 1)
             boost += overlap * boost_factor
 
-        # Apply boost
+        # Apply boost to whichever ranking field is present.
+        # Results from hybrid fusion (fusion="rrf", "bm25_rrf", …) carry an
+        # ``rrf_score`` that is the field actually used for final ordering; pure
+        # semantic results only carry ``similarity``.  Boosting the wrong field
+        # leaves the ranking unchanged — hence prefer rrf_score when it exists.
         if boost > 0:
-            r["similarity"] = min(1.0, r.get("similarity", 0) + boost)
+            if "rrf_score" in r:
+                r["rrf_score"] = r["rrf_score"] + boost
+            else:
+                r["similarity"] = min(1.0, r.get("similarity", 0) + boost)
             r["temporal_boost"] = round(boost, 4)
 
-    # Re-sort by boosted similarity
-    results.sort(key=lambda x: x.get("similarity", 0), reverse=True)
+    # Re-sort by the same field used for initial ordering.
+    # Use rrf_score when present (hybrid results); fall back to similarity.
+    def _rank_key(x: dict) -> float:
+        if "rrf_score" in x:
+            return x["rrf_score"]
+        return x.get("similarity", 0)
+
+    results.sort(key=_rank_key, reverse=True)
     return results

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -90,6 +90,13 @@ class VectorMemory:
         self._local_model = None
         self._onnx_session = None
         self._onnx_tokenizer = None
+        # BM25 index cache: rebuilt lazily and invalidated whenever the active
+        # corpus changes (add / supersede).  Keyed by fusion mode because
+        # bm25_rrf and bm25_lemma_rrf index different text forms.
+        # ``_bm25_cache`` maps mode → (retriever, texts, ids) tuple.
+        # ``_bm25_dirty`` is set on every write so the next query rebuilds.
+        self._bm25_cache: dict[str, tuple] = {}
+        self._bm25_dirty: bool = True
 
     async def init(self, http_client=None) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
@@ -250,6 +257,7 @@ class VectorMemory:
             (text, embedding_text, json.dumps(metadata or {}), now),
         )
         self._conn.commit()
+        self._bm25_dirty = True  # corpus changed — invalidate BM25 cache
         return cursor.lastrowid
 
     async def search(
@@ -373,10 +381,22 @@ class VectorMemory:
                     else:
                         bm25_texts = texts
                         bm25_query = query
-                    corpus_tokens = bm25s.tokenize(bm25_texts, stopwords=None, stemmer=None)
+                    # Build / reuse cached BM25 index for this fusion mode.
+                    # The cache is keyed by fusion mode and valid while the
+                    # active corpus is unchanged (_bm25_dirty is False).
+                    # Each entry is (retriever, bm25_texts_used) so a
+                    # corpus change (add / supersede) forces a full rebuild.
+                    cache_key = fusion
+                    cached = self._bm25_cache.get(cache_key)
+                    if self._bm25_dirty or cached is None or cached[1] != bm25_texts:
+                        corpus_tokens = bm25s.tokenize(bm25_texts, stopwords=None, stemmer=None)
+                        retriever = bm25s.BM25(k1=1.5, b=0.75)
+                        retriever.index(corpus_tokens)
+                        self._bm25_cache[cache_key] = (retriever, bm25_texts)
+                        self._bm25_dirty = False
+                    else:
+                        retriever = cached[0]
                     query_tokens = bm25s.tokenize([bm25_query], stopwords=None, stemmer=None)
-                    retriever = bm25s.BM25(k1=1.5, b=0.75)
-                    retriever.index(corpus_tokens)
                     bm25_indices, bm25_raw = retriever.retrieve(query_tokens, k=n)
                     # ranks for RRF
                     keyword_ranks = np.empty(n, dtype=np.int64)
@@ -543,6 +563,8 @@ class VectorMemory:
             (end, row_id),
         )
         self._conn.commit()
+        if cursor.rowcount > 0:
+            self._bm25_dirty = True  # active corpus changed — invalidate BM25 cache
         return cursor.rowcount > 0
 
     async def supersede_matching(self, text_or_substring: str, ended_at: float | None = None) -> int:
@@ -568,6 +590,8 @@ class VectorMemory:
             (end, text_or_substring),
         )
         self._conn.commit()
+        if cursor.rowcount > 0:
+            self._bm25_dirty = True  # active corpus changed — invalidate BM25 cache
         return cursor.rowcount
 
     async def clear(self) -> int:

--- a/tests/test_hermes_audit_batch2.py
+++ b/tests/test_hermes_audit_batch2.py
@@ -1,0 +1,531 @@
+"""Tests for Hermes Agent Audit batch-2 fixes.
+
+Covers issues #94, #93, #103, #105, #108, #111.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# #94 — temporal_boost writes to rrf_score when present
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_boost_affects_rrf_score_field():
+    """Boost must land on rrf_score (not only similarity) for hybrid results."""
+    from taosmd.temporal_boost import temporal_rerank
+
+    # Simulated results from vmem.search(fusion="rrf") — both fields present.
+    # Result A has higher similarity but lower rrf_score; after temporal boost
+    # it should be promoted when it contains strong temporal signals.
+    results = [
+        {
+            "id": 1,
+            "text": "2024-01-15 meeting happened on Monday morning",
+            "similarity": 0.90,
+            "rrf_score": 0.010,
+        },
+        {
+            "id": 2,
+            "text": "general discussion about the project",
+            "similarity": 0.92,
+            "rrf_score": 0.050,
+        },
+    ]
+
+    query = "when did the first meeting happen"
+    boosted = temporal_rerank(results, query, boost_factor=0.5)
+
+    # The temporal entry (id=1) should have received a temporal_boost marker.
+    temporal_result = next(r for r in boosted if r["id"] == 1)
+    assert "temporal_boost" in temporal_result
+    assert temporal_result["temporal_boost"] > 0
+
+    # rrf_score on the boosted entry must be larger than the original 0.010.
+    assert temporal_result["rrf_score"] > 0.010
+
+
+def test_temporal_boost_falls_back_to_similarity_when_no_rrf_score():
+    """For pure-semantic results (no rrf_score), boost goes to similarity."""
+    from taosmd.temporal_boost import temporal_rerank
+
+    results = [
+        {"id": 1, "text": "2023-11-14 event occurred on Tuesday afternoon", "similarity": 0.70},
+        {"id": 2, "text": "unrelated text", "similarity": 0.95},
+    ]
+    query = "when did that event happen last month"
+    boosted = temporal_rerank(results, query, boost_factor=0.4)
+
+    temporal_result = next(r for r in boosted if r["id"] == 1)
+    assert "temporal_boost" in temporal_result
+    # similarity must be > 0.70 after boost
+    assert temporal_result["similarity"] > 0.70
+    # no rrf_score key should be injected
+    assert "rrf_score" not in temporal_result
+
+
+def test_temporal_boost_reorders_by_rrf_score_not_similarity():
+    """When rrf_score is present, the sort key must be rrf_score."""
+    from taosmd.temporal_boost import temporal_rerank
+
+    # id=1: lower similarity, lower rrf_score — but rich temporal content.
+    # id=2: higher similarity, higher rrf_score — no temporal content.
+    # The boost should push id=1's rrf_score above id=2's.
+    results = [
+        {
+            "id": 1,
+            "text": "January 2024 the project launched on Friday morning 15 days after",
+            "similarity": 0.60,
+            "rrf_score": 0.010,
+        },
+        {
+            "id": 2,
+            "text": "no date info here at all",
+            "similarity": 0.99,
+            "rrf_score": 0.020,
+        },
+    ]
+    query = "when did the project launch in January"
+    boosted = temporal_rerank(results, query, boost_factor=1.0)
+
+    # id=1 must be ranked first after a large boost
+    assert boosted[0]["id"] == 1, "temporally rich result should be ranked first"
+
+
+# ---------------------------------------------------------------------------
+# #93 — _adapt_kg direction: source_id and text for incoming edges
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_kg_outgoing_source_id_is_subject():
+    from taosmd.retrieval import _adapt_kg
+
+    row = {
+        "subject_id": "person:alice",
+        "subject_name": "Alice",
+        "predicate": "works_at",
+        "object_id": "org:jan_labs",
+        "object_name": "JAN Labs",
+        "direction": "outgoing",
+        "confidence": 1.0,
+    }
+    adapted = _adapt_kg([row])
+    assert adapted[0]["source_id"] == "person:alice"
+    assert "Alice works_at JAN Labs" == adapted[0]["text"]
+
+
+def test_adapt_kg_incoming_source_id_is_object():
+    from taosmd.retrieval import _adapt_kg
+
+    # Incoming query on "jan_labs": subject_name = "Alice" (far node),
+    # object_id = "org:jan_labs" (the anchor that was queried).
+    row = {
+        "subject_id": "person:alice",
+        "subject_name": "Alice",
+        "predicate": "works_at",
+        "object_id": "org:jan_labs",
+        "direction": "incoming",
+        "confidence": 0.9,
+        # object_name is absent in real incoming results (no join for it)
+    }
+    adapted = _adapt_kg([row])
+    # source_id must track the anchor (object_id), not the far node
+    assert adapted[0]["source_id"] == "org:jan_labs"
+    # text must include the far-node subject
+    assert "Alice" in adapted[0]["text"]
+
+
+def test_adapt_kg_incoming_and_outgoing_differ():
+    from taosmd.retrieval import _adapt_kg
+
+    outgoing_row = {
+        "subject_id": "alice",
+        "subject_name": "Alice",
+        "predicate": "knows",
+        "object_id": "bob",
+        "object_name": "Bob",
+        "direction": "outgoing",
+        "confidence": 1.0,
+    }
+    incoming_row = {
+        "subject_id": "alice",
+        "subject_name": "Alice",
+        "predicate": "knows",
+        "object_id": "charlie",
+        "direction": "incoming",
+        "confidence": 1.0,
+    }
+    adapted = _adapt_kg([outgoing_row, incoming_row])
+    assert adapted[0]["source_id"] != adapted[1]["source_id"], (
+        "outgoing and incoming source_ids must differ"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #103 — BM25 cache: index rebuilt once, invalidated on write
+# ---------------------------------------------------------------------------
+
+
+def test_bm25_cache_is_populated_after_search(tmp_path):
+    """After a bm25_rrf search the cache entry must be set."""
+    from taosmd.vector_memory import VectorMemory
+
+    vm = VectorMemory(db_path=tmp_path / "vm.db", embed_mode="qmd")
+
+    async def go():
+        # Patch embed so no real HTTP call is made
+        vm._embed_mode = "local"
+
+        with patch.object(vm, "embed", new=AsyncMock(return_value=[0.1] * 8)):
+            await vm.init()
+            await vm.add("the quick brown fox jumps over the lazy dog")
+            await vm.add("a second document about cats and dogs")
+
+            # Cache should be dirty before first search
+            assert vm._bm25_dirty is True
+
+            results = await vm.search("quick fox", hybrid=True, fusion="bm25_rrf", limit=2)
+
+        # After a bm25_rrf search the cache must be populated and clean
+        assert "bm25_rrf" in vm._bm25_cache
+        assert vm._bm25_dirty is False
+
+    asyncio.run(go())
+
+
+def test_bm25_cache_invalidated_on_add(tmp_path):
+    """Adding a new document must mark the cache dirty."""
+    from taosmd.vector_memory import VectorMemory
+
+    vm = VectorMemory(db_path=tmp_path / "vm.db", embed_mode="qmd")
+
+    async def go():
+        with patch.object(vm, "embed", new=AsyncMock(return_value=[0.1] * 8)):
+            await vm.init()
+            await vm.add("first document")
+            await vm.search("first", hybrid=True, fusion="bm25_rrf", limit=1)
+
+            # Cache populated and clean
+            assert vm._bm25_dirty is False
+
+            # Adding a new doc must dirty the cache
+            await vm.add("second document added later")
+            assert vm._bm25_dirty is True
+
+    asyncio.run(go())
+
+
+def test_bm25_cache_not_rebuilt_on_second_query(tmp_path):
+    """Two consecutive queries on the same corpus must reuse the cached index."""
+    from taosmd.vector_memory import VectorMemory
+
+    vm = VectorMemory(db_path=tmp_path / "vm.db", embed_mode="qmd")
+
+    async def go():
+        with patch.object(vm, "embed", new=AsyncMock(return_value=[0.2] * 8)):
+            await vm.init()
+            await vm.add("cats are independent animals")
+            await vm.add("dogs are loyal companions")
+
+            await vm.search("cats", hybrid=True, fusion="bm25_rrf", limit=1)
+            first_retriever = vm._bm25_cache["bm25_rrf"][0]
+
+            await vm.search("dogs", hybrid=True, fusion="bm25_rrf", limit=1)
+            second_retriever = vm._bm25_cache["bm25_rrf"][0]
+
+        # Same object — not rebuilt
+        assert first_retriever is second_retriever
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# #105 — Contradiction detection uses predicate_vocab.SINGULAR_PREDICATES
+# ---------------------------------------------------------------------------
+
+
+def test_singular_predicates_exported_from_vocab():
+    """SINGULAR_PREDICATES must be importable from predicate_vocab."""
+    from taosmd.predicate_vocab import SINGULAR_PREDICATES, ALLOWED_PREDICATES
+
+    assert isinstance(SINGULAR_PREDICATES, frozenset)
+    assert len(SINGULAR_PREDICATES) > 0
+    # Every singular predicate must be in the allowed set
+    assert SINGULAR_PREDICATES.issubset(ALLOWED_PREDICATES)
+
+
+def test_knowledge_graph_singular_predicates_matches_vocab():
+    """TemporalKnowledgeGraph.SINGULAR_PREDICATES must equal the vocab set."""
+    from taosmd.knowledge_graph import TemporalKnowledgeGraph
+    from taosmd.predicate_vocab import SINGULAR_PREDICATES
+
+    assert TemporalKnowledgeGraph.SINGULAR_PREDICATES == SINGULAR_PREDICATES
+
+
+def test_contradiction_detected_for_vocab_predicate(tmp_path):
+    """detect_contradictions fires for predicates now in the vocab-derived set."""
+    from taosmd.knowledge_graph import TemporalKnowledgeGraph
+    from taosmd.predicate_vocab import SINGULAR_PREDICATES
+
+    # Pick a predicate that IS in vocab's SINGULAR_PREDICATES but was NOT in
+    # the old hardcoded set (works_at was added in the vocab extension).
+    assert "works_at" in SINGULAR_PREDICATES
+
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+
+        await kg.add_triple("Alice", "works_at", "CompanyA")
+        contradictions = await kg.detect_contradictions("Alice", "works_at", "CompanyB")
+        await kg.close()
+        return contradictions
+
+    contradictions = asyncio.run(go())
+    assert len(contradictions) == 1
+    assert contradictions[0]["object_name"].lower() == "companya"
+
+
+def test_no_contradiction_for_non_singular_predicate(tmp_path):
+    """Non-singular predicates must NOT trigger contradiction detection."""
+    from taosmd.knowledge_graph import TemporalKnowledgeGraph
+    from taosmd.predicate_vocab import SINGULAR_PREDICATES
+
+    # "knows" is many-to-many — should NOT be singular
+    assert "knows" not in SINGULAR_PREDICATES
+
+    async def go():
+        kg = TemporalKnowledgeGraph(db_path=tmp_path / "kg.db")
+        await kg.init()
+
+        await kg.add_triple("Alice", "knows", "Bob")
+        contradictions = await kg.detect_contradictions("Alice", "knows", "Charlie")
+        await kg.close()
+        return contradictions
+
+    contradictions = asyncio.run(go())
+    assert contradictions == []
+
+
+# ---------------------------------------------------------------------------
+# #108 — LLM reranker wired into retrieve() as opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_accepts_llm_reranker_param():
+    """retrieve() must accept llm_reranker kwarg without error when None."""
+    import inspect
+    from taosmd.retrieval import retrieve
+
+    sig = inspect.signature(retrieve)
+    assert "llm_reranker" in sig.parameters
+
+
+def test_retrieve_calls_llm_reranker_when_set():
+    """When llm_reranker dict is supplied, _apply_llm_rerank must be called."""
+    from taosmd.retrieval import retrieve
+
+    call_log = []
+
+    async def fake_llm_rerank(query, results, llm_reranker, top_k):
+        call_log.append({"query": query, "n": len(results)})
+        return list(reversed(results))[:top_k]  # flip order to prove it was called
+
+    class MockVMem:
+        async def search(self, q, limit=5, hybrid=True, **_):
+            return [
+                {"id": 1, "text": "alpha", "similarity": 0.9, "metadata": {}, "created_at": 1.0},
+                {"id": 2, "text": "beta", "similarity": 0.8, "metadata": {}, "created_at": 1.0},
+                {"id": 3, "text": "gamma", "similarity": 0.7, "metadata": {}, "created_at": 1.0},
+            ]
+
+    dummy_reranker_cfg = {
+        "client": object(),
+        "ollama_url": "http://localhost:11434",
+        "model": "test-model",
+    }
+
+    async def go():
+        with patch("taosmd.retrieval._apply_llm_rerank", side_effect=fake_llm_rerank):
+            results = await retrieve(
+                query="test query",
+                strategy="thorough",
+                sources={"vector": MockVMem()},
+                limit=2,
+                llm_reranker=dummy_reranker_cfg,
+            )
+        return results
+
+    results = asyncio.run(go())
+    assert len(call_log) == 1, "_apply_llm_rerank should have been called once"
+    assert call_log[0]["query"] == "test query"
+
+
+def test_retrieve_default_behavior_unchanged_without_llm_reranker():
+    """When llm_reranker=None (default), behavior is unchanged."""
+    from taosmd.retrieval import retrieve
+
+    call_log = []
+
+    class MockVMem:
+        async def search(self, q, limit=5, hybrid=True, **_):
+            return [
+                {"id": 1, "text": "result one", "similarity": 0.9, "metadata": {}, "created_at": 1.0},
+            ]
+
+    async def go():
+        with patch("taosmd.retrieval._apply_llm_rerank", side_effect=lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not be called"))):
+            return await retrieve(
+                query="test",
+                strategy="thorough",
+                sources={"vector": MockVMem()},
+                limit=1,
+                llm_reranker=None,  # default — must not call LLM reranker
+            )
+
+    # Must succeed without raising
+    results = asyncio.run(go())
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# #111 — Archive entry checksums
+# ---------------------------------------------------------------------------
+
+
+def test_archive_record_writes_sha256(tmp_path):
+    """Every recorded event must have a sha256 field in the JSONL line."""
+    from taosmd.archive import ArchiveStore
+
+    async def go():
+        store = ArchiveStore(
+            archive_dir=tmp_path / "archive",
+            index_path=tmp_path / "idx.db",
+        )
+        await store.init()
+        await store.record("test_event", {"content": "hello world"}, summary="test")
+        await store.close()
+
+    asyncio.run(go())
+
+    jsonl_files = list((tmp_path / "archive").rglob("*.jsonl"))
+    assert len(jsonl_files) == 1
+
+    with open(jsonl_files[0], "r", encoding="utf-8") as fh:
+        line = fh.readline().strip()
+
+    record = json.loads(line)
+    assert "sha256" in record, "sha256 key must be present in every JSONL entry"
+    assert len(record["sha256"]) == 64, "sha256 must be a 64-char hex string"
+
+
+def test_verify_entry_passes_for_intact_record(tmp_path):
+    """verify_entry() must return True for a freshly written line."""
+    from taosmd.archive import ArchiveStore
+
+    async def go():
+        store = ArchiveStore(
+            archive_dir=tmp_path / "archive",
+            index_path=tmp_path / "idx.db",
+        )
+        await store.init()
+        await store.record("test_event", {"content": "integrity check"})
+        await store.close()
+
+    asyncio.run(go())
+
+    jsonl_files = list((tmp_path / "archive").rglob("*.jsonl"))
+    with open(jsonl_files[0], "r", encoding="utf-8") as fh:
+        line = fh.readline()
+
+    assert ArchiveStore.verify_entry(line) is True
+
+
+def test_verify_entry_fails_for_tampered_record():
+    """verify_entry() must return False when the content doesn't match the hash."""
+    import hashlib
+    import json
+    from taosmd.archive import ArchiveStore
+
+    event = {
+        "timestamp": 1700000000.0,
+        "event_type": "test",
+        "agent_name": None,
+        "app_id": None,
+        "summary": "original",
+        "data": {"content": "original"},
+    }
+    # Build a valid line
+    line_for_hash = json.dumps(event, default=str)
+    event["sha256"] = hashlib.sha256(line_for_hash.encode()).hexdigest()
+    # Now tamper with the content
+    event["summary"] = "tampered"
+    tampered_line = json.dumps(event, default=str)
+
+    assert ArchiveStore.verify_entry(tampered_line) is False
+
+
+def test_verify_entry_passes_for_legacy_record_without_sha256():
+    """Legacy entries without sha256 must pass verify_entry (backwards compat)."""
+    import json
+    from taosmd.archive import ArchiveStore
+
+    legacy_event = {
+        "timestamp": 1700000000.0,
+        "event_type": "legacy",
+        "summary": "old entry",
+        "data": {},
+    }
+    line = json.dumps(legacy_event)
+    assert ArchiveStore.verify_entry(line) is True
+
+
+def test_verify_day_reports_correct_counts(tmp_path):
+    """verify_day() must count ok / bad / legacy entries correctly."""
+    from taosmd.archive import ArchiveStore
+
+    async def go():
+        store = ArchiveStore(
+            archive_dir=tmp_path / "archive",
+            index_path=tmp_path / "idx.db",
+        )
+        await store.init()
+        # Write two clean entries
+        import taosmd.archive as archive_mod
+        from unittest.mock import patch as _patch
+        # Pin timestamp so both go to the same day file
+        fixed_ts = 1_700_000_000.0
+        with _patch.object(archive_mod.time, "time", return_value=fixed_ts):
+            await store.record("ev", {"x": 1})
+            await store.record("ev", {"x": 2})
+        await store.close()
+        return fixed_ts
+
+    fixed_ts = asyncio.run(go())
+
+    from datetime import datetime, timezone
+    dt = datetime.fromtimestamp(fixed_ts, tz=timezone.utc)
+    date_str = f"{dt.year}-{dt.month:02d}-{dt.day:02d}"
+
+    async def verify():
+        store = ArchiveStore(
+            archive_dir=tmp_path / "archive",
+            index_path=tmp_path / "idx.db",
+        )
+        await store.init()
+        result = await store.verify_day(date_str)
+        await store.close()
+        return result
+
+    result = asyncio.run(verify())
+    assert result["total"] == 2
+    assert result["ok"] == 2
+    assert result["bad"] == 0
+    assert result["legacy"] == 0


### PR DESCRIPTION
## Summary

Addresses 6 of the 7 remaining open Hermes Agent Audit issues. Issue #102 (transactional consistency) received a design-options analysis comment instead of code changes, as directed.

- **#94 [Critical]** `temporal_boost` field mismatch: boost now written to `rrf_score` when present (hybrid results), falls back to `similarity` for pure-semantic results. Re-sort key matches the field used.
- **#93 [Critical]** `_adapt_kg` direction: incoming edges now record `object_id` (the queried anchor) as `source_id`, not `subject_id` (the far node). Both arms previously produced identical output.
- **#103 [Design]** BM25 per-query rebuild: `VectorMemory` now caches the built index per fusion mode. Invalidated on `add()` / `supersede()`. No behaviour change, no result change.
- **#105 [Design]** Contradiction predicates: `SINGULAR_PREDICATES` moved to `predicate_vocab` (the closed-vocab source of truth) and extended with `works_at`, `moved_to`, `birth_place`. `TemporalKnowledgeGraph.SINGULAR_PREDICATES` is now an alias.
- **#108 [Design]** LLM reranker wired as opt-in: `retrieve()` accepts `llm_reranker=None` (default off). When supplied with `{client, ollama_url, model}`, `llm_listwise_rerank()` runs after the cross-encoder in thorough/custom strategies. Full-scale LoCoMo-1540 validation pending before enabling by default.
- **#111 [Ops]** Archive checksums: `record()` appends a `sha256` field per entry. New `verify_entry()` + `verify_day()` helpers. Backwards-compatible — legacy entries without checksums pass through.
- **#102 [Design]** Design analysis comment posted on the issue directly. No code change.

## Test plan

- [ ] `python3 -m pytest tests/ -q` — 455 passed (434 baseline + 21 new)
- [ ] 21 new tests in `tests/test_hermes_audit_batch2.py` covering each fixed issue
- [ ] Default `retrieve()` behavior unchanged (no `llm_reranker` set by default)
- [ ] Old archives without checksums still load and verify as valid