### PR TITLE
feat(server): POST /ingest/batch + ?mode=bm25 search (taOS user-memory unification, taOS#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Bulk ingest with idempotent re-import.** `POST /ingest/batch` (and
+  `taosmd.ingest_batch()` / `RemoteClient.ingest_batch()`) shelves a list of
+  `{"text", "id"?, "metadata"?}` items in one call. Each item's `id` (the
+  caller's stable content hash) is preserved as `source_id` and used to skip
+  already-ingested items, so a migration batch can be re-POSTed safely.
+  Returns `{"ingested", "skipped"}`. Built for the taOS user-memory
+  unification (taOS#25): one-shot cutover of `user_memory_chunks` into a
+  shared `user-memory` agent namespace.
+- **BM25-only search mode.** `?mode=bm25` on `GET|POST /search` (and
+  `mode="bm25"` on `taosmd.search()`) skips query embedding and recipe
+  resolution entirely and returns BM25-ranked hits in the unchanged contract
+  shape, with `confidence` carrying the sigmoid-normalised BM25 score. The
+  search-as-you-type path for short-form user memory (sub-300ms SLA; the
+  BM25 index reuses the fusion-path cache). Uses `bm25s` when installed and
+  falls back to a dependency-free Okapi BM25 (same k1/b) when not.
+
 ## 0.3.0
 
 First PyPI release. `pip install taosmd` now works (previous versions were

--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -24,6 +24,7 @@ from .catalog_pipeline import CatalogPipeline
 from .retrieval import retrieve
 from .api import (
     ingest,
+    ingest_batch,
     search,
     list_projects,
     list_shelves,
@@ -131,6 +132,7 @@ __all__ = [
     # Retrieval
     "retrieve",
     "ingest",
+    "ingest_batch",
     "search",
     # Project identity + cross-agent discovery
     "project",

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -217,6 +217,98 @@ async def ingest(transcript, *, agent: str, project: str | None = None, data_dir
     return {"archived": archived, "agent": agent, "project": project, "data_dir": stores["data_dir"]}
 
 
+async def ingest_batch(
+    items,
+    *,
+    agent: str,
+    project: str | None = None,
+    data_dir=None,
+) -> dict:
+    """Bulk-shelve memory chunks with idempotent re-import (#25 contract).
+
+    The migration path for external memory stores (taOS user memory): each
+    item carries its own stable ``id`` (the caller's content hash) so the
+    whole batch can be re-POSTed safely — items whose ``id`` is already
+    stored are counted in ``skipped`` instead of duplicated.
+
+    Args:
+        items: List of ``{"text": str, "id": str?, "metadata": dict?}``.
+            ``text`` is required per item. ``id`` is the caller's stable
+            content hash, preserved as ``source_id`` in the stored metadata
+            and used for dedup. ``metadata`` is preserved verbatim (e.g.
+            ``collection``/``title`` for taOS user memory).
+        agent: Registered agent name (e.g. ``"user-memory"``). Auto-registered
+            if absent.
+        project: Optional project fingerprint, as in :func:`ingest`.
+        data_dir: Optional taosmd data dir (see :func:`ingest`).
+
+    Returns:
+        ``{"ingested": int, "skipped": int, "agent": str, "data_dir": str}``.
+        ``skipped`` counts duplicate ids (incl. in-batch repeats) and
+        empty-text items.
+
+    Raises:
+        ValueError: On a structurally invalid request (bad agent, items not
+            a list, an item that is not a dict or lacks a string ``text``).
+            Validation runs before any write so a 400 never leaves a
+            half-applied batch.
+    """
+    if not agent:
+        raise ValueError("agent name is required")
+    if not isinstance(items, list):
+        raise ValueError("'items' must be a list")
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise ValueError(f"items[{i}] must be an object")
+        if not isinstance(item.get("text"), str):
+            raise ValueError(f"items[{i}].text (string) is required")
+        if item.get("id") is not None and not isinstance(item["id"], str):
+            raise ValueError(f"items[{i}].id must be a string when provided")
+        if item.get("metadata") is not None and not isinstance(item["metadata"], dict):
+            raise ValueError(f"items[{i}].metadata must be an object when provided")
+
+    stores = await _ensure_stores(data_dir)
+
+    from taosmd.agents import ensure_agent, update_stats
+    ensure_agent(agent)
+
+    seen = stores["vector"].existing_source_ids(agent=agent)
+    ingested = 0
+    skipped = 0
+    for item in items:
+        text = item["text"].strip()
+        sid = item.get("id")
+        if not text or (sid and sid in seen):
+            skipped += 1
+            continue
+        user_md = dict(item.get("metadata") or {})
+        if sid:
+            user_md["source_id"] = sid
+        await stores["archive"].record(
+            "conversation",
+            {"content": text, "metadata": user_md},
+            agent_name=agent,
+            summary=text[:80],
+            project=project,
+        )
+        meta: dict = {"agent": agent, "metadata": user_md}
+        if project:
+            meta["project"] = project
+        await stores["vector"].add(text, metadata=meta)
+        if sid:
+            seen.add(sid)
+        ingested += 1
+
+    if ingested:
+        update_stats(agent, last_ingest_at=int(time.time()))
+    return {
+        "ingested": ingested,
+        "skipped": skipped,
+        "agent": agent,
+        "data_dir": stores["data_dir"],
+    }
+
+
 def _format_hit(hit: dict) -> dict:
     """Reshape a retrieve() hit into the agent-rules contract shape.
 
@@ -259,6 +351,7 @@ async def search(
     project: str | None = None,
     also_include: list[str] | None = None,
     limit: int = 5,
+    mode: str | None = None,
     data_dir=None,
 ) -> list[dict]:
     """Search the librarian's shelves for passages relevant to ``query``.
@@ -278,10 +371,16 @@ async def search(
             memories should be included in the search results (cross-agent
             reads). Only effective when ``project`` is also set.
         limit: Maximum number of hits to return.
+        mode: Optional retrieval mode. ``"bm25"`` skips query embedding and
+            recipe resolution entirely and returns BM25-only hits (the #25
+            user-memory contract: keyword search-as-you-type, sub-300ms).
+            Default ``None`` is the full recipe-driven retrieval path.
         data_dir: Optional taosmd data dir (see :func:`ingest`).
     """
     if not agent:
         raise ValueError("agent name is required")
+    if mode not in (None, "", "bm25"):
+        raise ValueError(f"unsupported search mode: {mode!r} (supported: 'bm25')")
     if not query:
         return []
 
@@ -293,6 +392,34 @@ async def search(
     # Register against the same data_dir the recipe layer resolves against, so
     # resolve_recipe() can read/write this agent's record.
     ensure_agent(agent, data_dir=data_dir)
+
+    # Build the list of agent names to search across.
+    # When project + also_include are set, we search the calling agent
+    # plus any explicitly included agents within the same project.
+    search_agents = [agent]
+    if project and also_include:
+        for name in also_include:
+            if name != agent:
+                search_agents.append(name)
+
+    if mode == "bm25":
+        # BM25-only path: no embed call, no recipe/reranker resolution. Hits
+        # come straight off the vector store's BM25 index in the same
+        # contract shape as the full path.
+        raw = await stores["vector"].search_bm25(
+            query, limit=limit, project=project, search_agents=search_agents
+        )
+        hits = []
+        for h in raw:
+            md = dict(h.get("metadata") or {})
+            md.setdefault("created_at", h.get("created_at"))
+            hits.append(_format_hit({
+                "text": h.get("text", ""),
+                "source": "vector",
+                "source_score": h.get("similarity", 0.0),
+                "metadata": md,
+            }))
+        return hits
 
     # Resolve the active recipe (per-agent -> global default -> recommend()[0])
     # and map its retrieval knobs onto the retrieve() call below.
@@ -315,15 +442,6 @@ async def search(
 
     # per-agent fanout (recipe-derived via librarian.fanout) governs retrieval breadth; recipe.retrieval.candidate_top_k sets the pre-rerank pool. retrieval.limit is advisory in SP1.
     effective_limit = limit
-
-    # Build the list of agent names to search across.
-    # When project + also_include are set, we search the calling agent
-    # plus any explicitly included agents within the same project.
-    search_agents = [agent]
-    if project and also_include:
-        for name in also_include:
-            if name != agent:
-                search_agents.append(name)
 
     raw = await _retrieve(
         query,

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -36,8 +36,9 @@ Endpoints
 ``GET  /ui``               -> alias of ``GET /``
 ``GET  /health``           -> ``{"status": "ok", "version": <str>}``
 ``POST /ingest``           ``{"text", "agent", "project"?}`` -> ingest result
-``POST /search``           ``{"query", "agent", "limit"?, "project"?, "also_include"?}`` -> ``{"hits": [...]}``
-``GET  /search?q=&agent=&limit=&project=&also_include=a,b``  -> ``{"hits": [...]}``
+``POST /ingest/batch``     ``{"items": [{"text", "id"?, "metadata"?}], "agent", "project"?}`` -> ``{"ingested", "skipped", ...}``
+``POST /search``           ``{"query", "agent", "limit"?, "project"?, "also_include"?, "mode"?}`` -> ``{"hits": [...]}``
+``GET  /search?q=&agent=&limit=&project=&also_include=a,b&mode=bm25``  -> ``{"hits": [...]}``
 ``GET  /projects``                                         -> ``{"projects": [...]}``
 ``GET  /shelves?project=``                                 -> ``{"shelves": [...]}``
 ``GET  /pending?agent=``                                   -> ``{"pending": [...]}``
@@ -625,6 +626,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_search_post()
                 elif method == "POST" and path == "/ingest":
                     self._handle_ingest()
+                elif method == "POST" and path == "/ingest/batch":
+                    self._handle_ingest_batch()
                 elif method == "GET" and path == "/projects":
                     self._handle_list_projects()
                 elif method == "GET" and path == "/shelves":
@@ -676,6 +679,25 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             result = runner.run(service.ingest(text, agent=agent, data_dir=data_dir, **opts))
             self._send_json(200, result)
 
+        def _handle_ingest_batch(self) -> None:
+            body = self._read_json_body()
+            items = body.get("items")
+            agent = body.get("agent")
+            project = body.get("project")
+            if not isinstance(items, list):
+                raise _BadRequest("'items' (list) is required")
+            if not isinstance(agent, str) or not agent:
+                raise _BadRequest("'agent' (non-empty string) is required")
+            if project is not None and not isinstance(project, str):
+                raise _BadRequest("'project' must be a string when provided")
+            opts = {"project": project} if project else {}
+            # Per-item shape validation lives in api.ingest_batch and runs
+            # before any write; its ValueError surfaces as a 400 here.
+            result = runner.run(
+                service.ingest_batch(items, agent=agent, data_dir=data_dir, **opts)
+            )
+            self._send_json(200, result)
+
         def _handle_search_post(self) -> None:
             body = self._read_json_body()
             query = body.get("query")
@@ -683,7 +705,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             limit = body.get("limit", 5)
             project = body.get("project")
             also_include = body.get("also_include")
-            self._do_search(query, agent, limit, project, also_include)
+            mode = body.get("mode")
+            self._do_search(query, agent, limit, project, also_include, mode)
 
         def _handle_search_get(self, qs: dict) -> None:
             query = (qs.get("q") or qs.get("query") or [None])[0]
@@ -693,9 +716,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             # Comma-separated list in the query string, e.g. also_include=a,b
             ai_raw = (qs.get("also_include") or [None])[0]
             also_include = [s for s in ai_raw.split(",") if s] if ai_raw else None
-            self._do_search(query, agent, limit, project, also_include)
+            mode = (qs.get("mode") or [None])[0]
+            self._do_search(query, agent, limit, project, also_include, mode)
 
-        def _do_search(self, query, agent, limit, project=None, also_include=None) -> None:
+        def _do_search(self, query, agent, limit, project=None, also_include=None, mode=None) -> None:
             if not isinstance(query, str) or not query:
                 raise _BadRequest("'query' (non-empty string) is required")
             if not isinstance(agent, str) or not agent:
@@ -710,11 +734,15 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            if mode is not None and not isinstance(mode, str):
+                raise _BadRequest("'mode' must be a string when provided")
             opts: dict = {}
             if project:
                 opts["project"] = project
             if also_include:
                 opts["also_include"] = also_include
+            if mode:
+                opts["mode"] = mode
             hits = runner.run(
                 service.search(query, agent=agent, data_dir=data_dir, limit=limit_i, **opts)
             )
@@ -913,7 +941,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     where = "localhost only" if bound_host in {"127.0.0.1", "::1"} else "LAN-reachable (no auth)"
     print(f"taosmd HTTP API listening on http://{bound_host}:{bound_port} ({where})")
     print(f"Inspection UI (read-only): http://{bound_host}:{bound_port}/")
-    print("Endpoints: GET /health, POST /ingest, GET|POST /search, "
+    print("Endpoints: GET /health, POST /ingest, POST /ingest/batch, GET|POST /search, "
           "GET /projects, GET /shelves, "
           "GET /pending, POST /pending/resolve, "
           "POST /a2a/send, GET /a2a/messages, GET /a2a/stream, "

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -92,6 +92,18 @@ class RemoteClient:
             body["project"] = project
         return await self._run("POST", "/ingest", body)
 
+    async def ingest_batch(
+        self, items: list[dict], agent: str, *, project: str | None = None, **_opts
+    ) -> dict:
+        """POST /ingest/batch: bulk-shelve items with idempotent re-import.
+
+        Returns ``{"ingested", "skipped", "agent", "data_dir"}``.
+        """
+        body: dict = {"items": items, "agent": agent}
+        if project is not None:
+            body["project"] = project
+        return await self._run("POST", "/ingest/batch", body)
+
     async def search(
         self,
         query: str,
@@ -100,18 +112,22 @@ class RemoteClient:
         *,
         project: str | None = None,
         also_include: list[str] | None = None,
+        mode: str | None = None,
         **_opts,
     ) -> list[dict]:
         """POST /search: return ranked hits for ``query`` from the remote server.
 
         ``project`` and ``also_include`` are forwarded so project-scoped and
-        cross-agent reads work over the remote path. Returns the ``hits`` list.
+        cross-agent reads work over the remote path. ``mode="bm25"`` selects
+        the server's BM25-only path. Returns the ``hits`` list.
         """
         body: dict = {"query": query, "agent": agent, "limit": limit}
         if project is not None:
             body["project"] = project
         if also_include is not None:
             body["also_include"] = also_include
+        if mode:
+            body["mode"] = mode
         resp = await self._run("POST", "/search", body)
         return resp.get("hits", [])
 

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -97,6 +97,23 @@ async def ingest(text, *, agent: str, data_dir=None, **opts) -> dict:
     return await _api.ingest(text, agent=agent, data_dir=data_dir, **opts)
 
 
+async def ingest_batch(items, *, agent: str, data_dir=None, **opts) -> dict:
+    """Bulk-shelve memory chunks with idempotent re-import.
+
+    Thin wrapper over :func:`taosmd.api.ingest_batch`. ``items`` is a list of
+    ``{"text", "id"?, "metadata"?}`` dicts; items whose ``id`` was already
+    ingested are skipped. Returns ``{"ingested", "skipped", "agent",
+    "data_dir"}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.ingest_batch(items, agent, **opts)
+    return await _api.ingest_batch(items, agent=agent, data_dir=data_dir, **opts)
+
+
 async def search(query: str, *, agent: str, data_dir=None, limit: int = 5, **opts) -> list[dict]:
     """Search memory for passages relevant to ``query``.
 

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -42,6 +42,44 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
     return dot / (norm_a * norm_b)
 
 
+def _bm25_python_rank(query: str, texts: list[str]) -> list[tuple[int, float]]:
+    """Dependency-free Okapi BM25; best-first (index, score) over ``texts``.
+
+    Fallback for :meth:`VectorMemory.search_bm25` when bm25s is not
+    installed. Matches the bm25s defaults the fusion paths were benchmarked
+    with: k1=1.5, b=0.75, Lucene IDF, lowercase + non-word-split tokens.
+    """
+    import math
+    import re
+
+    k1, b = 1.5, 0.75
+    docs = [re.findall(r"\w+", t.lower()) for t in texts]
+    n = len(docs)
+    avgdl = (sum(len(d) for d in docs) / n) if n else 0.0
+    avgdl = avgdl or 1.0
+    df: dict[str, int] = {}
+    for d in docs:
+        for term in set(d):
+            df[term] = df.get(term, 0) + 1
+
+    q_terms = re.findall(r"\w+", query.lower())
+    scored = []
+    for i, d in enumerate(docs):
+        tf: dict[str, int] = {}
+        for term in d:
+            tf[term] = tf.get(term, 0) + 1
+        score = 0.0
+        for term in q_terms:
+            f = tf.get(term)
+            if not f:
+                continue
+            idf = math.log(1.0 + (n - df[term] + 0.5) / (df[term] + 0.5))
+            score += idf * (f * (k1 + 1)) / (f + k1 * (1 - b + b * len(d) / avgdl))
+        scored.append((i, score))
+    scored.sort(key=lambda pair: -pair[1])
+    return scored
+
+
 def pack_sign_bits(embedding: list[float]) -> str:
     """Pack an embedding into a base64 string of sign bits (1 bit/dim).
 
@@ -260,6 +298,145 @@ class VectorMemory:
         self._bm25_dirty = True  # corpus changed; invalidate BM25 cache
         return cursor.lastrowid
 
+    def _load_active_rows(self, project: str | None = None, search_agents: list[str] | None = None):
+        """Fetch active (non-superseded) rows, scoped by project/agent.
+
+        Untagged rows are kept by both filters so pre-project / standalone
+        memory is never hidden. Shared by the semantic and BM25-only paths so
+        scoping rules cannot drift between them.
+        """
+        rows = self._conn.execute(
+            "SELECT id, text, embedding, metadata_json, created_at FROM vector_memory "
+            "WHERE valid_to IS NULL"
+        ).fetchall()
+
+        if project is not None or search_agents is not None:
+            filtered = []
+            agent_set = set(search_agents) if search_agents else None
+            for row in rows:
+                try:
+                    meta = json.loads(row["metadata_json"])
+                except (json.JSONDecodeError, TypeError):
+                    meta = {}
+                # Project filter: skip rows positively tagged with a different
+                # project. Untagged (pre-project) rows are kept so existing
+                # standalone memory is never hidden.
+                row_project = meta.get("project")
+                if project is not None and row_project is not None and row_project != project:
+                    continue
+                # Agent filter: skip rows positively tagged with an out-of-scope
+                # agent. Untagged rows are kept (preserves standalone behaviour).
+                row_agent = meta.get("agent")
+                if agent_set is not None and row_agent is not None and row_agent not in agent_set:
+                    continue
+                filtered.append(row)
+            rows = filtered
+        return rows
+
+    def existing_source_ids(self, agent: str | None = None) -> set[str]:
+        """Return the user-metadata ``source_id`` values already stored.
+
+        Backs idempotent re-imports over ``POST /ingest/batch`` (#25): items
+        whose ``id`` is already present are skipped instead of duplicated.
+        Rows tagged with a different agent are excluded when ``agent`` is set;
+        untagged rows are included, matching the search-scoping rules.
+        """
+        out: set[str] = set()
+        for row in self._load_active_rows(search_agents=[agent] if agent else None):
+            try:
+                meta = json.loads(row["metadata_json"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            inner = meta.get("metadata")
+            sid = inner.get("source_id") if isinstance(inner, dict) else None
+            if sid:
+                out.add(str(sid))
+        return out
+
+    async def search_bm25(
+        self,
+        query: str,
+        limit: int = 5,
+        project: str | None = None,
+        search_agents: list[str] | None = None,
+    ) -> list[dict]:
+        """BM25-only retrieval: no query embedding, no semantic scoring.
+
+        The fast path for short-form keyword search (the #25 user-memory
+        contract: search-as-you-type, sub-300ms SLA). Uses bm25s when
+        installed (same index parameters as the bm25_rrf fusion path, cached
+        in ``_bm25_cache``); otherwise falls back to a dependency-free Okapi
+        BM25 with identical k1/b. ``similarity`` carries the sigmoid-normalised
+        BM25 score so it reads in the same 0-1 confidence range as cosine
+        hits. Rows with zero term overlap are dropped rather than padded in.
+        """
+        if not query:
+            return []
+        rows = self._load_active_rows(project=project, search_agents=search_agents)
+        if not rows:
+            return []
+
+        ids = [row["id"] for row in rows]
+        texts = [row["text"] for row in rows]
+        metas = [row["metadata_json"] for row in rows]
+        created = [row["created_at"] for row in rows]
+
+        ranked = self._bm25_rank(query, texts)
+
+        from taosmd.utils.scoring import get_bm25_params, normalize_bm25
+        midpoint, steepness = get_bm25_params(query)
+
+        out = []
+        for idx, raw in ranked:
+            if len(out) >= limit:
+                break
+            if raw <= 0.0:
+                break  # ranked is best-first; everything after has no overlap
+            try:
+                meta = json.loads(metas[idx])
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+            out.append({
+                "id": ids[idx],
+                "text": texts[idx],
+                "bm25_score": round(float(raw), 4),
+                "similarity": round(normalize_bm25(float(raw), midpoint, steepness), 4),
+                "metadata": meta,
+                "created_at": created[idx],
+            })
+        return out
+
+    def _bm25_rank(self, query: str, texts: list[str]) -> list[tuple[int, float]]:
+        """Rank ``texts`` against ``query`` by BM25; best-first (index, score).
+
+        bm25s path reuses the same cache discipline as the fusion modes:
+        keyed entry holding (retriever, texts) so any corpus or scope change
+        forces a rebuild.
+        """
+        try:
+            import bm25s
+
+            cache_key = "bm25_only"
+            cached = self._bm25_cache.get(cache_key)
+            if self._bm25_dirty or cached is None or cached[1] != texts:
+                corpus_tokens = bm25s.tokenize(texts, stopwords=None, stemmer=None)
+                retriever = bm25s.BM25(k1=1.5, b=0.75)
+                retriever.index(corpus_tokens)
+                self._bm25_cache[cache_key] = (retriever, texts)
+                self._bm25_dirty = False
+            else:
+                retriever = cached[0]
+            query_tokens = bm25s.tokenize([query], stopwords=None, stemmer=None)
+            k = len(texts)
+            indices, scores = retriever.retrieve(query_tokens, k=k)
+            return [(int(indices[0][r]), float(scores[0][r])) for r in range(k)]
+        except ImportError:
+            logger.warning(
+                "bm25s not installed; using pure-Python BM25 fallback "
+                "(pip install bm25s for the fast path)"
+            )
+            return _bm25_python_rank(query, texts)
+
     async def search(
         self,
         query: str,
@@ -315,33 +492,7 @@ class VectorMemory:
         # below (cosine, binary-quant, and the pure-Python fallback) because
         # they all consume this single row set. No behaviour change when
         # nothing has been superseded.
-        rows = self._conn.execute(
-            "SELECT id, text, embedding, metadata_json, created_at FROM vector_memory "
-            "WHERE valid_to IS NULL"
-        ).fetchall()
-
-        # Filter by project and/or agent scope when specified.
-        if project is not None or search_agents is not None:
-            filtered = []
-            agent_set = set(search_agents) if search_agents else None
-            for row in rows:
-                try:
-                    meta = json.loads(row["metadata_json"])
-                except (json.JSONDecodeError, TypeError):
-                    meta = {}
-                # Project filter: skip rows positively tagged with a different
-                # project. Untagged (pre-project) rows are kept so existing
-                # standalone memory is never hidden.
-                row_project = meta.get("project")
-                if project is not None and row_project is not None and row_project != project:
-                    continue
-                # Agent filter: skip rows positively tagged with an out-of-scope
-                # agent. Untagged rows are kept (preserves standalone behaviour).
-                row_agent = meta.get("agent")
-                if agent_set is not None and row_agent is not None and row_agent not in agent_set:
-                    continue
-                filtered.append(row)
-            rows = filtered
+        rows = self._load_active_rows(project=project, search_agents=search_agents)
 
         if not rows:
             return []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -206,3 +206,155 @@ def test_format_hit_falls_back_to_source_score():
     formatted = taosmd_api._format_hit(hit)
     assert formatted["confidence"] == 0.95
     assert formatted["source"] == "kg"
+
+
+# ---------------------------------------------------------------------------
+# ingest_batch + mode="bm25" search (#25 user-memory contract)
+# ---------------------------------------------------------------------------
+
+def _batch_items():
+    return [
+        {"text": "Reverse a list in Python with list.reverse() or slicing.",
+         "id": "hash-py-reverse",
+         "metadata": {"collection": "snippets", "title": "Python list reverse"}},
+        {"text": "The quarterly planning meeting moved to Thursday afternoon.",
+         "id": "hash-meeting",
+         "metadata": {"collection": "notes", "title": "Planning meeting"}},
+    ]
+
+
+def test_ingest_batch_ingests_and_dedups(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    first = asyncio.run(taosmd.ingest_batch(
+        _batch_items(), agent="user-memory", data_dir=str(isolated_data_dir),
+    ))
+    assert first["ingested"] == 2
+    assert first["skipped"] == 0
+
+    # Re-importing the same batch is idempotent: everything skips on id.
+    again = asyncio.run(taosmd.ingest_batch(
+        _batch_items(), agent="user-memory", data_dir=str(isolated_data_dir),
+    ))
+    assert again["ingested"] == 0
+    assert again["skipped"] == 2
+
+    # A mixed batch only ingests the novel item; in-batch repeats also skip.
+    mixed = _batch_items() + [
+        {"text": "Fresh chunk with no prior hash.", "id": "hash-fresh"},
+        {"text": "Fresh chunk with no prior hash.", "id": "hash-fresh"},
+    ]
+    third = asyncio.run(taosmd.ingest_batch(
+        mixed, agent="user-memory", data_dir=str(isolated_data_dir),
+    ))
+    assert third["ingested"] == 1
+    assert third["skipped"] == 3
+
+
+def test_ingest_batch_skips_empty_text_counts(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    result = asyncio.run(taosmd.ingest_batch(
+        [{"text": "   "}, {"text": "real content", "id": "h1"}],
+        agent="user-memory",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert result["ingested"] == 1
+    assert result["skipped"] == 1
+
+
+def test_ingest_batch_validates_before_writing(isolated_data_dir):
+    stores = _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="items"):
+        asyncio.run(taosmd.ingest_batch(
+            "not-a-list", agent="user-memory", data_dir=str(isolated_data_dir),
+        ))
+    with pytest.raises(ValueError, match=r"items\[1\]\.text"):
+        asyncio.run(taosmd.ingest_batch(
+            [{"text": "ok", "id": "h1"}, {"id": "h2"}],
+            agent="user-memory",
+            data_dir=str(isolated_data_dir),
+        ))
+    # Fail-fast validation: the valid first item must NOT have been written.
+    assert stores["vector"].existing_source_ids() == set()
+    with pytest.raises(ValueError, match="agent name is required"):
+        asyncio.run(taosmd.ingest_batch([], agent="", data_dir=str(isolated_data_dir)))
+
+
+def test_search_mode_bm25_skips_embedding(isolated_data_dir):
+    """mode="bm25" must never call embed() and must return the contract shape."""
+    stores = _setup_stores(isolated_data_dir)
+    asyncio.run(taosmd.ingest_batch(
+        _batch_items(), agent="user-memory", data_dir=str(isolated_data_dir),
+    ))
+
+    async def _explode(text: str, task: str = "search_query") -> list[float]:
+        raise AssertionError("embed() must not be called on the bm25 path")
+
+    stores["vector"].embed = _explode  # type: ignore[assignment]
+
+    hits = asyncio.run(taosmd.search(
+        "planning meeting Thursday",
+        agent="user-memory",
+        mode="bm25",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert hits, "expected a BM25 hit for overlapping keywords"
+    hit = hits[0]
+    assert set(hit.keys()) >= {"text", "source", "timestamp", "confidence", "metadata"}
+    assert "meeting" in hit["text"]
+    assert hit["source"] == "vector"
+    assert 0.0 < hit["confidence"] <= 1.0
+    # User metadata (collection/title/source_id) survives the round trip.
+    assert hit["metadata"].get("collection") == "notes"
+    assert hit["metadata"].get("source_id") == "hash-meeting"
+
+    # Zero term overlap -> no hits, not arbitrary padding.
+    misses = asyncio.run(taosmd.search(
+        "zzqx unrelated",
+        agent="user-memory",
+        mode="bm25",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert misses == []
+
+
+def test_search_mode_bm25_python_fallback(isolated_data_dir, monkeypatch):
+    """With bm25s unavailable the pure-Python BM25 must serve the same path."""
+    import sys
+
+    _setup_stores(isolated_data_dir)
+    asyncio.run(taosmd.ingest_batch(
+        _batch_items(), agent="user-memory", data_dir=str(isolated_data_dir),
+    ))
+    monkeypatch.setitem(sys.modules, "bm25s", None)  # forces ImportError
+
+    hits = asyncio.run(taosmd.search(
+        "reverse a Python list",
+        agent="user-memory",
+        mode="bm25",
+        data_dir=str(isolated_data_dir),
+    ))
+    assert hits, "pure-Python BM25 fallback returned no hits"
+    assert "reverse" in hits[0]["text"].lower()
+    assert 0.0 < hits[0]["confidence"] <= 1.0
+
+
+def test_search_rejects_unknown_mode(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="unsupported search mode"):
+        asyncio.run(taosmd.search(
+            "anything", agent="a", mode="vector9000", data_dir=str(isolated_data_dir),
+        ))
+
+
+def test_bm25_python_rank_orders_by_relevance():
+    from taosmd.vector_memory import _bm25_python_rank
+
+    texts = [
+        "the cat sat on the mat",
+        "dogs chase cats around the garden",
+        "a completely unrelated sentence about tax law",
+    ]
+    ranked = _bm25_python_rank("cat mat", texts)
+    assert ranked[0][0] == 0, "exact-term doc should rank first"
+    assert ranked[0][1] > 0.0
+    assert ranked[-1][1] == 0.0, "no-overlap doc should score zero"

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -378,3 +378,74 @@ def test_a2a_members_populated(live_server):
     status, body = _get(f"{live_server}/a2a/members?channel=chan1")
     assert status == 200
     assert set(body["members"]) == {"agent-x", "agent-y"}
+
+
+# ---------------------------------------------------------------------------
+# POST /ingest/batch + ?mode=bm25 (#25 user-memory contract)
+# ---------------------------------------------------------------------------
+
+def test_ingest_batch_roundtrip_and_idempotent_reimport(live_server):
+    items = [
+        {"text": "Reverse a list in Python with slicing.",
+         "id": "abc123", "metadata": {"collection": "snippets", "title": "Reverse"}},
+        {"text": "The planning meeting moved to Thursday.",
+         "id": "def456", "metadata": {"collection": "notes", "title": "Meeting"}},
+    ]
+    status, body = _post(
+        f"{live_server}/ingest/batch", {"agent": "user-memory", "items": items},
+    )
+    assert status == 200
+    assert body["ingested"] == 2
+    assert body["skipped"] == 0
+
+    # Re-POST of the same batch must skip everything on id (migration re-run).
+    status, body = _post(
+        f"{live_server}/ingest/batch", {"agent": "user-memory", "items": items},
+    )
+    assert status == 200
+    assert body["ingested"] == 0
+    assert body["skipped"] == 2
+
+    # BM25-only search over the migrated chunks: GET with mode=bm25.
+    status, body = _get(
+        f"{live_server}/search?q=planning+meeting+Thursday&agent=user-memory&limit=10&mode=bm25"
+    )
+    assert status == 200
+    assert body["hits"], "expected a bm25 hit for overlapping keywords"
+    hit = body["hits"][0]
+    assert "meeting" in hit["text"]
+    assert set(hit.keys()) >= {"text", "source", "timestamp", "confidence", "metadata"}
+    assert hit["metadata"].get("collection") == "notes"
+    assert hit["metadata"].get("source_id") == "def456"
+
+    # POST body form of the same search.
+    status, body = _post(
+        f"{live_server}/search",
+        {"query": "reverse python list", "agent": "user-memory", "mode": "bm25"},
+    )
+    assert status == 200
+    assert body["hits"]
+    assert "Reverse" in body["hits"][0]["text"]
+
+
+def test_ingest_batch_validation_errors(live_server):
+    status, body = _post(f"{live_server}/ingest/batch", {"agent": "a"})
+    assert status == 400
+    assert "items" in body["error"]
+
+    status, body = _post(f"{live_server}/ingest/batch", {"items": []})
+    assert status == 400
+    assert "agent" in body["error"]
+
+    status, body = _post(
+        f"{live_server}/ingest/batch",
+        {"agent": "a", "items": [{"id": "no-text"}]},
+    )
+    assert status == 400
+    assert "text" in body["error"]
+
+
+def test_search_unknown_mode_is_400(live_server):
+    status, body = _get(f"{live_server}/search?q=x&agent=a&mode=cosine9000")
+    assert status == 400
+    assert "unsupported search mode" in body["error"]


### PR DESCRIPTION
Implements the locked taOS#25 contract for user-memory unification.

## What

- **POST /ingest/batch** `{agent, items:[{text, id?, metadata?}]}` returning `{ingested, skipped}`. Item `id` (caller's stable content hash) is preserved as `source_id` metadata and dedups re-imports, including in-batch repeats, so the one-shot migration of taOS `user_memory_chunks` can be re-run safely. Per-item validation runs before any write so a 400 never leaves a half-applied batch. Exposed as `taosmd.ingest_batch()`, `service.ingest_batch()`, `RemoteClient.ingest_batch()`.
- **`mode=bm25` on GET|POST /search**: skips query embedding and recipe resolution entirely; hits come off a cached BM25 index in the unchanged contract shape. `confidence` carries the sigmoid-normalised BM25 score; zero-overlap rows are dropped. Uses `bm25s` when installed (same k1/b and cache discipline as the `bm25_rrf` fusion path), with a dependency-free Okapi BM25 fallback otherwise.
- The active-row loading + project/agent scoping in `VectorMemory.search()` is extracted to `_load_active_rows()` and shared with the new `search_bm25()` so scoping rules cannot drift between the semantic and BM25-only paths.

## Verification

- 655 tests pass locally (13 new: batch ingest + dedup + fail-fast validation, bm25 contract shape, no-embed assertion, pure-Python fallback, mode validation, HTTP roundtrips).
- Verified end-to-end against the live Pi serve: idempotent re-POST, metadata round-trip, warm `mode=bm25` at 11-12ms (full path 63ms), inside the 300ms SLA.
- Counterparty (taOS proxy layer) exercised the live endpoints with its exact migrate/search payloads and confirmed.