### PR TITLE
feat: project identity fingerprinting (Phase 1/4)

### DIFF
--- a/taosmd/project.py
+++ b/taosmd/project.py
@@ -1,4 +1,4 @@
-"""Project identity — deterministic, environment-derived project fingerprints.
+"""Project identity: deterministic, environment-derived project fingerprints.
 
 The project fingerprint solves a real multi-agent problem: when Claude Code,
 Kilo Code, Hermes, or any other agent framework works on the same codebase,
@@ -6,13 +6,14 @@ they need to share memory without relying on agent instructions being
 identical. Instructions drift; git remotes don't.
 
 The fingerprint is a short hash of the git remote origin URL (normalized).
-It's stable across clones, machines, and agent sessions — as long as the
+It's stable across clones, machines, and agent sessions, as long as the
 repo has a remote, the fingerprint is deterministic.
 
-Fallback chain:
-  1. ``git config --get remote.origin.url`` → sha256, 12 hex chars
-  2. Explicit project ID from ``<project>/.taosmd/project.toml``
-  3. Hash of ``os.getcwd()`` (unstable if moved — last resort)
+Resolution order (first match wins):
+  1. ``explicit_id`` argument, if provided (manual override)
+  2. ``git config --get remote.origin.url`` hashed to sha256, 12 hex chars
+  3. Explicit project ID from ``<project>/.taosmd/project.toml``
+  4. Hash of ``os.getcwd()`` (unstable if moved, last resort)
 
 Usage::
 
@@ -41,7 +42,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_FINGERPRINT_LEN = 12  # 48 bits — enough for billions of projects, short enough to read
+_FINGERPRINT_LEN = 12  # 48 bits, enough for billions of projects, short enough to read
 
 
 class ProjectFingerprintError(RuntimeError):
@@ -99,7 +100,7 @@ def _read_project_toml(cwd: str | None = None) -> str | None:
         return None
     try:
         text = toml_path.read_text()
-        # Simple parse — look for ``project_id = "..."`` without toml dep
+        # Simple parse: look for ``project_id = "..."`` without toml dep
         match = re.search(r'project_id\s*=\s*["\']([^"\']+)["\']', text)
         if match:
             return match.group(1).strip()
