### PR TITLE
feat: project-scoped storage and cross-agent search (Phase 2/4)

### DIFF
--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -159,7 +159,7 @@ def _normalize_transcript(transcript) -> list[dict]:
     )
 
 
-async def ingest(transcript, *, agent: str, data_dir=None) -> dict:
+async def ingest(transcript, *, agent: str, project: str | None = None, data_dir=None) -> dict:
     """Shelve a transcript into the zero-loss archive and embed it for search.
 
     Per the agent-rules contract: call after every meaningful exchange.
@@ -171,11 +171,16 @@ async def ingest(transcript, *, agent: str, data_dir=None) -> dict:
             (``{"role", "content", optional "timestamp"}``), or an iterable
             of either.
         agent: Registered agent name. Auto-registered if absent.
+        project: Optional project fingerprint for cross-agent memory sharing.
+            When set, memories are tagged with this project ID so that
+            different agents working on the same project can find each
+            other's memories via ``search(..., also_include=[...])``.
+            Use ``taosmd.project.get_project_id()`` for automatic detection.
         data_dir: Optional taosmd data dir. Defaults to ``$TAOSMD_DATA_DIR``
             or ``~/.taosmd``.
 
     Returns:
-        ``{"archived": int, "agent": str, "data_dir": str}`` — ``archived``
+        ``{"archived": int, "agent": str, "project": str|None, "data_dir": str}`` — ``archived``
         is the count of non-empty turns that were shelved.
     """
     if not agent:
@@ -196,8 +201,11 @@ async def ingest(transcript, *, agent: str, data_dir=None) -> dict:
             item,
             agent_name=agent,
             summary=text[:80],
+            project=project,
         )
         meta: dict = {"agent": agent}
+        if project:
+            meta["project"] = project
         if "role" in item:
             meta["role"] = item["role"]
         if "timestamp" in item:
@@ -206,7 +214,7 @@ async def ingest(transcript, *, agent: str, data_dir=None) -> dict:
         archived += 1
 
     update_stats(agent, last_ingest_at=int(time.time()))
-    return {"archived": archived, "agent": agent, "data_dir": stores["data_dir"]}
+    return {"archived": archived, "agent": agent, "project": project, "data_dir": stores["data_dir"]}
 
 
 def _format_hit(hit: dict) -> dict:
@@ -244,7 +252,15 @@ def _format_hit(hit: dict) -> dict:
     }
 
 
-async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> list[dict]:
+async def search(
+    query: str,
+    *,
+    agent: str,
+    project: str | None = None,
+    also_include: list[str] | None = None,
+    limit: int = 5,
+    data_dir=None,
+) -> list[dict]:
     """Search the librarian's shelves for passages relevant to ``query``.
 
     Returns ranked hits in the agent-rules contract shape with explicit
@@ -255,6 +271,12 @@ async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> li
     Args:
         query: The search query.
         agent: Registered agent name. Auto-registered if absent.
+        project: Optional project fingerprint. When set, only memories
+            tagged with this project are returned (scoped search).
+            Use ``taosmd.project.get_project_id()`` for automatic detection.
+        also_include: Optional list of additional agent names whose
+            memories should be included in the search results (cross-agent
+            reads). Only effective when ``project`` is also set.
         limit: Maximum number of hits to return.
         data_dir: Optional taosmd data dir (see :func:`ingest`).
     """
@@ -269,6 +291,15 @@ async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> li
     from taosmd.retrieval import retrieve as _retrieve
     ensure_agent(agent)
 
