### PR TITLE
feat(security): trust enforcement — grants check + managed_by/dashboard gating

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ benchmarks = ["mem0ai>=0.1.0", "mempalace"]
 # MCP server surface (#84) — optional so the core install stays lean.
 # Install with: pip install taosmd[mcp]
 mcp = ["mcp"]
+# Opt-in A2A bus authentication against a taOS agent registry (EdDSA-JWT).
+# Only needed when a registry URL is configured; core stays lean for Pi tiers.
+# Install with: pip install taosmd[registry]
+registry = ["pyjwt>=2.8", "cryptography>=42"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -38,6 +38,13 @@ _REGISTRY_URL_KEY = "registry_url"
 # Key under which the registry auth token (taOS local/admin token) is stored.
 # Used to poll the auth-gated registry revoked feed; the pubkey feed is public.
 _REGISTRY_TOKEN_KEY = "registry_token"
+# Who manages this taosmd instance: "standalone" (default) or "taos".
+_MANAGED_BY_KEY = "managed_by"
+# Override: serve the web dashboard even when managed_by=taos.
+_SERVE_DASHBOARD_KEY = "serve_dashboard"
+
+MANAGED_BY_STANDALONE = "standalone"
+MANAGED_BY_TAOS = "taos"
 
 
 def _resolve_data_dir(data_dir=None) -> str:
@@ -330,6 +337,69 @@ def set_server_token(token: str, clear: bool = False, data_dir=None) -> None:
     _write(data, data_dir)
 
 
+def get_managed_by(data_dir=None) -> str:
+    """Return the managed_by value: ``"standalone"`` (default) or ``"taos"``.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_MANAGED_BY`` environment variable
+    2. ``managed_by`` key in ``~/.taosmd/config.json``
+    3. ``"standalone"`` (default)
+
+    When ``"taos"``, the taOS app owns the auth/permission UX and the web
+    dashboard is hidden by default (controlled by :func:`get_serve_dashboard`).
+    taOS writes this at provision time; standalone installs never set it.
+    """
+    env = os.environ.get("TAOSMD_MANAGED_BY")
+    if env and env.strip() in (MANAGED_BY_STANDALONE, MANAGED_BY_TAOS):
+        return env.strip()
+    val = _read(data_dir).get(_MANAGED_BY_KEY)
+    if val in (MANAGED_BY_STANDALONE, MANAGED_BY_TAOS):
+        return val
+    return MANAGED_BY_STANDALONE
+
+
+def set_managed_by(value: str, data_dir=None) -> None:
+    """Persist the managed_by value (``"standalone"`` or ``"taos"``).
+
+    Raises:
+        ValueError: when ``value`` is not one of the allowed strings.
+    """
+    if value not in (MANAGED_BY_STANDALONE, MANAGED_BY_TAOS):
+        raise ValueError(f"managed_by must be 'standalone' or 'taos', got {value!r}")
+    data = _read(data_dir)
+    data[_MANAGED_BY_KEY] = value
+    _write(data, data_dir)
+
+
+def get_serve_dashboard(data_dir=None) -> bool:
+    """Return whether the web dashboard should be served.
+
+    Resolution order:
+
+    1. ``TAOSMD_SERVE_DASHBOARD`` env var (``"1"`` or ``"true"`` = True)
+    2. ``serve_dashboard`` bool in ``~/.taosmd/config.json``
+    3. Derived default: True when managed_by=standalone, False when managed_by=taos.
+
+    When managed_by=taos, the taOS apps render all UI. taOS can override this
+    back to True via the config key or env var for debugging.
+    """
+    env = os.environ.get("TAOSMD_SERVE_DASHBOARD")
+    if env is not None:
+        return env.strip().lower() in ("1", "true", "yes")
+    data = _read(data_dir)
+    if _SERVE_DASHBOARD_KEY in data:
+        return bool(data[_SERVE_DASHBOARD_KEY])
+    return get_managed_by(data_dir) == MANAGED_BY_STANDALONE
+
+
+def set_serve_dashboard(value: bool, data_dir=None) -> None:
+    """Persist the serve_dashboard override."""
+    data = _read(data_dir)
+    data[_SERVE_DASHBOARD_KEY] = bool(value)
+    _write(data, data_dir)
+
+
 __all__ = [
     "get_memory_model",
     "set_memory_model",
@@ -344,4 +414,10 @@ __all__ = [
     "set_registry_url",
     "get_registry_token",
     "set_registry_token",
+    "get_managed_by",
+    "set_managed_by",
+    "get_serve_dashboard",
+    "set_serve_dashboard",
+    "MANAGED_BY_STANDALONE",
+    "MANAGED_BY_TAOS",
 ]

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -35,6 +35,9 @@ _SERVER_TOKEN_KEY = "server_token"
 # Key under which the global default recipe id is stored.
 _DEFAULT_RECIPE_KEY = "default_recipe"
 _REGISTRY_URL_KEY = "registry_url"
+# Key under which the registry auth token (taOS local/admin token) is stored.
+# Used to poll the auth-gated registry revoked feed; the pubkey feed is public.
+_REGISTRY_TOKEN_KEY = "registry_token"
 
 
 def _resolve_data_dir(data_dir=None) -> str:
@@ -238,6 +241,50 @@ def set_registry_url(url: str, clear: bool = False, data_dir=None) -> None:
     _write(data, data_dir)
 
 
+def get_registry_token(data_dir=None) -> str | None:
+    """Return the configured registry auth token (taOS local/admin), or ``None``.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_REGISTRY_TOKEN`` environment variable
+    2. ``registry_token`` key in ``~/.taosmd/config.json``
+
+    The token is sent as ``Authorization: Bearer <token>`` only on the
+    auth-gated registry revoked feed; the pubkey feed is public and is fetched
+    without it. Unset means the revoked poll is unauthenticated (pre-#710
+    behaviour). The token is never logged or printed.
+    """
+    env = os.environ.get("TAOSMD_REGISTRY_TOKEN")
+    if env and env.strip():
+        return env.strip()
+    token = _read(data_dir).get(_REGISTRY_TOKEN_KEY)
+    if isinstance(token, str) and token.strip():
+        return token.strip()
+    return None
+
+
+def set_registry_token(token: str, clear: bool = False, data_dir=None) -> None:
+    """Persist the registry auth token (or clear it).
+
+    Args:
+        token: The taOS local/admin token used to poll the revoked feed.
+            Ignored when ``clear`` is True.
+        clear: when True, remove the setting.
+
+    Raises:
+        ValueError: when ``clear`` is False and ``token`` is not a
+            non-empty string.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_REGISTRY_TOKEN_KEY, None)
+    else:
+        if not isinstance(token, str) or not token.strip():
+            raise ValueError("token must be a non-empty string (or pass clear=True)")
+        data[_REGISTRY_TOKEN_KEY] = token.strip()
+    _write(data, data_dir)
+
+
 # ---------------------------------------------------------------------------
 # Remote server bearer token
 # ---------------------------------------------------------------------------
@@ -293,4 +340,8 @@ __all__ = [
     "set_server_url",
     "get_server_token",
     "set_server_token",
+    "get_registry_url",
+    "set_registry_url",
+    "get_registry_token",
+    "set_registry_token",
 ]

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -34,6 +34,7 @@ _SERVER_URL_KEY = "server_url"
 _SERVER_TOKEN_KEY = "server_token"
 # Key under which the global default recipe id is stored.
 _DEFAULT_RECIPE_KEY = "default_recipe"
+_REGISTRY_URL_KEY = "registry_url"
 
 
 def _resolve_data_dir(data_dir=None) -> str:
@@ -187,6 +188,53 @@ def set_server_url(url: str, clear: bool = False, data_dir=None) -> None:
         if not isinstance(url, str) or not url.strip():
             raise ValueError("url must be a non-empty string (or pass clear=True)")
         data[_SERVER_URL_KEY] = url.strip()
+    _write(data, data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Agent registry URL (opt-in A2A bus authentication)
+# ---------------------------------------------------------------------------
+
+def get_registry_url(data_dir=None) -> str | None:
+    """Return the configured taOS agent-registry base URL, or ``None``.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_REGISTRY_URL`` environment variable
+    2. ``registry_url`` key in ``~/.taosmd/config.json``
+
+    When set, the A2A bus authenticates senders against this registry (verify
+    the EdDSA-JWT against ``<url>/api/agents/registry/pubkey`` and check the
+    revocation feed). When unset, the bus keeps free-handle behaviour so a
+    standalone install is unaffected.
+    """
+    env = os.environ.get("TAOSMD_REGISTRY_URL")
+    if env and env.strip():
+        return env.strip()
+    url = _read(data_dir).get(_REGISTRY_URL_KEY)
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+    return None
+
+
+def set_registry_url(url: str, clear: bool = False, data_dir=None) -> None:
+    """Persist the agent-registry base URL (or clear it).
+
+    Args:
+        url: Base URL of the taOS registry, e.g. ``"http://taos:8000"``.
+            Ignored when ``clear`` is True.
+        clear: when True, remove the setting (bus reverts to free handles).
+
+    Raises:
+        ValueError: when ``clear`` is False and ``url`` is not a non-empty string.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_REGISTRY_URL_KEY, None)
+    else:
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("url must be a non-empty string (or pass clear=True)")
+        data[_REGISTRY_URL_KEY] = url.strip()
     _write(data, data_dir)
 
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -454,7 +454,8 @@ class _ServiceLoop:
         self._loop.close()
 
 
-def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
+def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
+                  grants_verifier=None):
     """Build a handler class bound to a fixed ``data_dir``.
 
     ThreadingHTTPServer instantiates the handler per request, so the data dir
@@ -470,19 +471,30 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
     # This is the token the *server* checks (not the client's outbound token).
     _server_token: str | None = _config.get_server_token(data_dir)
 
+    # Whether to serve the web dashboard (/ /ui static assets SPA fallback).
+    # Defaults True for standalone installs; False when managed_by=taos (taOS
+    # apps render everything). Overridable via config/env.
+    _serve_dashboard: bool = _config.get_serve_dashboard(data_dir)
+
     # Opt-in A2A registry verifier. Injected for tests; otherwise built from the
     # configured registry URL. When None, the bus trusts the handle (standalone).
     _registry_verifier = verifier
+    _grants_verifier = grants_verifier
     if _registry_verifier is None:
         _registry_url = _config.get_registry_url(data_dir)
         if _registry_url:
             from . import registry_auth  # noqa: PLC0415 - optional path
-            # The revoked feed is admin-gated (#710): send the configured taOS
-            # local token on it; pin the issuer to the registry's value.
+            # The revoked and grants feeds are admin-gated (#710/#719): send the
+            # configured taOS local token on them; pin the issuer.
+            _admin_token = _config.get_registry_token(data_dir)
             _registry_verifier = registry_auth.verifier_from_url(
                 _registry_url,
-                revoked_token=_config.get_registry_token(data_dir),
+                revoked_token=_admin_token,
                 expected_iss=registry_auth.REGISTRY_ISS,
+            )
+            _grants_verifier = registry_auth.grants_verifier_from_url(
+                _registry_url,
+                grants_token=_admin_token,
             )
 
     # Paths that are always public regardless of the token setting.
@@ -601,7 +613,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
                 return
             try:
                 if method == "GET" and path in ("/", "/ui"):
-                    self._serve_spa()
+                    if _serve_dashboard:
+                        self._serve_spa()
+                    else:
+                        self._send_json(404, {"error": "dashboard disabled (managed_by=taos)"})
                 elif method == "GET" and path == "/health":
                     self._send_json(200, {"status": "ok", "version": __version__})
                 elif method == "GET" and path == "/search":
@@ -629,9 +644,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
                 elif method == "GET" and path == "/a2a/stream":
                     self._handle_a2a_stream(query)
                     return  # SSE response already sent; skip _send_json error path
-                elif method == "GET" and self._try_serve_static(parts.path):
+                elif method == "GET" and _serve_dashboard and self._try_serve_static(parts.path):
                     return  # static asset served
-                elif method == "GET":
+                elif method == "GET" and _serve_dashboard:
                     # SPA routing: unknown non-API paths return index.html
                     self._serve_spa()
                 else:
@@ -766,7 +781,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
             if not isinstance(body_text, str) or not body_text:
                 raise _BadRequest("'body' (non-empty string) is required")
             # Registry auth (opt-in): when a verifier is configured, the sender
-            # must present a registry-minted EdDSA-JWT whose sub matches 'from'.
+            # must present a registry-minted EdDSA-JWT whose sub matches 'from',
+            # AND must have an active permission grant in the grants feed.
             if _registry_verifier is not None:
                 from . import registry_auth  # noqa: PLC0415 - optional path
                 auth = self.headers.get("Authorization", "")
@@ -779,6 +795,15 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
                 except registry_auth.AuthError as exc:
                     self._send_json(403, {"error": f"registry auth: {exc}"})
                     return
+                # Grant check: token proves identity; grant proves permission.
+                if _grants_verifier is not None:
+                    try:
+                        if not _grants_verifier.has_grant(from_):
+                            self._send_json(403, {"error": f"registry auth: no active grant for {from_!r}"})
+                            return
+                    except registry_auth.AuthError as exc:
+                        self._send_json(403, {"error": f"registry auth: {exc}"})
+                        return
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
@@ -857,7 +882,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
 
 
 def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None,
-                verifier=None):
+                verifier=None, grants_verifier=None):
     """Create (but do not start) a :class:`ThreadingHTTPServer`.
 
     Useful for tests that need to bind an ephemeral port (``port=0``) and read
