### PR TITLE
feat(consistency): reconcile vector store from the archive

### DIFF
--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -384,6 +384,134 @@ async def resolve_pending_decision(
         await store.close()
 
 
+async def reconcile(*, agent: str, data_dir=None, repair: bool = True) -> dict:
+    """Detect archive turns missing from the vector store and optionally re-add them.
+
+    The append-only archive is the source of truth (Option A). The vector store
+    is a derived index. A crash between the archive write and the vector write in
+    :func:`ingest` leaves a turn present in the archive but absent from vector
+    recall. This function detects and, when ``repair=True``, corrects that gap.
+
+    **How missing is computed**
+
+    Build a ``Counter`` (multiset) of texts from both stores, then subtract the
+    vector multiset from the archive multiset. A text that appears twice in the
+    archive but only once in the vector store counts as 1 missing copy; a text
+    present in the archive but entirely absent from the vector store counts as N
+    missing copies where N is its archive count.
+
+    **Supersede guard**
+
+    ``iter_entries(include_superseded=True)`` includes intentionally superseded
+    rows in the vector multiset, so a turn whose vector copy was soft-hidden by a
+    correction is counted as *present* and is not re-added. Corrected/stale
+    content is therefore never resurrected by reconcile.
+
+    **Chunking**
+
+    ``add()`` stores each turn as one row (no splitting). The comparison is done
+    at the full-turn level: the archive's ``data.content`` field is compared
+    directly against the stored ``text`` column values. Archive rows whose content
+    field is empty or whitespace-only are skipped (they were skipped at ingest
+    time too, so they can never be in the vector store).
+
+    Args:
+        agent: Agent name whose archive + vector entries are reconciled.
+        data_dir: Optional taosmd data dir. Defaults to ``$TAOSMD_DATA_DIR`` or
+            ``~/.taosmd``.
+        repair: When True (default), re-add missing entries to the vector store.
+            When False, only report without modifying (dry-run / ``--check``).
+
+    Returns:
+        ``{
+            "agent": str,
+            "archive_turns": int,   # non-empty conversation turns in the archive
+            "vector_entries": int,  # entries in the vector store (incl. superseded)
+            "missing": int,         # archive turns absent from the vector store
+            "readded": int,         # entries re-added (0 when repair=False)
+            "checked_ok": bool,     # True when missing == 0
+        }``
+    """
+    import json as _json
+    from collections import Counter
+
+    if not agent:
+        raise ValueError("agent name is required")
+
+    stores = await _ensure_stores(data_dir)
+    archive = stores["archive"]
+    vmem = stores["vector"]
+
+    from taosmd.archive import EVENT_CONVERSATION
+
+    # --- Build archive multiset -----------------------------------------
+    # Use a large limit; the archive index is an SQLite table so this is fast.
+    rows = await archive.query(
+        event_type=EVENT_CONVERSATION,
+        agent_name=agent,
+        limit=1_000_000,
+    )
+    archive_texts: list[tuple[str, dict]] = []  # (text, row) for re-add
+    archive_counter: Counter[str] = Counter()
+    for row in rows:
+        try:
+            data = _json.loads(row.get("data_json", "{}"))
+        except (_json.JSONDecodeError, TypeError):
+            data = {}
+        text = str(data.get("content", "")).strip()
+        if not text:
+            continue
+        archive_counter[text] += 1
+        # Keep the first-seen archive row per text value for metadata
+        # reconstruction; duplicates will use the same metadata shape.
+        archive_texts.append((text, data))
+
+    # --- Build vector multiset (including superseded) -------------------
+    vector_counter: Counter[str] = Counter()
+    async for text, _meta in vmem.iter_entries(agent=agent, include_superseded=True):
+        vector_counter[text] += 1
+
+    # --- Compute missing (count-aware subtraction) ----------------------
+    missing_counter: Counter[str] = archive_counter.copy()
+    missing_counter.subtract(vector_counter)
+    # Discard zero or negative counts (present or over-represented in vector)
+    missing: dict[str, int] = {t: c for t, c in missing_counter.items() if c > 0}
+
+    total_missing = sum(missing.values())
+    readded = 0
+
+    if repair and missing:
+        # Build a lookup of text → archive data for timestamp reconstruction.
+        # Only need one representative row per distinct text.
+        text_to_data: dict[str, dict] = {}
+        for text, data in archive_texts:
+            if text not in text_to_data:
+                text_to_data[text] = data
+
+        for text, count in missing.items():
+            data = text_to_data.get(text, {})
+            meta: dict = {"agent": agent}
+            # Propagate role and timestamp from the archive entry where available.
+            if "role" in data:
+                meta["role"] = data["role"]
+            if "timestamp" in data:
+                meta["timestamp"] = data["timestamp"]
+            for _ in range(count):
+                added_id = await vmem.add(text, metadata=meta)
+                if added_id != -1:
+                    readded += 1
+
+    vector_total = sum(vector_counter.values())
+    return {
+        "agent": agent,
+        "archive_turns": sum(archive_counter.values()),
+        "vector_entries": vector_total,
+        "missing": total_missing,
+        "readded": readded,
+        "checked_ok": total_missing == 0,
+    }
+
+
 async def supersede_vectors(match: str, *, data_dir=None) -> int:
     """Soft-supersede vector chunk(s) whose stored text contains ``match``.
 
@@ -403,4 +531,5 @@ __all__ = [
     "list_pending_decisions",
     "resolve_pending_decision",
     "supersede_vectors",
+    "reconcile",
 ]

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -485,6 +485,52 @@ def _review_help() -> str:
     )
 
 
+def _reconcile_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd reconcile`` — compare archive to vector store and repair gaps."""
+    import asyncio  # noqa: PLC0415
+
+    from . import service  # noqa: PLC0415
+    from .agents import AgentRegistry  # noqa: PLC0415
+
+    repair = not args.check
+    data_dir = args.data_dir
+
+    agent_names: list[str]
+    if args.agent:
+        agent_names = [args.agent]
+    else:
+        # Reconcile all registered agents.
+        registry = AgentRegistry(data_dir)
+        agent_names = [a["name"] for a in registry.list_agents()]
+        if not agent_names:
+            print("No registered agents found.")
+            return 0
+
+    any_missing = False
+    for agent in agent_names:
+        result = asyncio.run(service.reconcile(agent=agent, data_dir=data_dir, repair=repair))
+        mode = "check" if not repair else "repair"
+        status = "ok" if result["checked_ok"] else "MISSING"
+        readded_col = f"  re-added={result['readded']}" if repair else ""
+        print(
+            f"[{mode}] {result['agent']:<24} "
+            f"archive={result['archive_turns']}  "
+            f"vector={result['vector_entries']}  "
+            f"missing={result['missing']}  "
+            f"{status}"
+            f"{readded_col}"
+        )
+        if not result["checked_ok"]:
+            any_missing = True
+
+    if any_missing and not repair:
+        print(
+            "\nhint: run without --check to repair, "
+            "or `taosmd reconcile` to re-add missing entries."
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="taosmd")
     parser.add_argument(
@@ -728,6 +774,23 @@ def main(argv: list[str] | None = None) -> int:
         help="Print the running status of the background service.",
     )
 
+    # ----- reconcile subcommand ----------------------------------------
+    reconcile_p = sub.add_parser(
+        "reconcile",
+        help="Detect (and repair) archive turns missing from the vector store "
+             "due to a crash between the two sequential writes in ingest(). "
+             "The archive is the source of truth; this re-adds any absent entries "
+             "without resurrecting superseded/corrected content.",
+    )
+    reconcile_p.add_argument(
+        "--agent", default=None,
+        help="Agent name to reconcile. When omitted, all registered agents are reconciled.",
+    )
+    reconcile_p.add_argument(
+        "--check", action="store_true",
+        help="Dry-run: report missing counts without modifying the vector store.",
+    )
+
     # ----- mcp subcommand (MCP server over stdio) -----------------------
     mcp_p = sub.add_parser(
         "mcp",
@@ -785,6 +848,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(f"superseded {result['superseded']} chunk(s) matching {result['match']!r}")
         return 0
+
+    if args.cmd == "reconcile":
+        return _reconcile_cmd(args)
 
     registry = AgentRegistry(args.data_dir)
 

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -154,6 +154,22 @@ async def pending_resolve(
     )
 
 
+async def reconcile(*, agent: str, data_dir=None, repair: bool = True) -> dict:
+    """Detect and (when ``repair=True``) fix archive turns missing from the vector store.
+
+    Thin wrapper over :func:`taosmd.api.reconcile`. The archive is the source of
+    truth; the vector store is a derived index. A crash between the two sequential
+    writes in :func:`ingest` leaves a turn in the archive but absent from vector
+    recall. Reconcile re-adds those missing entries without touching anything that
+    was deliberately superseded (superseded rows count as present).
+
+    Returns ``{"agent", "archive_turns", "vector_entries", "missing", "readded",
+    "checked_ok"}``. When ``repair=False`` this is a dry-run: ``readded`` is
+    always 0.
+    """
+    return await _api.reconcile(agent=agent, data_dir=data_dir, repair=repair)
+
+
 async def supersede(match: str, *, agent: str | None = None, data_dir=None) -> dict:
     """Soft-supersede vector chunk(s) whose stored text contains ``match``.
 
@@ -392,5 +408,5 @@ async def a2a_members(*, channel: str, data_dir=None) -> list[str]:
     return sorted(members)
 
 
-__all__ = ["ingest", "search", "pending_list", "pending_resolve", "stats", "supersede",
-           "a2a_send", "a2a_feed", "a2a_channels", "a2a_members"]
+__all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
+           "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members"]

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -594,6 +594,41 @@ class VectorMemory:
             self._bm25_dirty = True  # active corpus changed — invalidate BM25 cache
         return cursor.rowcount
 
+    async def iter_entries(
+        self,
+        agent: str | None = None,
+        include_superseded: bool = True,
+    ):
+        """Yield (text, metadata_dict) tuples for stored entries.
+
+        Used by :func:`taosmd.api.reconcile` to enumerate the current vector
+        corpus — including superseded rows when ``include_superseded=True`` — so
+        the reconcile logic can distinguish "truly absent" from "intentionally
+        superseded". Superseded rows count as *present* in the multiset; their
+        content is not re-added, so corrected/stale entries are never resurrected.
+
+        When ``agent`` is given, only rows whose stored metadata ``agent`` field
+        matches are returned. This mirrors the per-agent scope used by
+        :meth:`add` when metadata ``{"agent": ...}`` is attached at ingest time.
+        Rows with no ``agent`` field in their metadata are included only when
+        ``agent`` is ``None``.
+
+        Yields ``(text: str, metadata: dict)`` in insertion order (ascending id).
+        """
+        sql = "SELECT text, metadata_json FROM vector_memory"
+        if not include_superseded:
+            sql += " WHERE valid_to IS NULL"
+        sql += " ORDER BY id ASC"
+
+        for row in self._conn.execute(sql).fetchall():
+            try:
+                meta = json.loads(row["metadata_json"])
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+            if agent is not None and meta.get("agent") != agent:
+                continue
+            yield row["text"], meta
+
     async def clear(self) -> int:
         cursor = self._conn.execute("DELETE FROM vector_memory")
         self._conn.commit()

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,276 @@
+"""Tests for the archive→vector reconcile path (issue #102).
+
+Verifies that a turn present in the archive but absent from the vector store
+(simulating a crash between the two sequential writes in ingest()) is detected
+by reconcile() and, when repair=True, re-added so search() can find it again.
+
+All tests are hermetic: each uses its own tmp_path data dir and a
+deterministic fake embedder so ONNX/QMD are never required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+import taosmd
+from taosmd import api as taosmd_api
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    """Replace embed() with a stable hash-based 8-dim vector (no ONNX/QMD)."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """Isolated data dir + clean stores cache; embedder patched after first init."""
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    # Release SQLite handles before pytest removes tmp_path.
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _drop_vector_row_by_text(data_dir, text: str) -> int:
+    """Directly delete one vector_memory row matching ``text`` (simulate crash gap).
+
+    Returns the number of rows deleted. Uses a subquery to delete exactly one
+    row by rowid — SQLite's ``DELETE ... LIMIT`` requires a special compile flag
+    and is not available in the stdlib distribution.
+    """
+    db = data_dir / "vector-memory.db"
+    con = sqlite3.connect(str(db))
+    try:
+        cur = con.execute(
+            "DELETE FROM vector_memory WHERE rowid IN "
+            "(SELECT rowid FROM vector_memory WHERE text = ? LIMIT 1)",
+            (text,),
+        )
+        con.commit()
+        return cur.rowcount
+    finally:
+        con.close()
+
+
+def _drop_all_vector_rows_by_text(data_dir, text: str) -> int:
+    """Delete ALL vector_memory rows matching ``text``."""
+    db = data_dir / "vector-memory.db"
+    con = sqlite3.connect(str(db))
+    try:
+        cur = con.execute("DELETE FROM vector_memory WHERE text = ?", (text,))
+        con.commit()
+        return cur.rowcount
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Core repair test
+# ---------------------------------------------------------------------------
+
+def test_reconcile_repairs_crash_gap(isolated):
+    """ingest 3 turns, drop one vector row, reconcile repairs it."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    agent = "reconcile-agent"
+
+    turns = [
+        "the librarian keeps every word",
+        "even if the power goes out",
+        "that is the whole point",
+    ]
+    for t in turns:
+        asyncio.run(taosmd.ingest(t, agent=agent, data_dir=str(data_dir)))
+
+    # Simulate crash: delete one vector row directly.
+    missing_text = turns[1]
+    dropped = _drop_vector_row_by_text(data_dir, missing_text)
+    assert dropped == 1, "should have dropped exactly one vector row"
+
+    # Reconcile.
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+
+    assert result["agent"] == agent
+    assert result["archive_turns"] == 3
+    assert result["missing"] == 1
+    assert result["readded"] == 1
+    assert result["checked_ok"] is False  # was False before repair; result reflects pre-repair state
+
+    # After reconcile, search must find the previously-missing turn.
+    hits = asyncio.run(taosmd.search(missing_text, agent=agent, data_dir=str(data_dir), limit=5))
+    texts = {h["text"] for h in hits}
+    assert missing_text in texts, "reconciled entry must be findable via search"
+
+
+# ---------------------------------------------------------------------------
+# Dry-run (--check / repair=False)
+# ---------------------------------------------------------------------------
+
+def test_reconcile_dryrun_reports_but_does_not_repair(isolated):
+    """repair=False reports missing count without modifying the vector store."""
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "dryrun-agent"
+
+    asyncio.run(taosmd.ingest("alpha turn", agent=agent, data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("beta turn", agent=agent, data_dir=str(data_dir)))
+
+    _drop_vector_row_by_text(data_dir, "alpha turn")
+
+    # Dry-run.
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=False))
+    assert result["missing"] == 1
+    assert result["readded"] == 0
+    assert result["checked_ok"] is False
+
+    # Real reconcile now fixes it.
+    result2 = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result2["readded"] == 1
+    assert result2["checked_ok"] is False  # missing was 1 going in
+
+    # A third call on the now-consistent store.
+    result3 = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result3["missing"] == 0
+    assert result3["readded"] == 0
+    assert result3["checked_ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+def test_reconcile_idempotent_on_consistent_store(isolated):
+    """Reconciling an already-consistent store reports missing=0, readded=0."""
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "idempotent-agent"
+
+    for t in ("one fish", "two fish", "red fish"):
+        asyncio.run(taosmd.ingest(t, agent=agent, data_dir=str(data_dir)))
+
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result["missing"] == 0
+    assert result["readded"] == 0
+    assert result["checked_ok"] is True
+
+    # Second call — still consistent.
+    result2 = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result2["missing"] == 0
+    assert result2["readded"] == 0
+    assert result2["checked_ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Supersede guard
+# ---------------------------------------------------------------------------
+
+def test_reconcile_does_not_resurrect_superseded_entry(isolated):
+    """A superseded vector entry counts as present; reconcile must NOT re-add it."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    agent = "supersede-guard-agent"
+
+    asyncio.run(taosmd.ingest("old fact about jay", agent=agent, data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("another fact", agent=agent, data_dir=str(data_dir)))
+
+    # Supersede the vector copy of the first turn (correction path).
+    superseded = asyncio.run(
+        taosmd_api.supersede_vectors("old fact about jay", data_dir=str(data_dir))
+    )
+    assert superseded == 1
+
+    # Reconcile — the superseded entry must NOT be re-added.
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result["missing"] == 0, (
+        "superseded entry should count as present; reconcile must not resurrect it"
+    )
+    assert result["readded"] == 0
+    assert result["checked_ok"] is True
+
+    # The vector row must remain superseded (no new active row was inserted).
+    # Search through the underlying vector store directly: the superseded row
+    # must not appear in an active-only (valid_to IS NULL) count.
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    vmem = stores["vector"]
+    active_rows = vmem._conn.execute(
+        "SELECT text FROM vector_memory WHERE valid_to IS NULL AND text = ?",
+        ("old fact about jay",),
+    ).fetchall()
+    assert len(active_rows) == 0, (
+        "superseded entry must stay superseded after reconcile; no active row should exist"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate handling
+# ---------------------------------------------------------------------------
+
+def test_reconcile_duplicate_text_repairs_exactly_one_copy(isolated):
+    """When the same text is ingested twice and one vector copy is dropped,
+    reconcile re-adds exactly one copy — not both.
+    """
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "dup-agent"
+
+    repeated = "this message was sent twice"
+    asyncio.run(taosmd.ingest(repeated, agent=agent, data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest(repeated, agent=agent, data_dir=str(data_dir)))
+
+    # Drop one of the two vector copies.
+    dropped = _drop_vector_row_by_text(data_dir, repeated)
+    assert dropped == 1
+
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result["archive_turns"] == 2
+    assert result["missing"] == 1
+    assert result["readded"] == 1
+    assert result["checked_ok"] is False  # was 1 missing going in
+
+    # Consistent now.
+    result2 = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result2["missing"] == 0
+    assert result2["checked_ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Empty store edge case
+# ---------------------------------------------------------------------------
+
+def test_reconcile_empty_agent_is_consistent(isolated):
+    """An agent with no ingested turns reports consistent (missing=0)."""
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "empty-agent"
+
+    result = asyncio.run(taosmd_api.reconcile(agent=agent, data_dir=str(data_dir), repair=True))
+    assert result["archive_turns"] == 0
+    assert result["vector_entries"] == 0
+    assert result["missing"] == 0
+    assert result["checked_ok"] is True


### PR DESCRIPTION
## Summary

- Fixes the transactional gap in `ingest()`: a crash between the archive write and vector write leaves a turn archived but absent from vector recall (silent recall asymmetry).
- Implements Option A from the design comment: the **archive is the source of truth**; the **vector store is a derived index** that can be reconciled from it.
- Adds `taosmd reconcile [--agent NAME] [--check]` CLI command for post-crash repair or cron use (not run on every startup).

## Changes

- **`vector_memory.py`** — `iter_entries(agent, include_superseded=True)`: async generator that yields `(text, metadata)` for all stored entries, including superseded rows. Needed so reconcile can distinguish "truly absent" from "intentionally superseded".
- **`api.py`** — `reconcile(agent, data_dir, repair=True)`: builds `Counter` multisets from both archive and vector store, subtracts to find missing entries (count-aware for duplicates), re-adds via `vmem.add()` when `repair=True`. Superseded rows count as present — corrected content is never resurrected.
- **`service.py`** — thin `reconcile()` wrapper following the existing adapter pattern.
- **`cli.py`** — `taosmd reconcile [--agent NAME] [--check]` subcommand. `--check` is dry-run. Omitting `--agent` reconciles all registered agents.
- **`tests/test_reconcile.py`** — 6 hermetic tests: crash-gap repair, dry-run, idempotency, supersede guard, duplicate handling, empty store.

## Test plan

- [ ] `python3 -m pytest tests/test_reconcile.py -v` — all 6 pass
- [ ] `python3 -m pytest -q` — 493 passed (487 baseline + 6 new)
- [ ] `taosmd reconcile --agent <name> --check` (dry-run, no modifications)
- [ ] `taosmd reconcile --agent <name>` (repair mode)
- [ ] Verify a second reconcile on a healthy store reports `missing=0`

Closes #102