+    # Build the list of agent names to search across.
+    # When project + also_include are set, we search the calling agent
+    # plus any explicitly included agents within the same project.
+    search_agents = [agent]
+    if project and also_include:
+        for name in also_include:
+            if name != agent:
+                search_agents.append(name)
+
     raw = await _retrieve(
         query,
         sources={
@@ -279,6 +310,8 @@ async def search(query: str, *, agent: str, limit: int = 5, data_dir=None) -> li
         agent=agent,
         agent_name=agent,
         limit=limit,
+        project=project,
+        search_agents=search_agents,
     )
     return [_format_hit(hit) for hit in raw]
 

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS archive_index (
     event_type TEXT NOT NULL,
     agent_name TEXT,
     app_id TEXT,
+    project TEXT,
     summary TEXT NOT NULL DEFAULT '',
     file_path TEXT NOT NULL,
     line_number INTEGER NOT NULL,
@@ -106,6 +107,11 @@ class ArchiveStore:
         self._conn = _db.connect(self._index_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(INDEX_SCHEMA)
+        # Back-fill: add project column to existing installs
+        try:
+            self._conn.execute("SELECT project FROM archive_index LIMIT 1")
+        except Exception:
+            self._conn.execute("ALTER TABLE archive_index ADD COLUMN project TEXT")
         self._conn.commit()
         # Load user tracking preference
         row = self._conn.execute(
@@ -168,6 +174,7 @@ class ArchiveStore:
         agent_name: str | None = None,
         app_id: str | None = None,
         summary: str = "",
+        project: str | None = None,
     ) -> int:
         """Record an event to the archive. Returns the index row ID."""
         # Skip user activity events if tracking is disabled
@@ -187,6 +194,7 @@ class ArchiveStore:
             "event_type": event_type,
             "agent_name": agent_name,
             "app_id": app_id,
+            "project": project,
             "summary": summary,
             "data": data,
         }
@@ -220,9 +228,9 @@ class ArchiveStore:
         # Index for fast lookup
         cursor = self._conn.execute(
             """INSERT INTO archive_index
-               (timestamp, event_type, agent_name, app_id, summary, file_path, line_number, data_json)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (ts, event_type, agent_name, app_id, summary, file_path, line_count, json.dumps(data, default=str)),
+               (timestamp, event_type, agent_name, app_id, project, summary, file_path, line_number, data_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (ts, event_type, agent_name, app_id, project, summary, file_path, line_count, json.dumps(data, default=str)),
         )
 
         # Index in FTS for full-text search

--- a/taosmd/retrieval.py
+++ b/taosmd/retrieval.py
@@ -280,14 +280,27 @@ def _deduplicate(results: list[dict], threshold: float = 0.8) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-async def _query_source(name: str, source: object, query: str, limit: int) -> list[dict]:
+async def _query_source(
+    name: str,
+    source: object,
+    query: str,
+    limit: int,
+    project: str | None = None,
+    search_agents: list[str] | None = None,
+) -> list[dict]:
     """Query a single source and return adapted results.
 
     Returns an empty list if the query raises an exception.
     """
     try:
         if name == "vector":
-            raw = await source.search(query, limit=limit, hybrid=True)
+            raw = await source.search(
+                query,
+                limit=limit,
+                hybrid=True,
+                project=project,
+                search_agents=search_agents,
+            )
             return _adapt_vector(raw)
         elif name == "kg":
             words = [w for w in query.split() if len(w) > 2]
@@ -595,6 +608,53 @@ async def _attach_neighbors(
     return hits
 
 
+
+def _filter_project_scope(
+    results: list[dict],
+    project: str | None = None,
+    search_agents: list[str] | None = None,
+) -> list[dict]:
+    """Post-filter results by project and agent scope.
+
+    Applied after all sources return results. Handles the different metadata
+    shapes from each source (archive uses ``agent_name`` and stores project
+    inside ``data_json``, vector uses ``agent``/``project`` in metadata,
+    KG has no agent field).
+    """
+    if project is None and search_agents is None:
+        return results
+
+    agent_set = set(search_agents) if search_agents else None
+    filtered = []
+    for hit in results:
+        md = hit.get("metadata", {}) or {}
+        # Unwrap nested metadata (archive wraps in inner dict)
+        inner = md.get("metadata") if isinstance(md, dict) else None
+        user_md = inner if isinstance(inner, dict) else md
+
+        # Project filter: check all metadata layers
+        if project is not None:
+            hit_project = (
+                (user_md.get("project") if isinstance(user_md, dict) else None)
+                or (md.get("project") if isinstance(md, dict) else None)
+            )
+            if hit_project is not None and hit_project != project:
+                continue
+
+        # Agent filter: check top-level, then archive agent_name
+        if agent_set is not None:
+            hit_agent = (
+                (user_md.get("agent") if isinstance(user_md, dict) else None)
+                or (md.get("agent") if isinstance(user_md, dict) else None)
+                or (md.get("agent_name") if isinstance(md, dict) else None)
+            )
+            if hit_agent is not None and hit_agent not in agent_set:
+                continue
+
+        filtered.append(hit)
+    return filtered
+
+
 async def retrieve(
     query: str,
     strategy: str = "thorough",
@@ -610,6 +670,8 @@ async def retrieve(
     adjacent_neighbors: int = 0,
     position_key: str = "position",
     group_key: str | None = None,
+    project: str | None = None,
+    search_agents: list[str] | None = None,
 ) -> list[dict]:
     """Retrieve relevant results from available memory sources.
 
@@ -689,7 +751,11 @@ async def retrieve(
         available = {k: v for k, v in sources.items()}
 
         tasks = [
-            asyncio.create_task(_query_source(name, src, query, fetch_limit))
+            asyncio.create_task(_query_source(
+                name, src, query, fetch_limit,
+                project=project if name == "vector" else None,
+                search_agents=search_agents if name == "vector" else None,
+            ))
             for name, src in available.items()
         ]
         results_per_source = await asyncio.gather(*tasks, return_exceptions=True)
@@ -718,7 +784,7 @@ async def retrieve(
             results = await _attach_neighbors(
                 results, sources, adjacent_neighbors, position_key, group_key,
             )
-        return results
+        return _filter_project_scope(results, project, search_agents)
 
     elif strategy == "fast":
         strategy_info = get_search_strategy(query)
@@ -744,7 +810,7 @@ async def retrieve(
             results = await _attach_neighbors(
                 results, sources, adjacent_neighbors, position_key, group_key,
             )
-        return results
+        return _filter_project_scope(results, project, search_agents)
 
     elif strategy == "minimal":
         strategy_info = get_search_strategy(query)
@@ -763,7 +829,7 @@ async def retrieve(
             results = await _attach_neighbors(
                 results, sources, adjacent_neighbors, position_key, group_key,
             )
-        return results
+        return _filter_project_scope(results, project, search_agents)
 
     elif strategy == "custom":
         if memory_layers is None:
@@ -799,7 +865,7 @@ async def retrieve(
             results = await _attach_neighbors(
                 results, sources, adjacent_neighbors, position_key, group_key,
             )
-        return results
+        return _filter_project_scope(results, project, search_agents)
 
     else:
         raise ValueError(f"Unknown strategy {strategy!r}. Must be one of: thorough, fast, minimal, custom.")

--- a/taosmd/retrieval.py
+++ b/taosmd/retrieval.py
@@ -645,7 +645,7 @@ def _filter_project_scope(
         if agent_set is not None:
             hit_agent = (
                 (user_md.get("agent") if isinstance(user_md, dict) else None)
-                or (md.get("agent") if isinstance(user_md, dict) else None)
+                or (md.get("agent") if isinstance(md, dict) else None)
                 or (md.get("agent_name") if isinstance(md, dict) else None)
             )
             if hit_agent is not None and hit_agent not in agent_set:

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -329,11 +329,16 @@ class VectorMemory:
                     meta = json.loads(row["metadata_json"])
                 except (json.JSONDecodeError, TypeError):
                     meta = {}
-                # Project filter: skip rows that don't match the project.
-                if project is not None and meta.get("project") != project:
+                # Project filter: skip rows positively tagged with a different
+                # project. Untagged (pre-project) rows are kept so existing
+                # standalone memory is never hidden.
+                row_project = meta.get("project")
+                if project is not None and row_project is not None and row_project != project:
                     continue
-                # Agent filter: skip rows whose agent isn't in the allowed set.
-                if agent_set is not None and meta.get("agent") not in agent_set:
+                # Agent filter: skip rows positively tagged with an out-of-scope
+                # agent. Untagged rows are kept (preserves standalone behaviour).
+                row_agent = meta.get("agent")
+                if agent_set is not None and row_agent is not None and row_agent not in agent_set:
                     continue
                 filtered.append(row)
             rows = filtered

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -266,6 +266,8 @@ class VectorMemory:
         limit: int = 5,
         hybrid: bool = True,
         fusion: str = "boost",
+        project: str | None = None,
+        search_agents: list[str] | None = None,
     ) -> list[dict]:
         """Semantic search with optional hybrid fusion.
 
@@ -289,6 +291,11 @@ class VectorMemory:
           "none"           — Pure semantic cosine similarity.
 
         When hybrid=False, fusion mode is ignored and pure semantic is used.
+
+        Args:
+            project: When set, only return memories tagged with this project.
+            search_agents: When set (with project), only return memories from
+                these agent names within the project. Enables cross-agent reads.
         """
         query_emb = await self.embed(query, task="search_query")
         if not query_emb:
@@ -312,6 +319,25 @@ class VectorMemory:
             "SELECT id, text, embedding, metadata_json, created_at FROM vector_memory "
             "WHERE valid_to IS NULL"
         ).fetchall()
+
+        # Filter by project and/or agent scope when specified.
+        if project is not None or search_agents is not None:
+            filtered = []
+            agent_set = set(search_agents) if search_agents else None
+            for row in rows:
+                try:
+                    meta = json.loads(row["metadata_json"])
+                except (json.JSONDecodeError, TypeError):
+                    meta = {}
+                # Project filter: skip rows that don't match the project.
+                if project is not None and meta.get("project") != project:
+                    continue
+                # Agent filter: skip rows whose agent isn't in the allowed set.
+                if agent_set is not None and meta.get("agent") not in agent_set:
+                    continue
+                filtered.append(row)
+            rows = filtered
+
         if not rows:
             return []
 

--- a/tests/test_project_storage.py
+++ b/tests/test_project_storage.py
@@ -1,0 +1,104 @@
+"""Tests for project-scoped storage — project parameter on ingest/search."""
+from __future__ import annotations
+
+import pytest
+
+from taosmd.api import ingest, search
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Return a fresh taosmd data dir for each test."""
+    return str(tmp_path / "taosmd-data")
+
+
+# --- ingest with project -----------------------------------------------------
+
+
+class TestIngestProject:
+    @pytest.mark.asyncio
+    async def test_ingest_stores_project_metadata(self, data_dir):
+        result = await ingest(
+            "The login page uses OAuth2",
+            agent="claude",
+            project="abc123",
+            data_dir=data_dir,
+        )
+        assert result["project"] == "abc123"
+        assert result["archived"] == 1
+
+    @pytest.mark.asyncio
+    async def test_ingest_without_project(self, data_dir):
+        result = await ingest(
+            "Some fact",
+            agent="claude",
+            data_dir=data_dir,
+        )
+        assert result["project"] is None
+
+    @pytest.mark.asyncio
+    async def test_ingest_different_agents_same_project(self, data_dir):
+        await ingest("Fact from Claude", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("Fact from Kilo", agent="kilo", project="proj1", data_dir=data_dir)
+        # Both should succeed — no conflict
+        hits = await search("Fact", agent="claude", project="proj1", data_dir=data_dir)
+        assert len(hits) >= 1
+
+
+# --- search with project -----------------------------------------------------
+
+
+class TestSearchProject:
+    @pytest.mark.asyncio
+    async def test_search_scoped_to_project(self, data_dir):
+        await ingest("OAuth2 on login page", agent="claude", project="proj-a", data_dir=data_dir)
+        await ingest("OAuth2 on signup page", agent="claude", project="proj-b", data_dir=data_dir)
+
+        hits_a = await search("OAuth2", agent="claude", project="proj-a", data_dir=data_dir)
+        hits_b = await search("OAuth2", agent="claude", project="proj-b", data_dir=data_dir)
+
+        # Each project should only see its own memories
+        texts_a = [h["text"] for h in hits_a]
+        texts_b = [h["text"] for h in hits_b]
+        assert any("login" in t for t in texts_a)
+        assert any("signup" in t for t in texts_b)
+
+    @pytest.mark.asyncio
+    async def test_search_without_project_sees_all(self, data_dir):
+        await ingest("Fact A", agent="claude", project="proj-a", data_dir=data_dir)
+        await ingest("Fact B", agent="claude", project="proj-b", data_dir=data_dir)
+
+        hits = await search("Fact", agent="claude", data_dir=data_dir)
+        assert len(hits) >= 2
+
+    @pytest.mark.asyncio
+    async def test_cross_agent_search_with_also_include(self, data_dir):
+        await ingest("Database schema uses UUIDs", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("API returns JSON:API format", agent="kilo", project="proj1", data_dir=data_dir)
+
+        # Claude searches, including Kilo's memories
+        hits = await search(
+            "API format",
+            agent="claude",
+            project="proj1",
+            also_include=["kilo"],
+            data_dir=data_dir,
+        )
+        texts = [h["text"] for h in hits]
+        assert any("JSON:API" in t for t in texts)
+
+    @pytest.mark.asyncio
+    async def test_cross_agent_excludes_other_projects(self, data_dir):
+        await ingest("Claude fact in proj1", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("Kilo fact in proj2", agent="kilo", project="proj2", data_dir=data_dir)
+
+        hits = await search(
+            "fact",
+            agent="claude",
+            project="proj1",
+            also_include=["kilo"],
+            data_dir=data_dir,
+        )
+        texts = [h["text"] for h in hits]
+        # Should NOT see Kilo's proj2 fact
+        assert not any("proj2" in t for t in texts)

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -22,7 +22,7 @@ from taosmd.retrieval import (
 
 
 class MockVectorMemory:
-    async def search(self, query, limit=5, hybrid=True, fusion="rrf"):
+    async def search(self, query, limit=5, hybrid=True, fusion="rrf", project=None, search_agents=None):
         return [
             {"id": 1, "text": "Jay created taOS", "similarity": 0.95, "metadata": {}, "created_at": 1744531200.0},
             {"id": 2, "text": "taOS runs on Orange Pi", "similarity": 0.85, "metadata": {}, "created_at": 1744531200.0},
@@ -409,7 +409,7 @@ class PositionalVectorMemory:
     def __init__(self, rows: list[dict]):
         self._rows = rows
 
-    async def search(self, query, limit=5, hybrid=True, fusion="rrf"):
+    async def search(self, query, limit=5, hybrid=True, fusion="rrf", project=None, search_agents=None):
         # Return the first `limit` rows verbatim for a deterministic ranking.
         return [
             {


### PR DESCRIPTION
adds `project` parameter to `ingest()` and `search()` so memories can be scoped to a specific project.

changes:
- `api.py`: `project` and `also_include` params on ingest/search
- `archive.py`: `project` column on archive_index, with migration for existing installs
- `vector_memory.py`: project and agent filtering on search()
- `retrieval.py`: `_filter_project_scope()` post-filter that works across all sources

how it works:
- `ingest(agent="claude", project="abc123")` tags the memory
- `search(agent="claude", project="abc123")` only returns matching memories
- `search(agent="claude", project="abc123", also_include=["kilo"])` includes kilo's memories from the same project
- without project, everything works as before

7 new tests. all 76 existing tests still pass.

builds on #142. refs #141.