### PR TITLE
feat: librarian discovery — list_projects and list_shelves (Phase 3/4)

### DIFF
--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -316,6 +316,68 @@ async def search(
     return [_format_hit(hit) for hit in raw]
 
 
+async def list_projects(*, data_dir=None) -> list[dict]:
+    """List all projects that have stored memories.
+
+    Returns a list of dicts with project_id, agent count, and last activity.
+    Useful for discovery when an agent doesn't know which project it's in.
+
+    Returns:
+        ``[{"project_id": str, "agents": [str], "last_ingest": float}]``
+    """
+    stores = await _ensure_stores(data_dir)
+
+    rows = stores["archive"]._conn.execute(
+        "SELECT project, agent_name, MAX(timestamp) as last_ts "
+        "FROM archive_index WHERE project IS NOT NULL "
+        "GROUP BY project, agent_name ORDER BY last_ts DESC"
+    ).fetchall()
+
+    projects: dict[str, dict] = {}
+    for row in rows:
+        pid = row["project"]
+        if pid not in projects:
+            projects[pid] = {"project_id": pid, "agents": [], "last_ingest": 0}
+        if row["agent_name"] and row["agent_name"] not in projects[pid]["agents"]:
+            projects[pid]["agents"].append(row["agent_name"])
+        if row["last_ts"] and row["last_ts"] > projects[pid]["last_ingest"]:
+            projects[pid]["last_ingest"] = row["last_ts"]
+
+    return list(projects.values())
+
+
+async def list_shelves(*, project: str, data_dir=None) -> list[dict]:
+    """List all agent shelves within a specific project.
+
+    Returns agent names, fact counts, and last activity for the given project.
+    Use this to discover what other agents have memories for a project before
+    using ``also_include`` in ``search()``.
+
+    Args:
+        project: The project fingerprint to query.
+
+    Returns:
+        ``[{"agent": str, "facts": int, "last_ingest": float}]``
+    """
+    stores = await _ensure_stores(data_dir)
+
+    rows = stores["archive"]._conn.execute(
+        "SELECT agent_name, COUNT(*) as cnt, MAX(timestamp) as last_ts "
+        "FROM archive_index WHERE project = ? "
+        "GROUP BY agent_name ORDER BY last_ts DESC",
+        (project,),
+    ).fetchall()
+
+    return [
+        {
+            "agent": row["agent_name"] or "unknown",
+            "facts": row["cnt"],
+            "last_ingest": row["last_ts"],
+        }
+        for row in rows
+    ]
+
+
 async def list_pending_decisions(
     *, limit: int = 20, subject: str | None = None, data_dir=None,
 ) -> list[dict]:

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -1,4 +1,4 @@
-"""Tests for librarian discovery — list_projects and list_shelves."""
+"""Tests for librarian discovery: list_projects and list_shelves."""
 from __future__ import annotations
 
 import pytest

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -1,0 +1,85 @@
+"""Tests for librarian discovery — list_projects and list_shelves."""
+from __future__ import annotations
+
+import pytest
+
+from taosmd.api import ingest, list_projects, list_shelves
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    return str(tmp_path / "taosmd-data")
+
+
+class TestListProjects:
+    @pytest.mark.asyncio
+    async def test_empty_when_no_projects(self, data_dir):
+        result = await list_projects(data_dir=data_dir)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_projects(self, data_dir):
+        await ingest("fact A", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("fact B", agent="kilo", project="proj2", data_dir=data_dir)
+
+        result = await list_projects(data_dir=data_dir)
+        ids = [p["project_id"] for p in result]
+        assert "proj1" in ids
+        assert "proj2" in ids
+
+    @pytest.mark.asyncio
+    async def test_groups_agents_per_project(self, data_dir):
+        await ingest("fact from claude", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("fact from kilo", agent="kilo", project="proj1", data_dir=data_dir)
+
+        result = await list_projects(data_dir=data_dir)
+        proj1 = next(p for p in result if p["project_id"] == "proj1")
+        assert "claude" in proj1["agents"]
+        assert "kilo" in proj1["agents"]
+
+    @pytest.mark.asyncio
+    async def test_excludes_non_project_memories(self, data_dir):
+        await ingest("no project here", agent="claude", data_dir=data_dir)
+        await ingest("has project", agent="kilo", project="proj1", data_dir=data_dir)
+
+        result = await list_projects(data_dir=data_dir)
+        assert len(result) == 1
+        assert result[0]["project_id"] == "proj1"
+
+
+class TestListShelves:
+    @pytest.mark.asyncio
+    async def test_empty_project(self, data_dir):
+        result = await list_shelves(project="nonexistent", data_dir=data_dir)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_agents_in_project(self, data_dir):
+        await ingest("fact from claude", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("fact from kilo", agent="kilo", project="proj1", data_dir=data_dir)
+
+        result = await list_shelves(project="proj1", data_dir=data_dir)
+        agents = [s["agent"] for s in result]
+        assert "claude" in agents
+        assert "kilo" in agents
+
+    @pytest.mark.asyncio
+    async def test_fact_counts(self, data_dir):
+        await ingest("fact 1", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("fact 2", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("fact 3", agent="kilo", project="proj1", data_dir=data_dir)
+
+        result = await list_shelves(project="proj1", data_dir=data_dir)
+        by_agent = {s["agent"]: s["facts"] for s in result}
+        assert by_agent["claude"] == 2
+        assert by_agent["kilo"] == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_other_projects(self, data_dir):
+        await ingest("proj1 fact", agent="claude", project="proj1", data_dir=data_dir)
+        await ingest("proj2 fact", agent="kilo", project="proj2", data_dir=data_dir)
+
+        result = await list_shelves(project="proj1", data_dir=data_dir)
+        agents = [s["agent"] for s in result]
+        assert "claude" in agents
+        assert "kilo" not in agents


### PR DESCRIPTION
adds two new API functions for discovering what memories exist.

`list_projects()` — returns all projects with stored memories, agent lists, and last activity. useful when an agent does not know which project it is in.

`list_shelves(project)` — returns all agent shelves within a project, with fact counts and last ingest times. use before `also_include` to see what other agents have memories for the current project.

8 new tests. builds on #142 and #143. refs #141.