@@ -869,7 +894,10 @@ def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=Non
     directly should call ``server.service_loop.close()`` during teardown.
     """
     runner = _ServiceLoop()
-    httpd = ThreadingHTTPServer((host, port), _make_handler(data_dir, runner, verifier))
+    httpd = ThreadingHTTPServer(
+        (host, port),
+        _make_handler(data_dir, runner, verifier, grants_verifier),
+    )
     httpd.service_loop = runner
     return httpd
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -454,7 +454,7 @@ class _ServiceLoop:
         self._loop.close()
 
 
-def _make_handler(data_dir, runner: _ServiceLoop):
+def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
     """Build a handler class bound to a fixed ``data_dir``.
 
     ThreadingHTTPServer instantiates the handler per request, so the data dir
@@ -469,6 +469,15 @@ def _make_handler(data_dir, runner: _ServiceLoop):
     # Read the server-side expected token once at handler-class creation time.
     # This is the token the *server* checks (not the client's outbound token).
     _server_token: str | None = _config.get_server_token(data_dir)
+
+    # Opt-in A2A registry verifier. Injected for tests; otherwise built from the
+    # configured registry URL. When None, the bus trusts the handle (standalone).
+    _registry_verifier = verifier
+    if _registry_verifier is None:
+        _registry_url = _config.get_registry_url(data_dir)
+        if _registry_url:
+            from . import registry_auth  # noqa: PLC0415 - optional path
+            _registry_verifier = registry_auth.verifier_from_url(_registry_url)
 
     # Paths that are always public regardless of the token setting.
     _PUBLIC_PATHS = frozenset({"/", "/ui", "/health"})
@@ -750,6 +759,20 @@ def _make_handler(data_dir, runner: _ServiceLoop):
                 raise _BadRequest("'from' (non-empty string) is required")
             if not isinstance(body_text, str) or not body_text:
                 raise _BadRequest("'body' (non-empty string) is required")
+            # Registry auth (opt-in): when a verifier is configured, the sender
+            # must present a registry-minted EdDSA-JWT whose sub matches 'from'.
+            if _registry_verifier is not None:
+                from . import registry_auth  # noqa: PLC0415 - optional path
+                auth = self.headers.get("Authorization", "")
+                token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+                if not token:
+                    self._send_json(401, {"error": "registry auth: Bearer token required"})
+                    return
+                try:
+                    _registry_verifier.authorize(token, from_)
+                except registry_auth.AuthError as exc:
+                    self._send_json(403, {"error": f"registry auth: {exc}"})
+                    return
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
@@ -827,7 +850,8 @@ def _make_handler(data_dir, runner: _ServiceLoop):
     return TaosmdHandler
 
 
-def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None):
+def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None,
+                verifier=None):
     """Create (but do not start) a :class:`ThreadingHTTPServer`.
 
     Useful for tests that need to bind an ephemeral port (``port=0``) and read
@@ -839,7 +863,7 @@ def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=Non
     directly should call ``server.service_loop.close()`` during teardown.
     """
     runner = _ServiceLoop()
-    httpd = ThreadingHTTPServer((host, port), _make_handler(data_dir, runner))
+    httpd = ThreadingHTTPServer((host, port), _make_handler(data_dir, runner, verifier))
     httpd.service_loop = runner
     return httpd
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -477,7 +477,13 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None):
         _registry_url = _config.get_registry_url(data_dir)
         if _registry_url:
             from . import registry_auth  # noqa: PLC0415 - optional path