@@ -158,7 +159,7 @@ class ProjectResolver:
         toml_id = _read_project_toml(self.cwd)
         if toml_id:
             warnings.append(
-                "No git remote detected — using .taosmd/project.toml. "
+                "No git remote detected, using .taosmd/project.toml. "
                 "Consider adding a git remote for stable project identity."
             )
             return ProjectInfo(
@@ -170,7 +171,7 @@ class ProjectResolver:
         # 4. Fallback: hash of cwd
         cwd = self.cwd or os.getcwd()
         warnings.append(
-            "No git remote or .taosmd/project.toml found — using directory hash. "
+            "No git remote or .taosmd/project.toml found, using directory hash. "
             "This is unstable if the project is moved. "
             "Create .taosmd/project.toml with: project_id = \"my-project\""
         )
@@ -186,7 +187,7 @@ def get_project_id(
     cwd: str | None = None,
     explicit_id: str | None = None,
 ) -> str:
-    """Convenience wrapper — return the project fingerprint as a string.
+    """Convenience wrapper: return the project fingerprint as a string.
 
     Args:
         cwd: Working directory. Defaults to ``os.getcwd()``.

--- a/taosmd/project.py
+++ b/taosmd/project.py
@@ -1,0 +1,198 @@
+"""Project identity — deterministic, environment-derived project fingerprints.
+
+The project fingerprint solves a real multi-agent problem: when Claude Code,
+Kilo Code, Hermes, or any other agent framework works on the same codebase,
+they need to share memory without relying on agent instructions being
+identical. Instructions drift; git remotes don't.
+
+The fingerprint is a short hash of the git remote origin URL (normalized).
+It's stable across clones, machines, and agent sessions — as long as the
+repo has a remote, the fingerprint is deterministic.
+
+Fallback chain:
+  1. ``git config --get remote.origin.url`` → sha256, 12 hex chars
+  2. Explicit project ID from ``<project>/.taosmd/project.toml``
+  3. Hash of ``os.getcwd()`` (unstable if moved — last resort)
+
+Usage::
+
+    from taosmd.project import get_project_id, ProjectResolver
+
+    # Auto-detect from git remote
+    pid = get_project_id()
+
+    # Explicit override
+    pid = get_project_id(explicit_id="my-project")
+
+    # Full resolver with fallback chain
+    resolver = ProjectResolver()
+    pid = resolver.resolve()
+    info = resolver.describe()  # includes source and warnings
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_FINGERPRINT_LEN = 12  # 48 bits — enough for billions of projects, short enough to read
+
+
+class ProjectFingerprintError(RuntimeError):
+    """Raised when no project identity can be determined."""
+
+
+def _normalize_git_remote(url: str) -> str:
+    """Normalize a git remote URL to a canonical form for hashing.
+
+    Handles the common variants:
+    - ``git@github.com:owner/repo.git`` → ``https://github.com/owner/repo``
+    - ``https://github.com/owner/repo.git`` → ``https://github.com/owner/repo``
+    - ``ssh://git@github.com/owner/repo.git`` → ``https://github.com/owner/repo``
+    """
+    url = url.strip()
+    # Strip .git suffix
+    url = re.sub(r"\.git$", "", url)
+    # SSH shorthand: git@host:path → https://host/path
+    ssh_match = re.match(r"git@([^:]+):(.+)$", url)
+    if ssh_match:
+        url = f"https://{ssh_match.group(1)}/{ssh_match.group(2)}"
+    # ssh:// prefix
+    url = re.sub(r"^ssh://git@", "https://", url)
+    # Lowercase for consistency
+    url = url.lower()
+    return url
+
+
+def _hash_remote(url: str) -> str:
+    """SHA-256 hash of a normalized remote URL, truncated to _FINGERPRINT_LEN."""
+    return hashlib.sha256(url.encode()).hexdigest()[:_FINGERPRINT_LEN]
+
+
+def _get_git_remote(cwd: str | None = None) -> str | None:
+    """Return the origin URL for the git repo at *cwd*, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _read_project_toml(cwd: str | None = None) -> str | None:
+    """Read an explicit project ID from ``<cwd>/.taosmd/project.toml``."""
+    toml_path = Path(cwd or ".") / ".taosmd" / "project.toml"
+    if not toml_path.exists():
+        return None
+    try:
+        text = toml_path.read_text()
+        # Simple parse — look for ``project_id = "..."`` without toml dep
+        match = re.search(r'project_id\s*=\s*["\']([^"\']+)["\']', text)
+        if match:
+            return match.group(1).strip()
+    except OSError as exc:
+        logger.warning("taosmd: failed to read %s: %s", toml_path, exc)
+    return None
+
+
+@dataclass
+class ProjectInfo:
+    """Result of project identity resolution."""
+    project_id: str
+    source: str  # "git_remote", "project_toml", "explicit", "cwd_hash"
+    remote_url: str | None = None
+    warnings: list[str] | None = None
+
+
+class ProjectResolver:
+    """Resolve project identity using the full fallback chain.
+
+    Args:
+        cwd: Working directory to resolve from. Defaults to ``os.getcwd()``.
+        explicit_id: If given, skip detection and use this ID directly.
+    """
+
+    def __init__(self, cwd: str | None = None, explicit_id: str | None = None):
+        self.cwd = cwd
+        self.explicit_id = explicit_id
+
+    def resolve(self) -> str:
+        """Return the project fingerprint (12-char hex string)."""
+        return self.describe().project_id
+
+    def describe(self) -> ProjectInfo:
+        """Return full resolution details including source and warnings."""
+        warnings: list[str] = []
+
+        # 1. Explicit override
+        if self.explicit_id:
+            return ProjectInfo(
+                project_id=self.explicit_id,
+                source="explicit",
+            )
+
+        # 2. Git remote
+        remote = _get_git_remote(self.cwd)
+        if remote:
+            normalized = _normalize_git_remote(remote)
+            return ProjectInfo(
+                project_id=_hash_remote(normalized),
+                source="git_remote",
+                remote_url=remote,
+            )
+
+        # 3. .taosmd/project.toml
+        toml_id = _read_project_toml(self.cwd)
+        if toml_id:
+            warnings.append(
+                "No git remote detected — using .taosmd/project.toml. "
+                "Consider adding a git remote for stable project identity."
+            )
+            return ProjectInfo(
+                project_id=toml_id,
+                source="project_toml",
+                warnings=warnings,
+            )
+
+        # 4. Fallback: hash of cwd
+        cwd = self.cwd or os.getcwd()
+        warnings.append(
+            "No git remote or .taosmd/project.toml found — using directory hash. "
+            "This is unstable if the project is moved. "
+            "Create .taosmd/project.toml with: project_id = \"my-project\""
+        )
+        return ProjectInfo(
+            project_id=_hash_remote(cwd),
+            source="cwd_hash",
+            warnings=warnings,
+        )
+
+
+def get_project_id(
+    *,
+    cwd: str | None = None,
+    explicit_id: str | None = None,
+) -> str:
+    """Convenience wrapper — return the project fingerprint as a string.
+
+    Args:
+        cwd: Working directory. Defaults to ``os.getcwd()``.
+        explicit_id: Skip detection, use this ID directly.
+
+    Returns:
+        12-character hex string identifying the project.
+    """
+    return ProjectResolver(cwd=cwd, explicit_id=explicit_id).resolve()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,170 @@
+"""Tests for project identity fingerprinting."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from taosmd.project import (
+    ProjectInfo,
+    ProjectResolver,
+    _get_git_remote,
+    _hash_remote,
+    _normalize_git_remote,
+    _read_project_toml,
+    get_project_id,
+)
+
+
+# --- _normalize_git_remote ---------------------------------------------------
+
+
+class TestNormalizeGitRemote:
+    def test_ssh_shorthand(self):
+        assert _normalize_git_remote("git@github.com:owner/repo.git") == "https://github.com/owner/repo"
+
+    def test_https_with_git_suffix(self):
+        assert _normalize_git_remote("https://github.com/owner/repo.git") == "https://github.com/owner/repo"
+
+    def test_https_without_suffix(self):
+        assert _normalize_git_remote("https://github.com/owner/repo") == "https://github.com/owner/repo"
+
+    def test_ssh_protocol(self):
+        assert _normalize_git_remote("ssh://git@github.com/owner/repo.git") == "https://github.com/owner/repo"
+
+    def test_case_normalization(self):
+        assert _normalize_git_remote("HTTPS://GitHub.COM/Owner/Repo") == "https://github.com/owner/repo"
+
+    def test_strips_whitespace(self):
+        assert _normalize_git_remote("  git@github.com:a/b.git  ") == "https://github.com/a/b"
+
+    def test_gitlab(self):
+        assert _normalize_git_remote("git@gitlab.com:group/project.git") == "https://gitlab.com/group/project"
+
+    def test_self_hosted(self):
+        assert _normalize_git_remote("https://git.example.com/team/repo.git") == "https://git.example.com/team/repo"
+
+
+# --- _hash_remote ------------------------------------------------------------
+
+
+class TestHashRemote:
+    def test_deterministic(self):
+        assert _hash_remote("https://github.com/owner/repo") == _hash_remote("https://github.com/owner/repo")
+
+    def test_length(self):
+        h = _hash_remote("https://github.com/owner/repo")
+        assert len(h) == 12
+
+    def test_hex(self):
+        h = _hash_remote("https://github.com/owner/repo")
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_different_urls_differ(self):
+        a = _hash_remote("https://github.com/owner/repo-a")
+        b = _hash_remote("https://github.com/owner/repo-b")
+        assert a != b
+
+
+# --- _get_git_remote ---------------------------------------------------------
+
+
+class TestGetGitRemote:
+    def test_returns_url_in_git_repo(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=tmp_path, capture_output=True,
+        )
+        assert _get_git_remote(str(tmp_path)) == "https://github.com/test/repo.git"
+
+    def test_returns_none_in_non_git_dir(self, tmp_path):
+        assert _get_git_remote(str(tmp_path)) is None
+
+    def test_returns_none_without_remote(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        assert _get_git_remote(str(tmp_path)) is None
+
+
+# --- _read_project_toml ------------------------------------------------------
+
+
+class TestReadProjectToml:
+    def test_reads_explicit_id(self, tmp_path):
+        toml_dir = tmp_path / ".taosmd"
+        toml_dir.mkdir()
+        (toml_dir / "project.toml").write_text('project_id = "my-project"\n')
+        assert _read_project_toml(str(tmp_path)) == "my-project"
+
+    def test_reads_single_quoted(self, tmp_path):
+        toml_dir = tmp_path / ".taosmd"
+        toml_dir.mkdir()
+        (toml_dir / "project.toml").write_text("project_id = 'my-project'\n")
+        assert _read_project_toml(str(tmp_path)) == "my-project"
+
+    def test_returns_none_without_file(self, tmp_path):
+        assert _read_project_toml(str(tmp_path)) is None
+
+    def test_returns_none_without_key(self, tmp_path):
+        toml_dir = tmp_path / ".taosmd"
+        toml_dir.mkdir()
+        (toml_dir / "project.toml").write_text("other_key = 'value'\n")
+        assert _read_project_toml(str(tmp_path)) is None
+
+
+# --- ProjectResolver ---------------------------------------------------------
+
+
+class TestProjectResolver:
+    def test_explicit_id_wins(self, tmp_path):
+        resolver = ProjectResolver(cwd=str(tmp_path), explicit_id="forced-id")
+        info = resolver.describe()
+        assert info.project_id == "forced-id"
+        assert info.source == "explicit"
+
+    def test_git_remote_preferred(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/owner/repo.git"],
+            cwd=tmp_path, capture_output=True,
+        )
+        resolver = ProjectResolver(cwd=str(tmp_path))
+        info = resolver.describe()
+        assert info.source == "git_remote"
+        assert info.project_id == _hash_remote("https://github.com/owner/repo")
+        assert info.remote_url == "https://github.com/owner/repo.git"
+
+    def test_toml_fallback(self, tmp_path):
+        toml_dir = tmp_path / ".taosmd"
+        toml_dir.mkdir()
+        (toml_dir / "project.toml").write_text('project_id = "custom-id"\n')
+        resolver = ProjectResolver(cwd=str(tmp_path))
+        info = resolver.describe()
+        assert info.source == "project_toml"
+        assert info.project_id == "custom-id"
+        assert info.warnings  # warns about no git remote
+
+    def test_cwd_hash_last_resort(self, tmp_path):
+        resolver = ProjectResolver(cwd=str(tmp_path))
+        info = resolver.describe()
+        assert info.source == "cwd_hash"
+        assert len(info.project_id) == 12
+        assert info.warnings  # warns about instability
+
+
+# --- get_project_id (convenience) -------------------------------------------
+
+
+class TestGetProjectId:
+    def test_returns_string(self, tmp_path):
+        pid = get_project_id(cwd=str(tmp_path), explicit_id="test")
+        assert isinstance(pid, str)
+
+    def test_length(self, tmp_path):
+        pid = get_project_id(cwd=str(tmp_path), explicit_id="test")
+        assert len(pid) == 12
+
+    def test_explicit(self, tmp_path):
+        pid = get_project_id(cwd=str(tmp_path), explicit_id="my-id")
+        assert pid == "my-id"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -162,7 +162,9 @@ class TestGetProjectId:
         assert isinstance(pid, str)
 
     def test_length(self, tmp_path):
-        pid = get_project_id(cwd=str(tmp_path), explicit_id="test")
+        # No explicit_id: a detected/derived fingerprint is always 12 hex chars.
+        # (explicit_id is returned verbatim, covered by test_explicit.)
+        pid = get_project_id(cwd=str(tmp_path))
         assert len(pid) == 12
 
     def test_explicit(self, tmp_path):


### PR DESCRIPTION
adds `taosmd.project` — a module that figures out which project you are in by hashing the git remote URL. 12-char hex fingerprint, deterministic across clones and machines.

the problem it solves: if Claude Code and Kilo Code both work on the same repo, they should share memories. right now that only works if both agents have the exact same name in their instruction files. instructions drift; git remotes do not.

resolution chain:
1. explicit override (pass it directly)
2. git remote origin URL (automatic)
3. `.taosmd/project.toml` in the repo root (manual, checked in)
4. cwd hash as last resort (warns you it is unstable)

26 tests, all passing. refs #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project fingerprinting system to establish consistent project identity across multiple agent sessions.
  * Projects are identified deterministically using git repository information, project configuration files, or working directory as a fallback.
  * Includes comprehensive test coverage for fingerprinting logic across various project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->