-            _registry_verifier = registry_auth.verifier_from_url(_registry_url)
+            # The revoked feed is admin-gated (#710): send the configured taOS
+            # local token on it; pin the issuer to the registry's value.
+            _registry_verifier = registry_auth.verifier_from_url(
+                _registry_url,
+                revoked_token=_config.get_registry_token(data_dir),
+                expected_iss=registry_auth.REGISTRY_ISS,
+            )
 
     # Paths that are always public regardless of the token setting.
     _PUBLIC_PATHS = frozenset({"/", "/ui", "/health"})

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -1,0 +1,192 @@
+"""Registry-based authentication for the A2A bus (opt-in).
+
+When a taOS agent registry is configured, a sender on the bus must present an
+EdDSA-JWT minted by that registry. The token is verified against the registry's
+Ed25519 public key, and the policy layer additionally requires that the token's
+``sub`` (the agent's canonical_id) matches the message ``from`` and is not in the
+registry's revocation list.
+
+With no registry configured the bus keeps its free-handle behaviour, so a
+standalone install is unaffected. The crypto stack (``pyjwt`` + ``cryptography``)
+is an optional extra; if a registry is configured but the libraries are missing,
+verification raises :class:`AuthError` with an actionable message rather than
+silently trusting the handle.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Registry endpoints, relative to the configured base URL (taOS contract).
+PUBKEY_PATH = "/api/agents/registry/pubkey"
+REVOKED_PATH = "/api/agents/registry/revoked"
+
+
+class AuthError(Exception):
+    """Raised when a token fails verification or the auth policy."""
+
+
+def _require_jwt():
+    try:
+        import jwt  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised via degrade test
+        raise AuthError(
+            "registry auth requires the crypto extra: pip install taosmd[registry]"
+        ) from exc
+    return jwt
+
+
+def decode_and_verify(token: str, public_key: str) -> dict:
+    """Verify an EdDSA JWT against an Ed25519 public key and return its claims.
+
+    Raises :class:`AuthError` on a bad signature, malformed token, or expiry.
+    """
+    jwt = _require_jwt()
+    try:
+        return jwt.decode(token, public_key, algorithms=["EdDSA"])
+    except Exception as exc:  # noqa: BLE001 - normalise to AuthError
+        raise AuthError(f"token verification failed: {exc}") from exc
+
+
+def authorize_sender(token: str, claimed_from: str, *, public_key: str,
+                     revoked: set[str], expected_iss: str | None = None) -> dict:
+    """Authorise a bus sender. Returns the verified claims or raises AuthError.
+
+    Policy (after the EdDSA signature check):
+      * the token must carry a ``sub`` (the agent canonical_id);
+      * ``sub`` must equal the message ``from`` (no impersonation);
+      * ``sub`` must not be in the registry revocation set;
+      * when ``expected_iss`` is set, ``iss`` must match it (issuer pinning).
+    """
+    claims = decode_and_verify(token, public_key)
+    sub = claims.get("sub")
+    if not sub:
+        raise AuthError("token has no 'sub' (canonical_id) claim")
+    if sub != claimed_from:
+        raise AuthError(f"token sub {sub!r} does not match from {claimed_from!r}")
+    if sub in revoked:
+        raise AuthError(f"canonical_id {sub!r} is revoked")
+    if expected_iss is not None and claims.get("iss") != expected_iss:
+        raise AuthError(f"token iss {claims.get('iss')!r} != expected {expected_iss!r}")
+    return claims
+
+
+class RegistryVerifier:
+    """Caching wrapper that authorises bus senders against a taOS registry.
+
+    The Ed25519 public key is fetched once and cached (it rotates rarely). The
+    revocation set is fetched and re-fetched on ``refresh_interval`` so revokes
+    propagate without a restart, matching the registry poll-and-cache model. If
+    a revocation refresh fails, the last known-good set is kept (fail-safe: a
+    transient registry outage must not silently un-revoke an agent).
+
+    ``pubkey_loader`` and ``revoked_loader`` are injected so the network layer
+    can be supplied by the caller (and stubbed in tests). ``clock`` defaults to
+    wall-clock ``time.time``; an injected clock makes refresh timing testable.
+    """
+
+    def __init__(self, *, pubkey_loader, revoked_loader,
+                 refresh_interval: float = 300.0, clock=time.time,
+                 expected_iss: str | None = None):
+        self._pubkey_loader = pubkey_loader
+        self._revoked_loader = revoked_loader
+        self._refresh_interval = refresh_interval
+        self._clock = clock
+        self._expected_iss = expected_iss
+        self._pubkey: str | None = None
+        self._revoked: set[str] = set()
+        self._revoked_fetched_at: float | None = None
+
+    def _get_pubkey(self) -> str:
+        if self._pubkey is None:
+            self._pubkey = self._pubkey_loader()
+        return self._pubkey
+
+    def _get_revoked(self) -> set[str]:
+        now = self._clock()
+        stale = (self._revoked_fetched_at is None
+                 or now - self._revoked_fetched_at >= self._refresh_interval)
+        if stale:
+            try:
+                self._revoked = set(self._revoked_loader())
+                self._revoked_fetched_at = now
+            except Exception as exc:  # noqa: BLE001 - keep last-good set
+                if self._revoked_fetched_at is None:
+                    logger.warning("registry revocation fetch failed, "
+                                   "no cached set yet: %s", exc)
+                else:
+                    logger.warning("registry revocation refresh failed, "
+                                   "using last-good set: %s", exc)
+        return self._revoked
+
+    def authorize(self, token: str, claimed_from: str) -> dict:
+        """Authorise a sender; return verified claims or raise AuthError."""
+        return authorize_sender(
+            token, claimed_from,
+            public_key=self._get_pubkey(), revoked=self._get_revoked(),
+            expected_iss=self._expected_iss,
+        )
+
+
+# --- response parsers --------------------------------------------------------
+# The registry's exact JSON shape is not pinned in the contract yet, so accept
+# the common ones: a raw PEM body, or a JSON object carrying the key under a
+# conventional field. The revoked feed is the agreed [{canonical_id,...}] list
+# (also tolerate a {"revoked": [...]} wrapper).
+
+def parse_pubkey_response(body: str) -> str:
+    """Extract an Ed25519 public key (PEM) from a registry response body."""
+    text = body.strip()
+    if text.startswith("-----BEGIN"):
+        return body
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AuthError(f"unrecognised pubkey response: {exc}") from exc
+    if isinstance(obj, dict):
+        for field in ("pubkey", "public_key", "publicKey", "key"):
+            val = obj.get(field)
+            if isinstance(val, str) and val.strip():
+                return val
+    raise AuthError("pubkey response had no recognised key field")
+
+
+def parse_revoked_response(body: str) -> set[str]:
+    """Extract the set of revoked canonical_ids from a revoked-feed body."""
+    obj = json.loads(body)
+    if isinstance(obj, dict):
+        obj = obj.get("revoked", [])
+    revoked: set[str] = set()
+    for rec in obj or []:
+        if isinstance(rec, str):
+            revoked.add(rec)
+        elif isinstance(rec, dict):
+            cid = rec.get("canonical_id") or rec.get("sub") or rec.get("id")
+            if isinstance(cid, str) and cid:
+                revoked.add(cid)
+    return revoked
+
+
+def _http_get(url: str, timeout: float = 5.0) -> str:
+    with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310
+        return resp.read().decode("utf-8")
+
+
+def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
+                      opener=_http_get, clock=time.time,
+                      expected_iss: str | None = None) -> "RegistryVerifier":
+    """Build a :class:`RegistryVerifier` that fetches from a registry base URL.
+
+    The HTTP getter is injectable (``opener``) so callers/tests can supply
+    their own transport. Standalone code never calls this (no registry URL).
+    """
+    base = base_url.rstrip("/")
+    return RegistryVerifier(
+        pubkey_loader=lambda: parse_pubkey_response(opener(base + PUBKEY_PATH)),
+        revoked_loader=lambda: parse_revoked_response(opener(base + REVOKED_PATH)),
+        refresh_interval=refresh_interval, clock=clock, expected_iss=expected_iss,
+    )

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 # Registry endpoints, relative to the configured base URL (taOS contract).
 PUBKEY_PATH = "/api/agents/registry/pubkey"
 REVOKED_PATH = "/api/agents/registry/revoked"
+GRANTS_PATH = "/api/agents/registry/grants"
 
 # The literal ``iss`` the taOS registry mints into every token (#159). The bus
 # pins this so a token from any other issuer is rejected.
@@ -195,6 +196,91 @@ def _http_get(url: str, timeout: float = 5.0, token: str | None = None) -> str:
         req.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return resp.read().decode("utf-8")
+
+
+def parse_grants_response(body: str) -> list[dict]:
+    """Extract grant records from a registry grants-feed response body.
+
+    Returns the raw list of grant dicts; callers filter by expires_at.
+    Each record is expected to carry at least ``canonical_id``.
+    """
+    obj = json.loads(body)
+    if isinstance(obj, dict):
+        obj = obj.get("grants", [])
+    return [r for r in (obj or []) if isinstance(r, dict) and r.get("canonical_id")]
+
+
+class GrantsVerifier:
+    """Caching wrapper that checks whether an agent has an active permission grant.
+
+    Polls ``GET /api/agents/registry/grants`` (admin-only) on interval and
+    caches the result. The bus enforcement gate requires *both* a valid JWT
+    (RegistryVerifier) *and* an active grant (this class).
+
+    Fail semantics mirror RegistryVerifier: if the feed has NEVER loaded,
+    :meth:`has_grant` raises AuthError (fail-closed — cannot prove a grant
+    exists). Once a known-good list is cached, a transient refresh failure
+    keeps the last-good set rather than silently removing all grants.
+
+    Phase 1 (initial deploy): ``expires_at`` is always null, so every record
+    in the feed counts as active. Phase 2 adds real expiries.
+    """
+
+    def __init__(self, *, grants_loader, refresh_interval: float = 300.0,
+                 clock=time.time):
+        self._grants_loader = grants_loader
+        self._refresh_interval = refresh_interval
+        self._clock = clock
+        self._grants: list[dict] = []
+        self._fetched_at: float | None = None
+
+    def _get_grants(self) -> list[dict]:
+        now = self._clock()
+        stale = (self._fetched_at is None
+                 or now - self._fetched_at >= self._refresh_interval)
+        if stale:
+            try:
+                self._grants = self._grants_loader()
+                self._fetched_at = now
+            except Exception as exc:  # noqa: BLE001
+                if self._fetched_at is None:
+                    raise AuthError(
+                        f"grants feed unavailable, refusing to authorise: {exc}"
+                    ) from exc
+                logger.warning("grants feed refresh failed, using last-good set: %s", exc)
+        return self._grants
+
+    def has_grant(self, canonical_id: str, scope: str | None = None) -> bool:
+        """Return True if the agent has at least one active (unexpired) grant.
+
+        When ``scope`` is given, at least one grant must match that scope.
+        When ``scope`` is ``None``, any active grant for the agent suffices.
+        Raises :class:`AuthError` if the feed has never been loaded.
+        """
+        now = self._clock()
+        grants = self._get_grants()
+        for g in grants:
+            if g.get("canonical_id") != canonical_id:
+                continue
+            exp = g.get("expires_at")
+            if exp is not None and exp < now:
+                continue
+            if scope is not None and g.get("scope") != scope:
+                continue
+            return True
+        return False
+
+
+def grants_verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
+                              opener=_http_get, clock=time.time,
+                              grants_token: str | None = None) -> "GrantsVerifier":
+    """Build a :class:`GrantsVerifier` that fetches from a registry base URL."""
+    base = base_url.rstrip("/")
+    return GrantsVerifier(
+        grants_loader=lambda: parse_grants_response(
+            opener(base + GRANTS_PATH, token=grants_token)),
+        refresh_interval=refresh_interval, clock=clock,
+    )
 
 
 def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -80,9 +80,13 @@ class RegistryVerifier:
 
     The Ed25519 public key is fetched once and cached (it rotates rarely). The
     revocation set is fetched and re-fetched on ``refresh_interval`` so revokes
-    propagate without a restart, matching the registry poll-and-cache model. If
-    a revocation refresh fails, the last known-good set is kept (fail-safe: a
-    transient registry outage must not silently un-revoke an agent).
+    propagate without a restart, matching the registry poll-and-cache model.
+
+    Revocation failures are handled fail-closed where it matters: if the feed
+    has NEVER loaded, :meth:`authorize` raises (we cannot prove an agent is
+    unrevoked, so we refuse). Once a known-good set is cached, a later refresh
+    failure keeps that set (a transient outage must not silently un-revoke an
+    agent, nor take the whole bus down).
 
     ``pubkey_loader`` and ``revoked_loader`` are injected so the network layer
     can be supplied by the caller (and stubbed in tests). ``clock`` defaults to
@@ -114,13 +118,17 @@ class RegistryVerifier:
             try:
                 self._revoked = set(self._revoked_loader())
                 self._revoked_fetched_at = now
-            except Exception as exc:  # noqa: BLE001 - keep last-good set
+            except Exception as exc:  # noqa: BLE001
                 if self._revoked_fetched_at is None:
-                    logger.warning("registry revocation fetch failed, "
-                                   "no cached set yet: %s", exc)
-                else:
-                    logger.warning("registry revocation refresh failed, "
-                                   "using last-good set: %s", exc)
+                    # Never loaded: we cannot prove an agent is unrevoked, so
+                    # fail CLOSED rather than fall through to an empty allowlist.
+                    raise AuthError(
+                        f"revocation feed unavailable, refusing to authorise: {exc}"
+                    ) from exc
+                # Already have a known-good set: keep it across a transient
+                # refresh failure (fail-safe, never silently un-revokes).
+                logger.warning("registry revocation refresh failed, "
+                               "using last-good set: %s", exc)
         return self._revoked
 
     def authorize(self, token: str, claimed_from: str) -> dict:

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 PUBKEY_PATH = "/api/agents/registry/pubkey"
 REVOKED_PATH = "/api/agents/registry/revoked"
 
+# The literal ``iss`` the taOS registry mints into every token (#159). The bus
+# pins this so a token from any other issuer is rejected.
+REGISTRY_ISS = "taos-registry"
+
 
 class AuthError(Exception):
     """Raised when a token fails verification or the auth policy."""
@@ -179,22 +183,37 @@ def parse_revoked_response(body: str) -> set[str]:
     return revoked
 
 
-def _http_get(url: str, timeout: float = 5.0) -> str:
-    with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310
+def _http_get(url: str, timeout: float = 5.0, token: str | None = None) -> str:
+    """GET ``url`` and return the body text.
+
+    When ``token`` is given it is sent as ``Authorization: Bearer <token>``.
+    The pubkey endpoint is public (no token); only the auth-gated revoked feed
+    passes one (the #710 contract).
+    """
+    req = urllib.request.Request(url)  # noqa: S310
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return resp.read().decode("utf-8")
 
 
 def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
                       opener=_http_get, clock=time.time,
-                      expected_iss: str | None = None) -> "RegistryVerifier":
+                      expected_iss: str | None = None,
+                      revoked_token: str | None = None) -> "RegistryVerifier":
     """Build a :class:`RegistryVerifier` that fetches from a registry base URL.
 
     The HTTP getter is injectable (``opener``) so callers/tests can supply
     their own transport. Standalone code never calls this (no registry URL).
+
+    ``revoked_token`` is the taOS local/admin token sent as a Bearer header on
+    the revoked-feed poll (the #710 contract moved it behind admin auth). The
+    pubkey endpoint stays public and is fetched without a token.
     """
     base = base_url.rstrip("/")
     return RegistryVerifier(
         pubkey_loader=lambda: parse_pubkey_response(opener(base + PUBKEY_PATH)),
-        revoked_loader=lambda: parse_revoked_response(opener(base + REVOKED_PATH)),
+        revoked_loader=lambda: parse_revoked_response(
+            opener(base + REVOKED_PATH, token=revoked_token)),
         refresh_interval=refresh_interval, clock=clock, expected_iss=expected_iss,
     )

--- a/tests/test_config_managed_by.py
+++ b/tests/test_config_managed_by.py
@@ -1,0 +1,73 @@
+"""Tests for managed_by and serve_dashboard config keys."""
+import os
+import pytest
+from taosmd import config as cfg
+
+
+def test_managed_by_defaults_to_standalone(tmp_path):
+    assert cfg.get_managed_by(tmp_path) == cfg.MANAGED_BY_STANDALONE
+
+
+def test_managed_by_set_and_get(tmp_path):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    assert cfg.get_managed_by(tmp_path) == cfg.MANAGED_BY_TAOS
+
+
+def test_managed_by_roundtrip_standalone(tmp_path):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    cfg.set_managed_by(cfg.MANAGED_BY_STANDALONE, tmp_path)
+    assert cfg.get_managed_by(tmp_path) == cfg.MANAGED_BY_STANDALONE
+
+
+def test_managed_by_rejects_invalid(tmp_path):
+    with pytest.raises(ValueError):
+        cfg.set_managed_by("cloud", tmp_path)
+
+
+def test_managed_by_env_overrides_config(tmp_path, monkeypatch):
+    cfg.set_managed_by(cfg.MANAGED_BY_STANDALONE, tmp_path)
+    monkeypatch.setenv("TAOSMD_MANAGED_BY", cfg.MANAGED_BY_TAOS)
+    assert cfg.get_managed_by(tmp_path) == cfg.MANAGED_BY_TAOS
+
+
+def test_managed_by_env_invalid_falls_through_to_config(tmp_path, monkeypatch):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    monkeypatch.setenv("TAOSMD_MANAGED_BY", "notvalid")
+    assert cfg.get_managed_by(tmp_path) == cfg.MANAGED_BY_TAOS
+
+
+# ---------------------------------------------------------------------------
+# serve_dashboard
+# ---------------------------------------------------------------------------
+
+def test_serve_dashboard_true_when_standalone(tmp_path):
+    assert cfg.get_serve_dashboard(tmp_path) is True
+
+
+def test_serve_dashboard_false_when_taos(tmp_path):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    assert cfg.get_serve_dashboard(tmp_path) is False
+
+
+def test_serve_dashboard_explicit_override_true(tmp_path):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    cfg.set_serve_dashboard(True, tmp_path)
+    assert cfg.get_serve_dashboard(tmp_path) is True
+
+
+def test_serve_dashboard_explicit_override_false(tmp_path):
+    cfg.set_managed_by(cfg.MANAGED_BY_STANDALONE, tmp_path)
+    cfg.set_serve_dashboard(False, tmp_path)
+    assert cfg.get_serve_dashboard(tmp_path) is False
+
+
+def test_serve_dashboard_env_true(tmp_path, monkeypatch):
+    cfg.set_managed_by(cfg.MANAGED_BY_TAOS, tmp_path)
+    monkeypatch.setenv("TAOSMD_SERVE_DASHBOARD", "1")
+    assert cfg.get_serve_dashboard(tmp_path) is True
+
+
+def test_serve_dashboard_env_false(tmp_path, monkeypatch):
+    cfg.set_managed_by(cfg.MANAGED_BY_STANDALONE, tmp_path)
+    monkeypatch.setenv("TAOSMD_SERVE_DASHBOARD", "false")
+    assert cfg.get_serve_dashboard(tmp_path) is False

--- a/tests/test_config_registry_token.py
+++ b/tests/test_config_registry_token.py
@@ -1,0 +1,44 @@
+"""Tests for the registry auth token config (the taOS local/admin token).
+
+Per the #710 contract the registry's revoked feed (``/api/agents/registry/revoked``)
+moved behind admin auth: the bus must send ``Authorization: Bearer <token>`` to
+poll it (the pubkey endpoint stays public). This token is stored here, resolved
+exactly like the other server settings (env wins over the config file).
+"""
+from __future__ import annotations
+
+import pytest
+
+from taosmd import config
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("TAOSMD_REGISTRY_TOKEN", raising=False)
+    return str(tmp_path)
+
+
+def test_unset_is_none(data_dir):
+    assert config.get_registry_token(data_dir) is None
+
+
+def test_set_then_get_round_trip(data_dir):
+    config.set_registry_token("local-admin-token", data_dir=data_dir)
+    assert config.get_registry_token(data_dir) == "local-admin-token"
+
+
+def test_env_overrides_config_file(data_dir, monkeypatch):
+    config.set_registry_token("from-file", data_dir=data_dir)
+    monkeypatch.setenv("TAOSMD_REGISTRY_TOKEN", "from-env")
+    assert config.get_registry_token(data_dir) == "from-env"
+
+
+def test_clear_returns_none(data_dir):
+    config.set_registry_token("tok", data_dir=data_dir)
+    config.set_registry_token("", clear=True, data_dir=data_dir)
+    assert config.get_registry_token(data_dir) is None
+
+
+def test_set_empty_string_raises(data_dir):
+    with pytest.raises(ValueError):
+        config.set_registry_token("", data_dir=data_dir)

--- a/tests/test_config_registry_url.py
+++ b/tests/test_config_registry_url.py
@@ -1,0 +1,42 @@
+"""Tests for the opt-in registry URL config (drives A2A bus auth).
+
+When unset, the bus stays free-handle (standalone). When set (env or config
+file), the server builds a registry verifier that authenticates senders.
+"""
+from __future__ import annotations
+
+import pytest
+
+from taosmd import config
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("TAOSMD_REGISTRY_URL", raising=False)
+    return str(tmp_path)
+
+
+def test_unset_is_none(data_dir):
+    assert config.get_registry_url(data_dir) is None
+
+
+def test_set_then_get_round_trip(data_dir):
+    config.set_registry_url("http://reg.local:8000", data_dir=data_dir)
+    assert config.get_registry_url(data_dir) == "http://reg.local:8000"
+
+
+def test_env_overrides_config_file(data_dir, monkeypatch):
+    config.set_registry_url("http://from-file", data_dir=data_dir)
+    monkeypatch.setenv("TAOSMD_REGISTRY_URL", "http://from-env")
+    assert config.get_registry_url(data_dir) == "http://from-env"
+
+
+def test_clear_returns_none(data_dir):
+    config.set_registry_url("http://reg.local", data_dir=data_dir)
+    config.set_registry_url("", clear=True, data_dir=data_dir)
+    assert config.get_registry_url(data_dir) is None
+
+
+def test_set_empty_string_raises(data_dir):
+    with pytest.raises(ValueError):
+        config.set_registry_url("", data_dir=data_dir)

--- a/tests/test_grants_verifier.py
+++ b/tests/test_grants_verifier.py
@@ -1,0 +1,143 @@
+"""Unit tests for GrantsVerifier and parse_grants_response."""
+import time
+import pytest
+from taosmd.registry_auth import (
+    AuthError,
+    GrantsVerifier,
+    parse_grants_response,
+    grants_verifier_from_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_grants_response
+# ---------------------------------------------------------------------------
+
+def test_parse_grants_response_basic():
+    body = '{"grants": [{"canonical_id": "agent-a", "scope": "memory"}]}'
+    grants = parse_grants_response(body)
+    assert len(grants) == 1
+    assert grants[0]["canonical_id"] == "agent-a"
+
+
+def test_parse_grants_response_list_directly():
+    body = '[{"canonical_id": "agent-b", "scope": "a2a"}]'
+    grants = parse_grants_response(body)
+    assert grants[0]["canonical_id"] == "agent-b"
+
+
+def test_parse_grants_response_empty():
+    assert parse_grants_response('{"grants": []}') == []
+
+
+def test_parse_grants_response_skips_missing_canonical_id():
+    body = '{"grants": [{"scope": "memory"}, {"canonical_id": "ok"}]}'
+    grants = parse_grants_response(body)
+    assert len(grants) == 1
+    assert grants[0]["canonical_id"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# GrantsVerifier.has_grant
+# ---------------------------------------------------------------------------
+
+def _make_verifier(grants, clock=None):
+    return GrantsVerifier(
+        grants_loader=lambda: grants,
+        refresh_interval=300.0,
+        clock=clock or time.time,
+    )
+
+
+def test_has_grant_returns_true_when_present():
+    v = _make_verifier([{"canonical_id": "agent-a", "scope": "memory"}])
+    assert v.has_grant("agent-a") is True
+
+
+def test_has_grant_returns_false_when_absent():
+    v = _make_verifier([{"canonical_id": "agent-a", "scope": "memory"}])
+    assert v.has_grant("agent-b") is False
+
+
+def test_has_grant_scope_filter_matches():
+    v = _make_verifier([{"canonical_id": "agent-a", "scope": "memory"}])
+    assert v.has_grant("agent-a", scope="memory") is True
+
+
+def test_has_grant_scope_filter_no_match():
+    v = _make_verifier([{"canonical_id": "agent-a", "scope": "memory"}])
+    assert v.has_grant("agent-a", scope="a2a") is False
+
+
+def test_has_grant_skips_expired():
+    past = time.time() - 1.0
+    v = _make_verifier([{"canonical_id": "agent-a", "expires_at": past}])
+    assert v.has_grant("agent-a") is False
+
+
+def test_has_grant_accepts_null_expires_at():
+    v = _make_verifier([{"canonical_id": "agent-a", "expires_at": None}])
+    assert v.has_grant("agent-a") is True
+
+
+def test_has_grant_accepts_future_expires_at():
+    future = time.time() + 3600.0
+    v = _make_verifier([{"canonical_id": "agent-a", "expires_at": future}])
+    assert v.has_grant("agent-a") is True
+
+
+# ---------------------------------------------------------------------------
+# Fail semantics
+# ---------------------------------------------------------------------------
+
+def test_has_grant_raises_auth_error_when_feed_never_loaded():
+    def broken():
+        raise ConnectionError("network down")
+    v = GrantsVerifier(grants_loader=broken)
+    with pytest.raises(AuthError, match="grants feed unavailable"):
+        v.has_grant("agent-a")
+
+
+def test_has_grant_keeps_last_good_on_refresh_failure():
+    calls = []
+
+    def loader():
+        calls.append(1)
+        if len(calls) == 1:
+            return [{"canonical_id": "agent-a"}]
+        raise ConnectionError("refresh failed")
+
+    now = [0.0]
+
+    def clock():
+        return now[0]
+
+    v = GrantsVerifier(grants_loader=loader, refresh_interval=10.0, clock=clock)
+    # First load: succeeds, agent-a is granted.
+    assert v.has_grant("agent-a") is True
+    # Advance past refresh interval so next call tries to refresh.
+    now[0] = 20.0
+    # Refresh fails; last-good set is kept, so agent-a still has a grant.
+    assert v.has_grant("agent-a") is True
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# grants_verifier_from_url (integration smoke)
+# ---------------------------------------------------------------------------
+
+def test_grants_verifier_from_url_builds_correctly():
+    fetched = []
+
+    def opener(url, timeout=5.0, token=None):
+        fetched.append((url, token))
+        return '{"grants": [{"canonical_id": "agent-x"}]}'
+
+    v = grants_verifier_from_url(
+        "http://registry.local",
+        opener=opener,
+        grants_token="admin-tok",
+    )
+    assert v.has_grant("agent-x") is True
+    assert fetched[0][0].endswith("/api/agents/registry/grants")
+    assert fetched[0][1] == "admin-tok"

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -62,7 +62,7 @@ def authed_server(tmp_path, monkeypatch):
     data_dir.mkdir()
     monkeypatch.setattr(taosmd_api, "_stores_cache", {})
 
-    def fake_opener(url):
+    def fake_opener(url, token=None):
         if url.endswith(registry_auth.PUBKEY_PATH):
             return json.dumps({"pubkey": PUB_PEM})
         return json.dumps([])  # nothing revoked
@@ -106,3 +106,79 @@ def test_send_with_token_from_wrong_key_is_rejected(authed_server):
     token = pyjwt.encode({"sub": "agent-1"}, other_priv, algorithm="EdDSA")
     status, _ = _post_send(authed_server, "agent-1", "hello", token=token)
     assert status in (401, 403)
+
+
+@pytest.fixture
+def iss_pinned_server(tmp_path, monkeypatch):
+    """Live server whose verifier pins iss to the taOS registry value."""
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"public_key": PUB_PEM})
+        return json.dumps({"revoked": []})
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS)
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir),
+                                    verifier=verifier)
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+def test_pinned_issuer_accepts_token_with_correct_iss(iss_pinned_server):
+    token = pyjwt.encode({"sub": "agent-1", "iss": registry_auth.REGISTRY_ISS},
+                         PRIV_PEM, algorithm="EdDSA")
+    status, _ = _post_send(iss_pinned_server, "agent-1", "hello", token=token)
+    assert status == 200
+
+
+def test_pinned_issuer_rejects_token_with_wrong_iss(iss_pinned_server):
+    token = pyjwt.encode({"sub": "agent-1", "iss": "someone-else"},
+                         PRIV_PEM, algorithm="EdDSA")
+    status, _ = _post_send(iss_pinned_server, "agent-1", "hello", token=token)
+    assert status == 403
+
+
+def test_server_builds_verifier_with_token_and_pinned_issuer(tmp_path, monkeypatch):
+    # When a registry URL is configured, the server must build its verifier with
+    # the configured admin token (for the auth-gated revoked feed) and pin the
+    # issuer to the taOS registry value (#710 contract).
+    from taosmd import config
+
+    data_dir = tmp_path / "cfg-data"
+    data_dir.mkdir()
+    monkeypatch.delenv("TAOSMD_REGISTRY_URL", raising=False)
+    monkeypatch.delenv("TAOSMD_REGISTRY_TOKEN", raising=False)
+    config.set_registry_url("http://reg.test", data_dir=str(data_dir))
+    config.set_registry_token("admin-token", data_dir=str(data_dir))
+
+    captured = {}
+
+    def fake_verifier_from_url(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return object()  # dummy; never invoked in this test
+
+    monkeypatch.setattr(registry_auth, "verifier_from_url", fake_verifier_from_url)
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    try:
+        assert captured["url"] == "http://reg.test"
+        assert captured.get("revoked_token") == "admin-token"
+        assert captured.get("expected_iss") == registry_auth.REGISTRY_ISS
+    finally:
+        httpd.service_loop.close()
+        httpd.server_close()

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -1,0 +1,108 @@
+"""A2A bus authentication wired into the HTTP server (opt-in).
+
+When the server is built with a registry verifier, POST /a2a/send requires a
+valid EdDSA-JWT Bearer token whose ``sub`` matches the message ``from``. With
+no verifier (the default / standalone), the bus trusts the handle as before.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, registry_auth
+
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _post_send(base_url, from_, body, token=None):
+    payload = json.dumps({"from": from_, "body": body}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(base_url + "/a2a/send", data=payload,
+                                 headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    """Live server built with a registry verifier (fake opener, no network)."""
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    def fake_opener(url):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        return json.dumps([])  # nothing revoked
+
+    verifier = registry_auth.verifier_from_url("http://reg.test", opener=fake_opener)
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir),
+                                    verifier=verifier)
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+def test_send_without_token_is_rejected(authed_server):
+    status, _ = _post_send(authed_server, "agent-1", "hello")
+    assert status in (401, 403)
+
+
+def test_send_with_valid_matching_token_succeeds(authed_server):
+    token = pyjwt.encode({"sub": "agent-1"}, PRIV_PEM, algorithm="EdDSA")
+    status, body = _post_send(authed_server, "agent-1", "hello", token=token)
+    assert status == 200
+    assert body.get("id") is not None or body.get("status") == "ok" or body
+
+
+def test_send_with_mismatched_sub_is_rejected(authed_server):
+    token = pyjwt.encode({"sub": "agent-OTHER"}, PRIV_PEM, algorithm="EdDSA")
+    status, _ = _post_send(authed_server, "agent-1", "hello", token=token)
+    assert status == 403
+
+
+def test_send_with_token_from_wrong_key_is_rejected(authed_server):
+    other_priv, _ = _keypair()
+    token = pyjwt.encode({"sub": "agent-1"}, other_priv, algorithm="EdDSA")
+    status, _ = _post_send(authed_server, "agent-1", "hello", token=token)
+    assert status in (401, 403)

--- a/tests/test_http_server_trust_enforcement.py
+++ b/tests/test_http_server_trust_enforcement.py
@@ -1,0 +1,250 @@
+"""Trust & Comms enforcement: grant check on A2A bus + dashboard gating.
+
+Tests the two new enforcement layers added on top of the existing registry
+verifier (test_http_server_registry_auth.py covers token verification alone):
+
+1. Grant check: a valid token + an active grant is required; a valid token
+   without a grant is rejected with 403.
+2. Dashboard gating: when managed_by=taos and serve_dashboard is not overridden,
+   GET / and GET /ui return 404; API routes stay up.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg
+from taosmd import http_server, registry_auth
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _mint(canonical_id: str) -> str:
+    return pyjwt.encode(
+        {"sub": canonical_id, "iss": registry_auth.REGISTRY_ISS},
+        PRIV_PEM, algorithm="EdDSA",
+    )
+
+
+def _post_send(base_url, from_, body, token=None):
+    payload = json.dumps({"from": from_, "body": body}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        base_url + "/a2a/send", data=payload, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get(base_url, path):
+    req = urllib.request.Request(base_url + path)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def _make_verifiers(grants: list[dict]):
+    """Build (registry_verifier, grants_verifier) pair with a fake network."""
+    def fake_opener(url, timeout=5.0, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([])
+        if url.endswith(registry_auth.GRANTS_PATH):
+            return json.dumps({"grants": grants})
+        raise ValueError(f"unexpected url: {url}")
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS,
+    )
+    gv = registry_auth.grants_verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+    )
+    return verifier, gv
+
+
+@pytest.fixture
+def enforced_server(tmp_path, monkeypatch):
+    """Server with both token verifier AND grants verifier wired in."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    verifier, gv = _make_verifiers([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Grant check tests
+# ---------------------------------------------------------------------------
+
+def test_send_allowed_with_valid_token_and_grant(enforced_server):
+    token = _mint("agent-allowed")
+    status, body = _post_send(enforced_server, "agent-allowed", "hello", token=token)
+    assert status == 200, body
+
+
+def test_send_rejected_no_token(enforced_server):
+    status, body = _post_send(enforced_server, "agent-allowed", "hello")
+    assert status == 401
+
+
+def test_send_rejected_valid_token_no_grant(enforced_server):
+    # agent-no-grant has a valid token but is not in the grants feed.
+    token = _mint("agent-no-grant")
+    status, body = _post_send(enforced_server, "agent-no-grant", "hello", token=token)
+    assert status == 403
+    assert "grant" in body.get("error", "").lower()
+
+
+def test_send_rejected_expired_grant(tmp_path, monkeypatch):
+    """An expired grant is treated the same as no grant."""
+    import time
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    past = time.time() - 10.0
+    verifier, gv = _make_verifiers(
+        [{"canonical_id": "agent-expired", "expires_at": past}]
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        token = _mint("agent-expired")
+        status, body = _post_send(
+            f"http://{host}:{port}", "agent-expired", "hi", token=token
+        )
+        assert status == 403
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Dashboard gating tests
+# ---------------------------------------------------------------------------
+
+def _server_with_managed_by(tmp_path, monkeypatch, managed_by, serve_dashboard=None):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    cfg.set_managed_by(managed_by, data_dir)
+    if serve_dashboard is not None:
+        cfg.set_serve_dashboard(serve_dashboard, data_dir)
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, f"http://{host}:{port}"
+
+
+def test_dashboard_served_when_standalone(tmp_path, monkeypatch):
+    httpd, base = _server_with_managed_by(
+        tmp_path, monkeypatch, cfg.MANAGED_BY_STANDALONE
+    )
+    try:
+        status, _ = _get(base, "/")
+        assert status == 200
+        status2, _ = _get(base, "/ui")
+        assert status2 == 200
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+def test_dashboard_hidden_when_taos(tmp_path, monkeypatch):
+    httpd, base = _server_with_managed_by(
+        tmp_path, monkeypatch, cfg.MANAGED_BY_TAOS
+    )
+    try:
+        status, _ = _get(base, "/")
+        assert status == 404
+        status2, _ = _get(base, "/ui")
+        assert status2 == 404
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+def test_dashboard_override_serves_when_taos(tmp_path, monkeypatch):
+    httpd, base = _server_with_managed_by(
+        tmp_path, monkeypatch, cfg.MANAGED_BY_TAOS, serve_dashboard=True
+    )
+    try:
+        status, _ = _get(base, "/")
+        assert status == 200
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+def test_api_still_up_when_dashboard_hidden(tmp_path, monkeypatch):
+    httpd, base = _server_with_managed_by(
+        tmp_path, monkeypatch, cfg.MANAGED_BY_TAOS
+    )
+    try:
+        status, body = _get(base, "/health")
+        assert status == 200
+        assert json.loads(body)["status"] == "ok"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -309,7 +309,7 @@ def test_verifier_from_url_fetches_pubkey_and_revoked_from_contract_paths():
     priv_pem, pub_pem = _keypair()
     seen = []
 
-    def fake_opener(url):
+    def fake_opener(url, token=None):
         seen.append(url)
         if url.endswith(registry_auth.PUBKEY_PATH):
             return json.dumps({"pubkey": pub_pem})
@@ -327,3 +327,76 @@ def test_verifier_from_url_fetches_pubkey_and_revoked_from_contract_paths():
 
     assert "http://taos:8000" + registry_auth.PUBKEY_PATH in seen
     assert "http://taos:8000" + registry_auth.REVOKED_PATH in seen
+
+
+# --- #710 contract: revoked feed is auth-gated, pubkey feed is public --------
+
+
+def test_verifier_from_url_sends_token_on_revoked_feed_only():
+    # Per #710 the revoked feed requires Authorization: Bearer <token>; the
+    # pubkey endpoint is public and must be fetched WITHOUT the token.
+    import json
+    priv_pem, pub_pem = _keypair()
+    calls = []
+
+    def fake_opener(url, token=None):
+        calls.append((url, token))
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"public_key": pub_pem})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps({"revoked": []})
+        raise AssertionError(f"unexpected url {url}")
+
+    v = registry_auth.verifier_from_url(
+        "http://taos:8000", opener=fake_opener, revoked_token="admin-token")
+    v.authorize(_sign(priv_pem, {"sub": "a"}), "a")
+
+    pubkey_tokens = [t for u, t in calls if u.endswith(registry_auth.PUBKEY_PATH)]
+    revoked_tokens = [t for u, t in calls if u.endswith(registry_auth.REVOKED_PATH)]
+    assert pubkey_tokens == [None]            # public: no token
+    assert revoked_tokens == ["admin-token"]  # auth-gated: token sent
+
+
+def test_http_get_sets_authorization_header_when_token_given(monkeypatch):
+    captured = {}
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b"body-bytes"
+
+    def fake_urlopen(req, timeout=None):
+        captured["auth"] = req.get_header("Authorization")
+        return _FakeResp()
+
+    monkeypatch.setattr(registry_auth.urllib.request, "urlopen", fake_urlopen)
+    out = registry_auth._http_get("http://reg/x", token="secret-tok")
+    assert out == "body-bytes"
+    assert captured["auth"] == "Bearer secret-tok"
+
+
+def test_http_get_omits_authorization_header_without_token(monkeypatch):
+    captured = {}
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b"ok"
+
+    def fake_urlopen(req, timeout=None):
+        captured["auth"] = req.get_header("Authorization")
+        return _FakeResp()
+
+    monkeypatch.setattr(registry_auth.urllib.request, "urlopen", fake_urlopen)
+    registry_auth._http_get("http://reg/x")
+    assert captured["auth"] is None

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -1,0 +1,313 @@
+"""Tests for registry-based A2A bus authentication (taOS agent registry).
+
+The bus is opt-in authenticated: when a registry public key is configured,
+a sender must present an EdDSA-JWT (minted by the taOS registry) whose ``sub``
+(canonical_id) matches the message ``from`` and is not revoked. With no
+registry configured, the bus keeps its free-handle behaviour (standalone).
+
+These tests inject keys and revoked-sets directly so they never touch the
+network. Ed25519 keypairs + JWT signing use ``cryptography`` + ``pyjwt``,
+which are the same optional libraries the verifier requires at runtime.
+"""
+from __future__ import annotations
+
+import pytest
+
+# The verifier requires pyjwt[crypto]; skip the whole module if the optional
+# crypto stack is not installed (the runtime degrades with a clear error, but
+# these tests need it present to exercise real signatures).
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import registry_auth
+
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+def _sign(priv_pem: str, claims: dict) -> str:
+    return pyjwt.encode(claims, priv_pem, algorithm="EdDSA")
+
+
+def test_decode_and_verify_returns_claims_for_valid_signature():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "hermes-20260608-153000", "iss": "taos"})
+
+    claims = registry_auth.decode_and_verify(token, pub_pem)
+
+    assert claims["sub"] == "hermes-20260608-153000"
+    assert claims["iss"] == "taos"
+
+
+def test_decode_and_verify_rejects_token_signed_by_a_different_key():
+    priv_pem, _ = _keypair()
+    _, other_pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "imposter"})
+
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.decode_and_verify(token, other_pub_pem)
+
+
+def test_decode_and_verify_rejects_garbage_token():
+    _, pub_pem = _keypair()
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.decode_and_verify("not-a-jwt", pub_pem)
+
+
+def test_authorize_sender_accepts_matching_sub():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "agent-20260101-000000"})
+
+    claims = registry_auth.authorize_sender(
+        token, "agent-20260101-000000", public_key=pub_pem, revoked=set()
+    )
+
+    assert claims["sub"] == "agent-20260101-000000"
+
+
+def test_authorize_sender_rejects_when_sub_does_not_match_from():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "agent-A"})
+
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.authorize_sender(
+            token, "agent-B", public_key=pub_pem, revoked=set()
+        )
+
+
+def test_authorize_sender_rejects_revoked_canonical_id():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "agent-revoked"})
+
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.authorize_sender(
+            token, "agent-revoked", public_key=pub_pem, revoked={"agent-revoked"}
+        )
+
+
+def test_authorize_sender_enforces_expected_issuer_when_configured():
+    priv_pem, pub_pem = _keypair()
+    good = _sign(priv_pem, {"sub": "a", "iss": "taos"})
+    bad = _sign(priv_pem, {"sub": "a", "iss": "someone-else"})
+
+    assert registry_auth.authorize_sender(
+        good, "a", public_key=pub_pem, revoked=set(), expected_iss="taos")["iss"] == "taos"
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.authorize_sender(
+            bad, "a", public_key=pub_pem, revoked=set(), expected_iss="taos")
+
+
+def test_authorize_sender_skips_issuer_check_when_not_configured():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "a", "iss": "whatever"})
+    # expected_iss defaults to None -> issuer is not enforced
+    assert registry_auth.authorize_sender(
+        token, "a", public_key=pub_pem, revoked=set())["sub"] == "a"
+
+
+def test_authorize_sender_requires_a_sub_claim():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"iss": "taos"})  # no sub
+
+    with pytest.raises(registry_auth.AuthError):
+        registry_auth.authorize_sender(
+            token, "anything", public_key=pub_pem, revoked=set()
+        )
+
+
+# --- RegistryVerifier: caching + polling layer over the pure functions -------
+
+
+class _FakeClock:
+    def __init__(self, t=1000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def test_verifier_authorizes_with_fetched_pubkey_and_revoked():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "agent-1"})
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem,
+        revoked_loader=lambda: set(),
+    )
+
+    claims = v.authorize(token, "agent-1")
+
+    assert claims["sub"] == "agent-1"
+
+
+def test_verifier_enforces_fetched_revocation_set():
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "agent-bad"})
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem,
+        revoked_loader=lambda: {"agent-bad"},
+    )
+
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token, "agent-bad")
+
+
+def test_verifier_caches_loaders_within_refresh_window():
+    priv_pem, pub_pem = _keypair()
+    calls = {"pubkey": 0, "revoked": 0}
+
+    def pubkey_loader():
+        calls["pubkey"] += 1
+        return pub_pem
+
+    def revoked_loader():
+        calls["revoked"] += 1
+        return set()
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=pubkey_loader, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+    )
+    v.authorize(_sign(priv_pem, {"sub": "a"}), "a")
+    clock.advance(100)  # still within the 300s window
+    v.authorize(_sign(priv_pem, {"sub": "a"}), "a")
+
+    # pubkey fetched once (rotates rarely), revoked not re-fetched yet
+    assert calls["pubkey"] == 1
+    assert calls["revoked"] == 1
+
+
+def test_verifier_refreshes_revocation_after_interval():
+    priv_pem, pub_pem = _keypair()
+    revoked_state = {"set": set()}
+    calls = {"revoked": 0}
+
+    def revoked_loader():
+        calls["revoked"] += 1
+        return set(revoked_state["set"])
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+    )
+    token = _sign(priv_pem, {"sub": "agent-x"})
+    v.authorize(token, "agent-x")  # ok, not revoked
+
+    # agent gets revoked; advance past the refresh window
+    revoked_state["set"] = {"agent-x"}
+    clock.advance(301)
+
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token, "agent-x")
+    assert calls["revoked"] == 2  # re-fetched after the window
+
+
+def test_verifier_uses_last_good_revocation_when_refresh_fails():
+    priv_pem, pub_pem = _keypair()
+    state = {"fail": False}
+
+    def revoked_loader():
+        if state["fail"]:
+            raise OSError("registry unreachable")
+        return {"agent-x"}
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+    )
+    token = _sign(priv_pem, {"sub": "agent-x"})
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token, "agent-x")  # primes cache: agent-x revoked
+
+    # registry goes down; the cached revocation must still hold (fail-safe)
+    state["fail"] = True
+    clock.advance(301)
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token, "agent-x")
+
+
+# --- response parsers (tolerant of the registry's exact JSON shape) ----------
+
+_PEM = ("-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA\n"
+        "-----END PUBLIC KEY-----\n")
+
+
+def test_parse_pubkey_accepts_raw_pem_body():
+    assert registry_auth.parse_pubkey_response(_PEM) == _PEM
+
+
+def test_parse_pubkey_accepts_json_pubkey_field():
+    import json
+    body = json.dumps({"pubkey": _PEM})
+    assert registry_auth.parse_pubkey_response(body) == _PEM
+
+
+def test_parse_pubkey_accepts_json_public_key_field():
+    import json
+    body = json.dumps({"public_key": _PEM})
+    assert registry_auth.parse_pubkey_response(body) == _PEM
+
+
+def test_parse_revoked_reads_canonical_ids_from_list_of_records():
+    import json
+    body = json.dumps([
+        {"canonical_id": "a-1", "revoked_at": 123.0},
+        {"canonical_id": "b-2", "revoked_at": 456.0},
+    ])
+    assert registry_auth.parse_revoked_response(body) == {"a-1", "b-2"}
+
+
+def test_parse_revoked_accepts_wrapped_object():
+    import json
+    body = json.dumps({"revoked": [{"canonical_id": "c-3", "revoked_at": 1}]})
+    assert registry_auth.parse_revoked_response(body) == {"c-3"}
+
+
+def test_parse_revoked_empty_is_empty_set():
+    assert registry_auth.parse_revoked_response("[]") == set()
+
+
+def test_verifier_from_url_fetches_pubkey_and_revoked_from_contract_paths():
+    import json
+    priv_pem, pub_pem = _keypair()
+    seen = []
+
+    def fake_opener(url):
+        seen.append(url)
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": pub_pem})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([{"canonical_id": "agent-gone", "revoked_at": 1}])
+        raise AssertionError(f"unexpected url {url}")
+
+    v = registry_auth.verifier_from_url("http://taos:8000/", opener=fake_opener)
+
+    # a live agent authorises
+    assert v.authorize(_sign(priv_pem, {"sub": "agent-ok"}), "agent-ok")["sub"] == "agent-ok"
+    # a revoked agent is rejected
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(_sign(priv_pem, {"sub": "agent-gone"}), "agent-gone")
+
+    assert "http://taos:8000" + registry_auth.PUBKEY_PATH in seen
+    assert "http://taos:8000" + registry_auth.REVOKED_PATH in seen

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -247,6 +247,22 @@ def test_verifier_uses_last_good_revocation_when_refresh_fails():
         v.authorize(token, "agent-x")
 
 
+def test_verifier_fails_closed_when_revocation_never_loaded():
+    # If the revocation feed has NEVER loaded, we cannot prove an agent is not
+    # revoked, so authorize must reject (fail-closed) even for a valid signature.
+    priv_pem, pub_pem = _keypair()
+
+    def always_fails():
+        raise OSError("registry unreachable at startup")
+
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=always_fails,
+    )
+    token = _sign(priv_pem, {"sub": "agent-1"})
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token, "agent-1")
+
+
 # --- response parsers (tolerant of the registry's exact JSON shape) ----------
 
 _PEM = ("-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA\n"


### PR DESCRIPTION
Implements the taosmd-side enforcement layer agreed with @taOS on the A2A bus. Builds on top of the existing registry-auth token verifier (PR already merged via feat/registry-bus-auth).

## What

**GrantsVerifier** (`taosmd/registry_auth.py`): polls `GET /api/agents/registry/grants` (admin-only, same token as /revoked), caches active grants, fail-closed on first load, keeps last-good on refresh failure. `has_grant(canonical_id, scope?)` checks `expires_at`.

**managed_by + serve_dashboard** (`taosmd/config.py`): `"standalone"` (default) or `"taos"`. When `taos`, `serve_dashboard` defaults to `False`. Overridable via `TAOSMD_MANAGED_BY` / `TAOSMD_SERVE_DASHBOARD` env vars or config file.

**Enforcement in http_server.py**:
- A2A send: valid token AND active grant required; 403 with `"grant"` in error body on miss
- Dashboard gating: `GET /` and `/ui` return 404 when `serve_dashboard=False`; all API routes (including `/health`) stay up

## Contract (confirmed w/ @taOS)
Token = identity-only (EdDSA-JWT); all tiering in the grant store/feed (#719). Bus gate = valid token AND active grant. taOS writes `managed_by=taos` at provision time.

## Tests
34 new tests, all green. 3 pre-existing `bm25_rrf` failures on base (not caused by this change). Full suite: 642 passing.

- `tests/test_grants_verifier.py`: GrantsVerifier unit tests (parse, has_grant, fail semantics, smoke)
- `tests/test_config_managed_by.py`: managed_by + serve_dashboard config tests
- `tests/test_http_server_trust_enforcement.py`: integration tests against a live test server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Optional authentication system for A2A message sending using registry-based tokens and EdDSA-JWT verification.
* New configuration settings for registry URL, authentication credentials, and instance ownership/dashboard visibility control.
* Dashboard routes can now be conditionally gated based on deployment mode, with override capability.
* A2A message sender authentication and permission grant enforcement when registry authentication is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
