### PR TITLE
feat(tasks): dependency-aware task graph (ready queue + prime), archive-backed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 ## Unreleased
 
 ### Added
+- **Task graph component.** New `taosmd/tasks.py` module implements a
+  dependency-aware task graph backed by SQLite (`tasks.db` under the data
+  dir). Tasks have content-hash IDs (`t-<sha256[:12]>`) that are safe for
+  concurrent multi-agent creation without coordination. A `task_edges` table
+  expresses `blocks`, `parent`, `relates`, and `duplicates` relationships.
+  Edges are soft-removed (never deleted). A `ready_tasks` SQL view derives
+  the ready queue directly from the edge table: a task is ready when it is
+  open and has no active blocking edge whose source task is still live.
+  Every mutation is appended to the zero-loss archive before touching
+  projection tables, so `rebuild_from_archive()` can replay the full history
+  into fresh tables at any time.
+  Exposed via: 7 HTTP endpoints (`POST /tasks`, `GET /tasks`, `GET
+  /tasks/ready`, `GET /tasks/prime`, `POST /tasks/{id}`, `POST
+  /tasks/{id}/edges`, `POST /tasks/{id}/edges/remove`); `taosmd tasks
+  add|list|ready|prime|start|close|block` CLI subcommands; and 5 MCP tools
+  (`task_add`, `task_ready`, `task_prime`, `task_update`, `task_edge`).
+  The `GET /tasks/prime` endpoint (and `taosmd tasks prime` CLI) returns a
+  token-budgeted session-bootstrap briefing covering ready, in-progress,
+  blocked, and recently-closed tasks, suitable for direct injection into an
+  agent system prompt.
+  Concept credit: the dependency-graph, ready-queue, and prime ideas come
+  from beads (github.com/gastownhall/beads); this is an independent minimal
+  implementation for the taosmd substrate.
 - **Bulk ingest with idempotent re-import.** `POST /ingest/batch` (and
   `taosmd.ingest_batch()` / `RemoteClient.ingest_batch()`) shelves a list of
   `{"text", "id"?, "metadata"?}` items in one call. Each item's `id` (the

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -754,6 +754,127 @@ def _review_help() -> str:
     )
 
 
+def _fmt_task_line(t: dict) -> str:
+    """Format a single task as one line of output."""
+    extra = ""
+    if t.get("assignee"):
+        extra += f" @{t['assignee']}"
+    if t.get("priority"):
+        extra += f" p{t['priority']}"
+    status = t.get("status", "open")
+    return f"[{t['id']}] ({status}) {t['title']}{extra}"
+
+
+def _tasks_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd tasks`` subcommand group."""
+    import asyncio  # noqa: PLC0415
+
+    from . import service  # noqa: PLC0415
+
+    data_dir = args.data_dir
+
+    if args.tasks_cmd == "add":
+        task = asyncio.run(
+            service.task_create(
+                args.title,
+                body=args.body,
+                project=args.project,
+                assignee=args.assignee,
+                priority=args.priority,
+                depends_on=args.depends_on,
+                created_by=args.created_by,
+                data_dir=data_dir,
+            )
+        )
+        print(_fmt_task_line(task))
+        return 0
+
+    if args.tasks_cmd == "list":
+        tasks = asyncio.run(
+            service.task_list(
+                status=args.status,
+                project=args.project,
+                assignee=args.assignee,
+                limit=args.limit,
+                data_dir=data_dir,
+            )
+        )
+        if not tasks:
+            print("No tasks found.")
+            return 0
+        for t in tasks:
+            print(_fmt_task_line(t))
+        return 0
+
+    if args.tasks_cmd == "ready":
+        tasks = asyncio.run(
+            service.task_ready(
+                project=args.project,
+                assignee=args.assignee,
+                limit=args.limit,
+                data_dir=data_dir,
+            )
+        )
+        if not tasks:
+            print("No ready tasks.")
+            return 0
+        for t in tasks:
+            print(_fmt_task_line(t))
+        return 0
+
+    if args.tasks_cmd == "prime":
+        result = asyncio.run(
+            service.task_prime(
+                project=args.project,
+                assignee=args.assignee,
+                data_dir=data_dir,
+            )
+        )
+        print(result["text"])
+        return 0
+
+    if args.tasks_cmd == "start":
+        opts: dict = {"status": "in_progress"}
+        if getattr(args, "assignee", None):
+            opts["assignee"] = args.assignee
+        try:
+            task = asyncio.run(
+                service.task_update(args.task_id, data_dir=data_dir, **opts)
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(_fmt_task_line(task))
+        return 0
+
+    if args.tasks_cmd == "close":
+        try:
+            task = asyncio.run(
+                service.task_update(args.task_id, status="closed", data_dir=data_dir)
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(_fmt_task_line(task))
+        return 0
+
+    if args.tasks_cmd == "block":
+        try:
+            edge = asyncio.run(
+                service.task_add_edge(
+                    args.blocker_id, args.task_id, "blocks", "cli",
+                    data_dir=data_dir,
+                )
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(f"edge: {edge['from_id']} --[blocks]--> {edge['to_id']}")
+        return 0
+
+    return 1
+
+
 def _projects_cmd(args: argparse.Namespace) -> int:
     """Handle ``taosmd projects`` and ``taosmd shelves``: project-scoped discovery."""
     import asyncio  # noqa: PLC0415
@@ -1172,6 +1293,60 @@ def main(argv: list[str] | None = None) -> int:
         help="Project id (from `taosmd projects` or taosmd.get_project_id())",
     )
 
+    # ----- tasks subcommand group ---------------------------------------
+    tasks_p = sub.add_parser(
+        "tasks",
+        help="Dependency-aware task graph: add, list, ready queue, prime briefing",
+    )
+    tasks_sub = tasks_p.add_subparsers(dest="tasks_cmd", required=True)
+
+    # tasks add
+    t_add_p = tasks_sub.add_parser("add", help="Create a new task")
+    t_add_p.add_argument("--title", required=True, help="Task title")
+    t_add_p.add_argument("--body", default=None, help="Task description / body")
+    t_add_p.add_argument("--project", default=None, help="Project id")
+    t_add_p.add_argument("--assignee", default=None, help="Agent handle to assign")
+    t_add_p.add_argument("--priority", type=int, default=0, help="Priority (higher = more urgent, default 0)")
+    t_add_p.add_argument(
+        "--depends-on", dest="depends_on", action="append", default=None,
+        metavar="TASK_ID",
+        help="Task IDs that must close before this task is ready. Repeat for multiple.",
+    )
+    t_add_p.add_argument("--by", dest="created_by", default="cli", help="Creator handle (default: cli)")
+
+    # tasks list
+    t_list_p = tasks_sub.add_parser("list", help="List tasks with optional filters")
+    t_list_p.add_argument("--status", default=None, help="Filter by status (open|in_progress|blocked|closed|superseded)")
+    t_list_p.add_argument("--project", default=None, help="Filter by project id")
+    t_list_p.add_argument("--assignee", default=None, help="Filter by assignee")
+    t_list_p.add_argument("--limit", type=int, default=50, help="Max results (default 50)")
+
+    # tasks ready
+    t_ready_p = tasks_sub.add_parser("ready", help="Show tasks that are ready to run (no active blockers)")
+    t_ready_p.add_argument("--project", default=None, help="Filter by project id")
+    t_ready_p.add_argument("--assignee", default=None, help="Filter by assignee")
+    t_ready_p.add_argument("--limit", type=int, default=20, help="Max results (default 20)")
+
+    # tasks prime
+    t_prime_p = tasks_sub.add_parser("prime", help="Print the session-bootstrap briefing")
+    t_prime_p.add_argument("--project", default=None, help="Filter by project id")
+    t_prime_p.add_argument("--assignee", default=None, help="Filter by assignee")
+
+    # tasks start (update status to in_progress)
+    t_start_p = tasks_sub.add_parser("start", help="Mark a task as in progress")
+    t_start_p.add_argument("task_id", help="Task ID")
+    t_start_p.add_argument("--assignee", default=None, help="Assign to this agent handle")
+
+    # tasks close (update status to closed)
+    t_close_p = tasks_sub.add_parser("close", help="Mark a task as closed")
+    t_close_p.add_argument("task_id", help="Task ID")
+
+    # tasks block (add a blocks edge: blocker -> blocked)
+    t_block_p = tasks_sub.add_parser("block", help="Mark one task as blocked by another")
+    t_block_p.add_argument("task_id", help="The task to mark as blocked")
+    t_block_p.add_argument("--by", dest="blocker_id", required=True, metavar="BLOCKER_ID",
+                            help="The task that is blocking it")
+
     # ----- mcp subcommand (MCP server over stdio) -----------------------
     mcp_p = sub.add_parser(
         "mcp",
@@ -1218,6 +1393,9 @@ def main(argv: list[str] | None = None) -> int:
         return http_server.serve(
             host=args.host, port=args.port, data_dir=args.serve_data_dir,
         )
+
+    if args.cmd == "tasks":
+        return _tasks_cmd(args)
 
     if args.cmd == "mcp":
         from . import mcp_server  # noqa: PLC0415

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -48,6 +48,13 @@ Endpoints
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream)
 ``GET  /a2a/channels``                                     -> ``{"channels": [...]}``
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
+``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
+``GET  /tasks``            ``?status=&project=&assignee=&limit=``  -> ``{"tasks": [...]}``
+``GET  /tasks/ready``      ``?project=&assignee=&limit=``  -> ``{"tasks": [...]}``
+``GET  /tasks/prime``      ``?project=&assignee=``         -> ``{"text": ..., "tasks": [...]}``
+``POST /tasks/{id}``       ``{"status"?, "assignee"?, "priority"?, "body"?}`` -> updated task object
+``POST /tasks/{id}/edges`` ``{"to_id", "type", "created_by"}``     -> edge record
+``POST /tasks/{id}/edges/remove`` ``{"to_id", "type"}``   -> edge record with removed_ts
 
 Inspection UI
 -------------
@@ -647,6 +654,36 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 elif method == "GET" and path == "/a2a/stream":
                     self._handle_a2a_stream(query)
                     return  # SSE response already sent; skip _send_json error path
+                # Task graph endpoints — prefix matching for /tasks/{id} paths
+                elif method == "POST" and path == "/tasks":
+                    self._handle_task_create()
+                elif method == "GET" and path == "/tasks":
+                    self._handle_task_list(query)
+                elif method == "GET" and path == "/tasks/ready":
+                    self._handle_task_ready(query)
+                elif method == "GET" and path == "/tasks/prime":
+                    self._handle_task_prime(query)
+                elif method == "POST" and path.startswith("/tasks/"):
+                    # /tasks/{id}/edges/remove  or  /tasks/{id}/edges  or  /tasks/{id}
+                    rest = path[len("/tasks/"):]
+                    if rest.endswith("/edges/remove"):
+                        task_id = rest[: -len("/edges/remove")]
+                        if not task_id:
+                            self._send_json(404, {"error": "task id required"})
+                        else:
+                            self._handle_task_remove_edge(task_id)
+                    elif rest.endswith("/edges"):
+                        task_id = rest[: -len("/edges")]
+                        if not task_id:
+                            self._send_json(404, {"error": "task id required"})
+                        else:
+                            self._handle_task_add_edge(task_id)
+                    else:
+                        task_id = rest
+                        if not task_id:
+                            self._send_json(404, {"error": "task id required"})
+                        else:
+                            self._handle_task_update(task_id)
                 elif method == "GET" and _serve_dashboard and self._try_serve_static(parts.path):
                     return  # static asset served
                 elif method == "GET" and _serve_dashboard:
@@ -906,6 +943,156 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 # Client disconnected; exit the thread cleanly.
                 return
 
+        # ----- task graph handlers ----------------------------------------
+
+        def _handle_task_create(self) -> None:
+            body = self._read_json_body()
+            title = body.get("title")
+            created_by = body.get("created_by")
+            if not isinstance(title, str) or not title:
+                raise _BadRequest("'title' (non-empty string) is required")
+            if not isinstance(created_by, str) or not created_by:
+                raise _BadRequest("'created_by' (non-empty string) is required")
+            task_body = body.get("body")
+            project = body.get("project")
+            assignee = body.get("assignee")
+            priority = body.get("priority", 0)
+            depends_on = body.get("depends_on")
+            try:
+                priority = int(priority)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'priority' must be an integer") from exc
+            if depends_on is not None and not isinstance(depends_on, list):
+                raise _BadRequest("'depends_on' must be a list of task IDs when provided")
+            result = runner.run(
+                service.task_create(
+                    title,
+                    body=task_body,
+                    project=project,
+                    assignee=assignee,
+                    priority=priority,
+                    depends_on=depends_on,
+                    created_by=created_by,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, result)
+
+        def _handle_task_list(self, qs: dict) -> None:
+            status = (qs.get("status") or [None])[0]
+            project = (qs.get("project") or [None])[0]
+            assignee = (qs.get("assignee") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            tasks = runner.run(
+                service.task_list(
+                    status=status,
+                    project=project,
+                    assignee=assignee,
+                    limit=limit_i,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, {"tasks": tasks})
+
+        def _handle_task_ready(self, qs: dict) -> None:
+            project = (qs.get("project") or [None])[0]
+            assignee = (qs.get("assignee") or [None])[0]
+            limit_raw = (qs.get("limit") or [20])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            tasks = runner.run(
+                service.task_ready(
+                    project=project,
+                    assignee=assignee,
+                    limit=limit_i,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, {"tasks": tasks})
+
+        def _handle_task_prime(self, qs: dict) -> None:
+            project = (qs.get("project") or [None])[0]
+            assignee = (qs.get("assignee") or [None])[0]
+            result = runner.run(
+                service.task_prime(
+                    project=project,
+                    assignee=assignee,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, result)
+
+        def _handle_task_update(self, task_id: str) -> None:
+            body = self._read_json_body()
+            status = body.get("status")
+            assignee = body.get("assignee")
+            priority = body.get("priority")
+            task_body = body.get("body")
+            if priority is not None:
+                try:
+                    priority = int(priority)
+                except (TypeError, ValueError) as exc:
+                    raise _BadRequest("'priority' must be an integer") from exc
+            try:
+                result = runner.run(
+                    service.task_update(
+                        task_id,
+                        status=status,
+                        assignee=assignee,
+                        priority=priority,
+                        body=task_body,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, result)
+
+        def _handle_task_add_edge(self, from_id: str) -> None:
+            body = self._read_json_body()
+            to_id = body.get("to_id")
+            edge_type = body.get("type")
+            created_by = body.get("created_by", "unknown")
+            if not isinstance(to_id, str) or not to_id:
+                raise _BadRequest("'to_id' (non-empty string) is required")
+            if not isinstance(edge_type, str) or not edge_type:
+                raise _BadRequest("'type' (non-empty string) is required")
+            try:
+                result = runner.run(
+                    service.task_add_edge(
+                        from_id, to_id, edge_type, created_by,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, result)
+
+        def _handle_task_remove_edge(self, from_id: str) -> None:
+            body = self._read_json_body()
+            to_id = body.get("to_id")
+            edge_type = body.get("type")
+            if not isinstance(to_id, str) or not to_id:
+                raise _BadRequest("'to_id' (non-empty string) is required")
+            if not isinstance(edge_type, str) or not edge_type:
+                raise _BadRequest("'type' (non-empty string) is required")
+            try:
+                result = runner.run(
+                    service.task_remove_edge(
+                        from_id, to_id, edge_type,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, result)
+
     return TaosmdHandler
 
 
@@ -953,7 +1140,9 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "GET /projects, GET /shelves, "
           "GET /pending, POST /pending/resolve, "
           "POST /a2a/send, GET /a2a/messages, GET /a2a/stream, "
-          "GET /a2a/channels, GET /a2a/members")
+          "GET /a2a/channels, GET /a2a/members, "
+          "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
+          "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/taosmd/mcp_server.py
+++ b/taosmd/mcp_server.py
@@ -223,6 +223,131 @@ def build_server(data_dir=None, *, runner: _ServiceLoop | None = None):
             )
         )
 
+    # ---- Task graph tools -------------------------------------------------------
+
+    @mcp.tool()
+    async def task_add(
+        title: str,
+        created_by: str,
+        body: str | None = None,
+        project: str | None = None,
+        assignee: str | None = None,
+        priority: int = 0,
+        depends_on: list[str] | None = None,
+    ) -> dict:
+        """Create a new task in the task graph.
+
+        ``title`` and ``created_by`` are required. ``depends_on`` is an
+        optional list of task IDs that must be closed before this task is
+        ready (creates ``blocks`` edges automatically). Returns the created
+        task object including its content-hash ``id``.
+        """
+        return await _dispatch(
+            service.task_create(
+                title,
+                body=body,
+                project=project,
+                assignee=assignee,
+                priority=priority,
+                depends_on=depends_on,
+                created_by=created_by,
+                data_dir=data_dir,
+            )
+        )
+
+    @mcp.tool()
+    async def task_ready(
+        project: str | None = None,
+        assignee: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """Return the ready-queue: tasks that are open and have no active blockers.
+
+        Ordered by priority descending, then creation time ascending (oldest
+        first). Use this as the canonical "what should I work on next?" query.
+        """
+        return await _dispatch(
+            service.task_ready(
+                project=project,
+                assignee=assignee,
+                limit=limit,
+                data_dir=data_dir,
+            )
+        )
+
+    @mcp.tool()
+    async def task_prime(
+        project: str | None = None,
+        assignee: str | None = None,
+    ) -> dict:
+        """Fetch the session-bootstrap briefing for this task graph.
+
+        Returns ``{"text": str, "tasks": [...]}``. The ``text`` is a
+        token-budgeted plain-text summary covering ready tasks, in-progress
+        tasks, blocked tasks, and recently closed tasks (last 24h). Suitable
+        for direct injection into a session system prompt. ``tasks`` contains
+        the raw task objects referenced in the briefing.
+        """
+        return await _dispatch(
+            service.task_prime(
+                project=project,
+                assignee=assignee,
+                data_dir=data_dir,
+            )
+        )
+
+    @mcp.tool()
+    async def task_update(
+        task_id: str,
+        status: str | None = None,
+        assignee: str | None = None,
+        priority: int | None = None,
+        body: str | None = None,
+    ) -> dict:
+        """Update a task's status, assignee, priority, or body.
+
+        ``status`` must be one of ``open``, ``in_progress``, ``blocked``,
+        ``closed``, ``superseded``. Closing a task sets ``closed_ts``
+        automatically. Returns the updated task object.
+        """
+        return await _dispatch(
+            service.task_update(
+                task_id,
+                status=status,
+                assignee=assignee,
+                priority=priority,
+                body=body,
+                data_dir=data_dir,
+            )
+        )
+
+    @mcp.tool()
+    async def task_edge(
+        from_id: str,
+        to_id: str,
+        edge_type: str,
+        created_by: str,
+        remove: bool = False,
+    ) -> dict:
+        """Add or remove an edge between two tasks.
+
+        ``edge_type`` must be one of ``blocks``, ``parent``, ``relates``,
+        ``duplicates``. When ``remove=True``, soft-removes an existing active
+        edge by setting ``removed_ts`` (never deletes). Removing a ``blocks``
+        edge restores readiness of the downstream task.
+        """
+        if remove:
+            return await _dispatch(
+                service.task_remove_edge(
+                    from_id, to_id, edge_type, data_dir=data_dir
+                )
+            )
+        return await _dispatch(
+            service.task_add_edge(
+                from_id, to_id, edge_type, created_by, data_dir=data_dir
+            )
+        )
+
     return mcp
 
 

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -231,4 +231,130 @@ class RemoteClient:
         return {"agent": agent, "reachable": reachable, "server_version": health.get("version")}
 
 
+    async def task_create(
+        self,
+        title: str,
+        *,
+        body: str | None = None,
+        project: str | None = None,
+        assignee: str | None = None,
+        priority: int = 0,
+        depends_on: list[str] | None = None,
+        created_by: str,
+        **_opts,
+    ) -> dict:
+        """POST /tasks: create a task on the remote server."""
+        payload: dict = {"title": title, "created_by": created_by, "priority": priority}
+        if body is not None:
+            payload["body"] = body
+        if project is not None:
+            payload["project"] = project
+        if assignee is not None:
+            payload["assignee"] = assignee
+        if depends_on is not None:
+            payload["depends_on"] = depends_on
+        return await self._run("POST", "/tasks", payload)
+
+    async def task_list(
+        self,
+        *,
+        status: str | None = None,
+        project: str | None = None,
+        assignee: str | None = None,
+        limit: int = 50,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks: list tasks from the remote server."""
+        params: dict = {"limit": limit}
+        if status is not None:
+            params["status"] = status
+        if project is not None:
+            params["project"] = project
+        if assignee is not None:
+            params["assignee"] = assignee
+        resp = await self._run("GET", "/tasks", params=params)
+        return resp.get("tasks", [])
+
+    async def task_ready(
+        self,
+        *,
+        project: str | None = None,
+        assignee: str | None = None,
+        limit: int = 20,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks/ready: return the ready queue from the remote server."""
+        params: dict = {"limit": limit}
+        if project is not None:
+            params["project"] = project
+        if assignee is not None:
+            params["assignee"] = assignee
+        resp = await self._run("GET", "/tasks/ready", params=params)
+        return resp.get("tasks", [])
+
+    async def task_prime(
+        self,
+        *,
+        project: str | None = None,
+        assignee: str | None = None,
+        **_opts,
+    ) -> dict:
+        """GET /tasks/prime: fetch the prime briefing from the remote server."""
+        params: dict = {}
+        if project is not None:
+            params["project"] = project
+        if assignee is not None:
+            params["assignee"] = assignee
+        return await self._run("GET", "/tasks/prime", params=params or None)
+
+    async def task_update(
+        self,
+        task_id: str,
+        *,
+        status: str | None = None,
+        assignee: str | None = None,
+        priority: int | None = None,
+        body: str | None = None,
+        **_opts,
+    ) -> dict:
+        """POST /tasks/{id}: update a task on the remote server."""
+        payload: dict = {}
+        if status is not None:
+            payload["status"] = status
+        if assignee is not None:
+            payload["assignee"] = assignee
+        if priority is not None:
+            payload["priority"] = priority
+        if body is not None:
+            payload["body"] = body
+        return await self._run("POST", f"/tasks/{task_id}", payload)
+
+    async def task_add_edge(
+        self,
+        from_id: str,
+        to_id: str,
+        edge_type: str,
+        created_by: str,
+        **_opts,
+    ) -> dict:
+        """POST /tasks/{id}/edges: add an edge on the remote server."""
+        return await self._run(
+            "POST", f"/tasks/{from_id}/edges",
+            {"to_id": to_id, "type": edge_type, "created_by": created_by},
+        )
+
+    async def task_remove_edge(
+        self,
+        from_id: str,
+        to_id: str,
+        edge_type: str,
+        **_opts,
+    ) -> dict:
+        """POST /tasks/{id}/edges/remove: soft-remove an edge on the remote server."""
+        return await self._run(
+            "POST", f"/tasks/{from_id}/edges/remove",
+            {"to_id": to_id, "type": edge_type},
+        )
+
+
 __all__ = ["RemoteClient"]

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -449,5 +449,168 @@ async def a2a_members(*, channel: str, data_dir=None) -> list[str]:
     return sorted(members)
 
 
+async def task_create(
+    title: str,
+    *,
+    body: str | None = None,
+    project: str | None = None,
+    assignee: str | None = None,
+    priority: int = 0,
+    depends_on: list[str] | None = None,
+    created_by: str,
+    data_dir=None,
+) -> dict:
+    """Create a task and return the task object.
+
+    Thin wrapper over :func:`taosmd.tasks.create_task`. When a remote server
+    URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_create(
+            title, body=body, project=project, assignee=assignee,
+            priority=priority, depends_on=depends_on, created_by=created_by,
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.create_task(
+        title, body=body, project=project, assignee=assignee,
+        priority=priority, depends_on=depends_on, created_by=created_by,
+        data_dir=data_dir,
+    )
+
+
+async def task_list(
+    *,
+    status: str | None = None,
+    project: str | None = None,
+    assignee: str | None = None,
+    limit: int = 50,
+    data_dir=None,
+) -> list[dict]:
+    """Return tasks matching the given filters.
+
+    Thin wrapper over :func:`taosmd.tasks.list_tasks`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_list(
+            status=status, project=project, assignee=assignee, limit=limit
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.list_tasks(
+        status=status, project=project, assignee=assignee,
+        limit=limit, data_dir=data_dir,
+    )
+
+
+async def task_ready(
+    *,
+    project: str | None = None,
+    assignee: str | None = None,
+    limit: int = 20,
+    data_dir=None,
+) -> list[dict]:
+    """Return the ready-queue ordered list.
+
+    Thin wrapper over :func:`taosmd.tasks.ready_tasks`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_ready(
+            project=project, assignee=assignee, limit=limit
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.ready_tasks(
+        project=project, assignee=assignee, limit=limit, data_dir=data_dir,
+    )
+
+
+async def task_prime(
+    *,
+    project: str | None = None,
+    assignee: str | None = None,
+    data_dir=None,
+) -> dict:
+    """Return the prime session-bootstrap briefing.
+
+    Thin wrapper over :func:`taosmd.tasks.prime`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_prime(project=project, assignee=assignee)
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.prime(project=project, assignee=assignee, data_dir=data_dir)
+
+
+async def task_update(
+    task_id: str,
+    *,
+    status: str | None = None,
+    assignee: str | None = None,
+    priority: int | None = None,
+    body: str | None = None,
+    data_dir=None,
+) -> dict:
+    """Update a task and return the updated object.
+
+    Thin wrapper over :func:`taosmd.tasks.update_task`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_update(
+            task_id, status=status, assignee=assignee,
+            priority=priority, body=body,
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.update_task(
+        task_id, status=status, assignee=assignee,
+        priority=priority, body=body, data_dir=data_dir,
+    )
+
+
+async def task_add_edge(
+    from_id: str,
+    to_id: str,
+    edge_type: str,
+    created_by: str,
+    *,
+    data_dir=None,
+) -> dict:
+    """Add an edge between two tasks.
+
+    Thin wrapper over :func:`taosmd.tasks.add_edge`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_add_edge(from_id, to_id, edge_type, created_by)
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.add_edge(
+        from_id, to_id, edge_type, created_by, data_dir=data_dir
+    )
+
+
+async def task_remove_edge(
+    from_id: str,
+    to_id: str,
+    edge_type: str,
+    *,
+    data_dir=None,
+) -> dict:
+    """Soft-remove an edge (sets removed_ts, never deletes).
+
+    Thin wrapper over :func:`taosmd.tasks.remove_edge`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_remove_edge(from_id, to_id, edge_type)
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.remove_edge(
+        from_id, to_id, edge_type, data_dir=data_dir
+    )
+
+
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
-           "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members"]
+           "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
+           "task_create", "task_list", "task_ready", "task_prime",
+           "task_update", "task_add_edge", "task_remove_edge"]

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -1,0 +1,789 @@
+"""Dependency-aware task graph for taOSmd (archive-backed projection).
+
+Every mutation is appended to the zero-loss archive before touching the
+projection tables, so the full audit trail is free and the tables can be
+rebuilt from the archive at any time via :func:`rebuild_from_archive`.
+
+Concept credit: the dependency-graph, ready-queue, and prime ideas come from
+beads (github.com/gastownhall/beads); this is an independent minimal
+implementation for the taosmd substrate.
+
+Schema lives in ``tasks.db`` under the data dir, following the same pattern
+used by ``knowledge-graph.db``, ``vector-memory.db``, etc.
+
+Public API
+----------
+create_task(title, *, body, project, assignee, priority, depends_on,
+            created_by, data_dir) -> dict
+list_tasks(*, status, project, assignee, limit, data_dir) -> list[dict]
+ready_tasks(*, project, assignee, limit, data_dir) -> list[dict]
+prime(*, project, assignee, data_dir) -> {"text": str, "tasks": list[dict]}
+update_task(task_id, *, status, assignee, priority, body, data_dir) -> dict
+add_edge(from_id, to_id, edge_type, created_by, data_dir) -> dict
+remove_edge(from_id, to_id, edge_type, data_dir) -> dict
+rebuild_from_archive(data_dir) -> dict
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from . import _db
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_STATUSES = {"open", "in_progress", "blocked", "closed", "superseded"}
+CLOSED_STATUSES = {"closed", "superseded"}
+VALID_EDGE_TYPES = {"blocks", "parent", "relates", "duplicates"}
+
+# Approximate token cap for prime briefing (~6000 chars = ~1500 tokens)
+PRIME_CHAR_CAP = 6000
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id          TEXT PRIMARY KEY,
+    title       TEXT NOT NULL,
+    body        TEXT,
+    status      TEXT NOT NULL DEFAULT 'open'
+                    CHECK(status IN ('open','in_progress','blocked','closed','superseded')),
+    assignee    TEXT,
+    project     TEXT,
+    priority    INTEGER NOT NULL DEFAULT 0,
+    created_ts  REAL NOT NULL,
+    updated_ts  REAL NOT NULL,
+    closed_ts   REAL,
+    created_by  TEXT NOT NULL,
+    metadata    TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS task_edges (
+    from_id     TEXT NOT NULL REFERENCES tasks(id),
+    to_id       TEXT NOT NULL REFERENCES tasks(id),
+    type        TEXT NOT NULL CHECK(type IN ('blocks','parent','relates','duplicates')),
+    created_ts  REAL NOT NULL,
+    created_by  TEXT NOT NULL,
+    removed_ts  REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status   ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_project  ON tasks(project);
+CREATE INDEX IF NOT EXISTS idx_tasks_assignee ON tasks(assignee);
+CREATE INDEX IF NOT EXISTS idx_edges_to_id    ON task_edges(to_id);
+CREATE INDEX IF NOT EXISTS idx_edges_from_id  ON task_edges(from_id);
+
+CREATE VIEW IF NOT EXISTS ready_tasks AS
+SELECT t.*
+FROM tasks t
+WHERE t.status = 'open'
+  AND NOT EXISTS (
+    SELECT 1 FROM task_edges e
+    JOIN tasks blocker ON blocker.id = e.from_id
+    WHERE e.to_id = t.id
+      AND e.type = 'blocks'
+      AND e.removed_ts IS NULL
+      AND blocker.status NOT IN ('closed', 'superseded')
+  )
+ORDER BY t.priority DESC, t.created_ts ASC;
+"""
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+_db_cache: dict[str, sqlite3.Connection] = {}
+
+
+def _get_db(data_dir: str | None) -> sqlite3.Connection:
+    """Open (or return cached) the tasks SQLite connection for ``data_dir``."""
+    from . import api as _api  # noqa: PLC0415
+
+    resolved = _api._resolve_data_dir(data_dir)
+    conn = _db_cache.get(resolved)
+    if conn is not None:
+        return conn
+    path = Path(resolved)
+    path.mkdir(parents=True, exist_ok=True)
+    db_path = str(path / "tasks.db")
+    conn = _db.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    _db_cache[resolved] = conn
+    return conn
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    d = dict(row)
+    # Parse metadata JSON
+    try:
+        d["metadata"] = json.loads(d.get("metadata") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        d["metadata"] = {}
+    return d
+
+
+# ---------------------------------------------------------------------------
+# ID generation
+# ---------------------------------------------------------------------------
+
+def _make_task_id(title: str, project: str | None, created_ts: float) -> str:
+    """Deterministic content-hash task id."""
+    raw = f"{title}|{project or ''}|{created_ts}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:12]
+    return f"t-{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Archive helper
+# ---------------------------------------------------------------------------
+
+async def _archive_task_event(
+    action: str,
+    payload: dict,
+    *,
+    created_by: str,
+    project: str | None,
+    data_dir: str | None,
+) -> None:
+    """Append a task event to the archive BEFORE touching projection tables."""
+    from . import api as _api  # noqa: PLC0415
+
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    await archive.record(
+        "task",
+        {"action": action, **payload},
+        agent_name=created_by,
+        project=project,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core mutations
+# ---------------------------------------------------------------------------
+
+async def create_task(
+    title: str,
+    *,
+    body: str | None = None,
+    project: str | None = None,
+    assignee: str | None = None,
+    priority: int = 0,
+    depends_on: list[str] | None = None,
+    created_by: str,
+    data_dir: str | None = None,
+) -> dict:
+    """Create a new task and return the task object.
+
+    ``depends_on`` is an optional list of existing task IDs that must be
+    completed before this task is ready; each creates a ``blocks`` edge
+    pointing at the new task (blocker -> new task).
+
+    Raises :class:`ValueError` if ``created_by`` is empty or if any ID in
+    ``depends_on`` does not exist.
+    """
+    if not created_by:
+        raise ValueError("created_by is required")
+    if not title:
+        raise ValueError("title is required")
+
+    now = time.time()
+    task_id = _make_task_id(title, project, now)
+
+    row: dict[str, Any] = {
+        "id": task_id,
+        "title": title,
+        "body": body,
+        "status": "open",
+        "assignee": assignee,
+        "project": project,
+        "priority": int(priority),
+        "created_ts": now,
+        "updated_ts": now,
+        "closed_ts": None,
+        "created_by": created_by,
+        "metadata": "{}",
+    }
+
+    # Archive BEFORE touching projection
+    await _archive_task_event(
+        "created",
+        {k: v for k, v in row.items()},
+        created_by=created_by,
+        project=project,
+        data_dir=data_dir,
+    )
+
+    conn = _get_db(data_dir)
+    conn.execute(
+        """INSERT INTO tasks
+           (id, title, body, status, assignee, project, priority,
+            created_ts, updated_ts, closed_ts, created_by, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            task_id, title, body, "open", assignee, project, int(priority),
+            now, now, None, created_by, "{}",
+        ),
+    )
+    conn.commit()
+
+    # Create blocking edges for depends_on
+    if depends_on:
+        for blocker_id in depends_on:
+            # Verify blocker exists
+            blocker = conn.execute(
+                "SELECT id FROM tasks WHERE id = ?", (blocker_id,)
+            ).fetchone()
+            if blocker is None:
+                raise ValueError(f"depends_on task not found: {blocker_id!r}")
+            await add_edge(blocker_id, task_id, "blocks", created_by, data_dir=data_dir)
+
+    result = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    return _row_to_dict(result)
+
+
+async def list_tasks(
+    *,
+    status: str | None = None,
+    project: str | None = None,
+    assignee: str | None = None,
+    limit: int = 50,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return tasks matching the given filters, newest first."""
+    if status is not None and status not in VALID_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+
+    conn = _get_db(data_dir)
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if status is not None:
+        conditions.append("status = ?")
+        params.append(status)
+    if project is not None:
+        conditions.append("project = ?")
+        params.append(project)
+    if assignee is not None:
+        conditions.append("assignee = ?")
+        params.append(assignee)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+    rows = conn.execute(
+        f"SELECT * FROM tasks {where} ORDER BY created_ts DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+async def ready_tasks(
+    *,
+    project: str | None = None,
+    assignee: str | None = None,
+    limit: int = 20,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return tasks from the ready_tasks view (open, no active blockers)."""
+    conn = _get_db(data_dir)
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if project is not None:
+        conditions.append("project = ?")
+        params.append(project)
+    if assignee is not None:
+        conditions.append("assignee = ?")
+        params.append(assignee)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+    rows = conn.execute(
+        f"SELECT * FROM ready_tasks {where} LIMIT ?",
+        params,
+    ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+async def prime(
+    *,
+    project: str | None = None,
+    assignee: str | None = None,
+    data_dir: str | None = None,
+) -> dict:
+    """Return a token-budgeted session-bootstrap briefing.
+
+    Returns ``{"text": str, "tasks": list[dict]}``. The text covers four
+    sections in priority order: ready, in-progress, blocked, recently-closed
+    (last 24 hours). The combined text is capped at ~6000 characters (~1500
+    tokens) by truncating lower-priority sections first (recently-closed,
+    then blocked, then in-progress) before trimming ready tasks.
+    """
+    conn = _get_db(data_dir)
+    common_conditions: list[str] = []
+    common_params: list[Any] = []
+    if project is not None:
+        common_conditions.append("project = ?")
+        common_params.append(project)
+    if assignee is not None:
+        common_conditions.append("assignee = ?")
+        common_params.append(assignee)
+
+    def _where(extra: list[str] | None = None) -> str:
+        conds = list(common_conditions)
+        if extra:
+            conds.extend(extra)
+        return f"WHERE {' AND '.join(conds)}" if conds else ""
+
+    # Fetch each section (generous limits; we will truncate in text)
+    ready_rows = conn.execute(
+        f"SELECT * FROM ready_tasks {_where()} LIMIT 50",
+        common_params,
+    ).fetchall()
+
+    ip_rows = conn.execute(
+        f"SELECT * FROM tasks {_where(['status = ?'])} ORDER BY priority DESC, created_ts ASC LIMIT 20",
+        common_params + ["in_progress"],
+    ).fetchall()
+
+    # Blocked: status 'open' but has active blocker
+    blocked_rows = conn.execute(
+        f"""SELECT t.* FROM tasks t
+            {_where(['t.status = ?',
+                     'EXISTS (SELECT 1 FROM task_edges e '
+                     'JOIN tasks b ON b.id = e.from_id '
+                     'WHERE e.to_id = t.id AND e.type = ? '
+                     'AND e.removed_ts IS NULL '
+                     "AND b.status NOT IN (?,?))"
+                    ])}
+            ORDER BY t.priority DESC, t.created_ts ASC LIMIT 20""",
+        common_params + ["open", "blocks", "closed", "superseded"],
+    ).fetchall()
+
+    since_24h = time.time() - 86400
+    closed_rows = conn.execute(
+        f"SELECT * FROM tasks {_where(['status IN (?,?)', 'closed_ts >= ?'])} "
+        "ORDER BY closed_ts DESC LIMIT 20",
+        common_params + ["closed", "superseded", since_24h],
+    ).fetchall()
+
+    # Fetch blocker titles for blocked tasks
+    blocker_map: dict[str, str] = {}
+    for r in blocked_rows:
+        tid = r["id"]
+        blocker = conn.execute(
+            """SELECT t.title FROM task_edges e
+               JOIN tasks t ON t.id = e.from_id
+               WHERE e.to_id = ? AND e.type = 'blocks'
+                 AND e.removed_ts IS NULL
+                 AND t.status NOT IN ('closed','superseded')
+               LIMIT 1""",
+            (tid,),
+        ).fetchone()
+        if blocker:
+            blocker_map[tid] = blocker["title"]
+
+    # Build text sections
+    def _task_line(t: sqlite3.Row) -> str:
+        extra = ""
+        if t["assignee"]:
+            extra += f" @{t['assignee']}"
+        if t["priority"]:
+            extra += f" p{t['priority']}"
+        return f"  [{t['id']}] {t['title']}{extra}"
+
+    sections: list[tuple[str, list[str]]] = []
+
+    if ready_rows:
+        lines = [_task_line(t) for t in ready_rows]
+        sections.append(("READY", lines))
+
+    if ip_rows:
+        lines = [_task_line(t) for t in ip_rows]
+        sections.append(("IN PROGRESS", lines))
+
+    if blocked_rows:
+        lines = []
+        for t in blocked_rows:
+            blocker_title = blocker_map.get(t["id"], "unknown")
+            lines.append(f"{_task_line(t)}  (blocked by: {blocker_title})")
+        sections.append(("BLOCKED", lines))
+
+    if closed_rows:
+        lines = [_task_line(t) for t in closed_rows]
+        sections.append(("RECENTLY CLOSED (24h)", lines))
+
+    # Assemble text with cap — truncate from the end (lowest priority sections)
+    all_tasks_by_section: list[tuple[str, list[sqlite3.Row]]] = [
+        ("READY", list(ready_rows)),
+        ("IN PROGRESS", list(ip_rows)),
+        ("BLOCKED", list(blocked_rows)),
+        ("RECENTLY CLOSED (24h)", list(closed_rows)),
+    ]
+
+    header = "=== taOSmd Task Briefing ===\n"
+    tail = ""
+    if project:
+        header += f"Project: {project}\n"
+    header += "\n"
+
+    # Build final text respecting cap
+    text_parts = [header]
+    referenced_ids: set[str] = set()
+    char_used = len(header)
+
+    for section_name, rows in all_tasks_by_section:
+        if not rows:
+            continue
+        section_header = f"-- {section_name} --\n"
+        section_lines: list[str] = []
+        if section_name == "BLOCKED":
+            for t in rows:
+                blocker_title = blocker_map.get(t["id"], "unknown")
+                section_lines.append(f"{_task_line(t)}  (blocked by: {blocker_title})\n")
+        else:
+            for t in rows:
+                section_lines.append(f"{_task_line(t)}\n")
+
+        # Check if the whole section fits
+        section_text = section_header + "".join(section_lines) + "\n"
+        if char_used + len(section_text) <= PRIME_CHAR_CAP:
+            text_parts.append(section_text)
+            char_used += len(section_text)
+            for t in rows:
+                referenced_ids.add(t["id"])
+        else:
+            # Fit as many lines as possible
+            remaining = PRIME_CHAR_CAP - char_used - len(section_header) - 1
+            if remaining > 20:
+                text_parts.append(section_header)
+                char_used += len(section_header)
+                added = 0
+                for i, (t, line) in enumerate(zip(rows, section_lines)):
+                    if char_used + len(line) > PRIME_CHAR_CAP:
+                        omitted = len(rows) - added
+                        text_parts.append(f"  ... ({omitted} more)\n")
+                        break
+                    text_parts.append(line)
+                    char_used += len(line)
+                    referenced_ids.add(t["id"])
+                    added += 1
+            break  # Stop adding sections once we hit the cap
+
+    text = "".join(text_parts)
+
+    # Collect referenced task objects
+    all_rows = list(ready_rows) + list(ip_rows) + list(blocked_rows) + list(closed_rows)
+    seen: set[str] = set()
+    tasks_out: list[dict] = []
+    for r in all_rows:
+        if r["id"] in referenced_ids and r["id"] not in seen:
+            tasks_out.append(_row_to_dict(r))
+            seen.add(r["id"])
+
+    return {"text": text, "tasks": tasks_out}
+
+
+async def update_task(
+    task_id: str,
+    *,
+    status: str | None = None,
+    assignee: str | None = None,
+    priority: int | None = None,
+    body: str | None = None,
+    data_dir: str | None = None,
+) -> dict:
+    """Update task fields and return the updated task.
+
+    Raises :class:`ValueError` if the task does not exist or if ``status``
+    is not in the valid set.
+    """
+    if status is not None and status not in VALID_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+
+    conn = _get_db(data_dir)
+    row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row is None:
+        raise ValueError(f"task not found: {task_id!r}")
+
+    existing = _row_to_dict(row)
+    now = time.time()
+
+    updates: dict[str, Any] = {"updated_ts": now}
+    if status is not None:
+        updates["status"] = status
+        if status in CLOSED_STATUSES:
+            updates["closed_ts"] = now
+    if assignee is not None:
+        updates["assignee"] = assignee
+    if priority is not None:
+        updates["priority"] = int(priority)
+    if body is not None:
+        updates["body"] = body
+
+    # Archive BEFORE touching projection
+    actor = existing.get("created_by") or "unknown"
+    project = existing.get("project")
+    await _archive_task_event(
+        "updated",
+        {"id": task_id, **updates},
+        created_by=actor,
+        project=project,
+        data_dir=data_dir,
+    )
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    params = list(updates.values()) + [task_id]
+    conn.execute(f"UPDATE tasks SET {set_clause} WHERE id = ?", params)
+    conn.commit()
+
+    result = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    return _row_to_dict(result)
+
+
+async def add_edge(
+    from_id: str,
+    to_id: str,
+    edge_type: str,
+    created_by: str,
+    *,
+    data_dir: str | None = None,
+) -> dict:
+    """Add an edge between two tasks and return the edge record.
+
+    Raises :class:`ValueError` if either task does not exist or the edge type
+    is invalid.
+    """
+    if edge_type not in VALID_EDGE_TYPES:
+        raise ValueError(f"edge_type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    for tid, label in ((from_id, "from_id"), (to_id, "to_id")):
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (tid,)).fetchone():
+            raise ValueError(f"task not found: {tid!r} ({label})")
+
+    now = time.time()
+    edge: dict = {
+        "from_id": from_id,
+        "to_id": to_id,
+        "type": edge_type,
+        "created_ts": now,
+        "created_by": created_by,
+        "removed_ts": None,
+    }
+
+    # Fetch project from the to_id task for archive tagging
+    to_row = conn.execute("SELECT project FROM tasks WHERE id = ?", (to_id,)).fetchone()
+    project = to_row["project"] if to_row else None
+
+    # Archive BEFORE touching projection
+    await _archive_task_event(
+        "edge_added",
+        edge,
+        created_by=created_by,
+        project=project,
+        data_dir=data_dir,
+    )
+
+    conn.execute(
+        "INSERT INTO task_edges (from_id, to_id, type, created_ts, created_by, removed_ts) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        (from_id, to_id, edge_type, now, created_by),
+    )
+    conn.commit()
+    return edge
+
+
+async def remove_edge(
+    from_id: str,
+    to_id: str,
+    edge_type: str,
+    *,
+    data_dir: str | None = None,
+) -> dict:
+    """Soft-remove an edge by setting removed_ts (never deletes).
+
+    Returns the edge record with ``removed_ts`` set. Raises :class:`ValueError`
+    if the edge does not exist or is already removed.
+    """
+    if edge_type not in VALID_EDGE_TYPES:
+        raise ValueError(f"edge_type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    row = conn.execute(
+        "SELECT rowid, * FROM task_edges "
+        "WHERE from_id = ? AND to_id = ? AND type = ? AND removed_ts IS NULL",
+        (from_id, to_id, edge_type),
+    ).fetchone()
+    if row is None:
+        raise ValueError(
+            f"active edge not found: {from_id!r} --[{edge_type}]--> {to_id!r}"
+        )
+
+    now = time.time()
+
+    # Fetch project for archive tagging
+    to_task = conn.execute("SELECT project FROM tasks WHERE id = ?", (to_id,)).fetchone()
+    project = to_task["project"] if to_task else None
+    from_task = conn.execute("SELECT created_by FROM tasks WHERE id = ?", (from_id,)).fetchone()
+    actor = from_task["created_by"] if from_task else "unknown"
+
+    edge: dict = {
+        "from_id": from_id,
+        "to_id": to_id,
+        "type": edge_type,
+        "created_ts": row["created_ts"],
+        "created_by": row["created_by"],
+        "removed_ts": now,
+    }
+
+    # Archive BEFORE touching projection
+    await _archive_task_event(
+        "edge_removed",
+        edge,
+        created_by=actor,
+        project=project,
+        data_dir=data_dir,
+    )
+
+    conn.execute(
+        "UPDATE task_edges SET removed_ts = ? "
+        "WHERE from_id = ? AND to_id = ? AND type = ? AND removed_ts IS NULL",
+        (now, from_id, to_id, edge_type),
+    )
+    conn.commit()
+    return edge
+
+
+# ---------------------------------------------------------------------------
+# Archive rebuild
+# ---------------------------------------------------------------------------
+
+async def rebuild_from_archive(data_dir: str | None = None) -> dict:
+    """Replay task archive events into fresh projection tables.
+
+    Drops and recreates the ``tasks`` and ``task_edges`` tables (the view
+    is recreated automatically), then replays every ``event_type="task"``
+    event from the archive in timestamp order.
+
+    Returns ``{"tasks_rebuilt": int, "edges_rebuilt": int}``.
+    """
+    from . import api as _api  # noqa: PLC0415
+
+    # Drop cached connection so we get a fresh one after schema recreate
+    resolved = _api._resolve_data_dir(data_dir)
+    old_conn = _db_cache.pop(resolved, None)
+    if old_conn is not None:
+        try:
+            old_conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Rebuild schema on a fresh connection
+    path = Path(resolved)
+    db_path = str(path / "tasks.db")
+    conn = _db.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    # Drop projection tables (view drops automatically)
+    conn.executescript("""
+        DROP VIEW  IF EXISTS ready_tasks;
+        DROP TABLE IF EXISTS task_edges;
+        DROP TABLE IF EXISTS tasks;
+    """)
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    _db_cache[resolved] = conn
+
+    # Load archive events
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    events = await archive.query(event_type="task", limit=100000)
+    # Sort by timestamp ascending for correct replay order
+    events.sort(key=lambda e: e.get("timestamp", 0))
+
+    tasks_rebuilt = 0
+    edges_rebuilt = 0
+
+    for event in events:
+        try:
+            data_json = event.get("data_json") or event.get("data") or "{}"
+            if isinstance(data_json, str):
+                data = json.loads(data_json)
+            elif isinstance(data_json, dict):
+                data = data_json
+            else:
+                continue
+            action = data.get("action")
+            if action == "created":
+                conn.execute(
+                    """INSERT OR REPLACE INTO tasks
+                       (id, title, body, status, assignee, project, priority,
+                        created_ts, updated_ts, closed_ts, created_by, metadata)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        data.get("id"), data.get("title"), data.get("body"),
+                        data.get("status", "open"), data.get("assignee"),
+                        data.get("project"), data.get("priority", 0),
+                        data.get("created_ts"), data.get("updated_ts"),
+                        data.get("closed_ts"), data.get("created_by"), "{}",
+                    ),
+                )
+                tasks_rebuilt += 1
+            elif action == "updated":
+                task_id = data.get("id")
+                if not task_id:
+                    continue
+                updates = {
+                    k: v for k, v in data.items()
+                    if k not in ("action", "id") and v is not None
+                }
+                if not updates:
+                    continue
+                set_clause = ", ".join(f"{k} = ?" for k in updates)
+                params = list(updates.values()) + [task_id]
+                conn.execute(
+                    f"UPDATE tasks SET {set_clause} WHERE id = ?", params
+                )
+            elif action == "edge_added":
+                conn.execute(
+                    "INSERT OR IGNORE INTO task_edges "
+                    "(from_id, to_id, type, created_ts, created_by, removed_ts) "
+                    "VALUES (?, ?, ?, ?, ?, NULL)",
+                    (
+                        data.get("from_id"), data.get("to_id"),
+                        data.get("type"), data.get("created_ts"),
+                        data.get("created_by"),
+                    ),
+                )
+                edges_rebuilt += 1
+            elif action == "edge_removed":
+                removed_ts = data.get("removed_ts")
+                if removed_ts:
+                    conn.execute(
+                        "UPDATE task_edges SET removed_ts = ? "
+                        "WHERE from_id = ? AND to_id = ? AND type = ? "
+                        "AND removed_ts IS NULL",
+                        (
+                            removed_ts, data.get("from_id"),
+                            data.get("to_id"), data.get("type"),
+                        ),
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("rebuild_from_archive: skipped event %s: %s", event.get("id"), exc)
+
+    conn.commit()
+    return {"tasks_rebuilt": tasks_rebuilt, "edges_rebuilt": edges_rebuilt}

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -449,3 +449,183 @@ def test_search_unknown_mode_is_400(live_server):
     status, body = _get(f"{live_server}/search?q=x&agent=a&mode=cosine9000")
     assert status == 400
     assert "unsupported search mode" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# Task graph HTTP tests
+# ---------------------------------------------------------------------------
+
+
+def test_task_create(live_server):
+    """POST /tasks creates a task and returns the task object."""
+    status, body = _post(
+        f"{live_server}/tasks",
+        {"title": "Implement feature X", "created_by": "agent-test"},
+    )
+    assert status == 200, body
+    assert body["id"].startswith("t-")
+    assert body["title"] == "Implement feature X"
+    assert body["status"] == "open"
+    assert body["created_by"] == "agent-test"
+
+
+def test_task_create_missing_title(live_server):
+    status, body = _post(
+        f"{live_server}/tasks",
+        {"created_by": "agent-test"},
+    )
+    assert status == 400
+    assert "title" in body["error"]
+
+
+def test_task_create_missing_created_by(live_server):
+    status, body = _post(
+        f"{live_server}/tasks",
+        {"title": "Some task"},
+    )
+    assert status == 400
+    assert "created_by" in body["error"]
+
+
+def test_task_list(live_server):
+    """GET /tasks returns a list of tasks."""
+    _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    status, body = _get(f"{live_server}/tasks")
+    assert status == 200, body
+    assert "tasks" in body
+    assert len(body["tasks"]) >= 2
+
+
+def test_task_list_status_filter(live_server):
+    """GET /tasks?status= filters correctly."""
+    r, created = _post(f"{live_server}/tasks", {"title": "T-filter", "created_by": "a"})
+    assert r == 200
+    _post(f"{live_server}/tasks/{created['id']}", {"status": "closed"})
+
+    status, body = _get(f"{live_server}/tasks?status=closed")
+    assert status == 200
+    assert any(t["id"] == created["id"] for t in body["tasks"])
+
+
+def test_task_ready(live_server):
+    """GET /tasks/ready returns only open tasks with no active blockers."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "Blocker", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "Blocked", "created_by": "a"})
+    # Add blocks edge
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t2["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/ready")
+    assert status == 200
+    ready_ids = {t["id"] for t in body["tasks"]}
+    assert t1["id"] in ready_ids
+    assert t2["id"] not in ready_ids
+
+
+def test_task_prime(live_server):
+    """GET /tasks/prime returns a briefing with text and tasks keys."""
+    _post(f"{live_server}/tasks", {"title": "Prime target", "created_by": "a"})
+    status, body = _get(f"{live_server}/tasks/prime")
+    assert status == 200
+    assert "text" in body
+    assert "tasks" in body
+    assert isinstance(body["text"], str)
+    assert isinstance(body["tasks"], list)
+
+
+def test_task_update(live_server):
+    """POST /tasks/{id} updates task fields."""
+    _, task = _post(f"{live_server}/tasks", {"title": "To update", "created_by": "a"})
+    status, body = _post(
+        f"{live_server}/tasks/{task['id']}",
+        {"status": "in_progress"},
+    )
+    assert status == 200
+    assert body["status"] == "in_progress"
+
+
+def test_task_update_bad_status(live_server):
+    _, task = _post(f"{live_server}/tasks", {"title": "T", "created_by": "a"})
+    status, body = _post(
+        f"{live_server}/tasks/{task['id']}",
+        {"status": "not_a_status"},
+    )
+    assert status == 400
+
+
+def test_task_update_not_found(live_server):
+    status, body = _post(
+        f"{live_server}/tasks/t-000000000000",
+        {"status": "closed"},
+    )
+    assert status == 400
+    assert "not found" in body["error"]
+
+
+def test_task_add_edge(live_server):
+    """POST /tasks/{id}/edges adds a dependency edge."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "Blocker", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "Blocked", "created_by": "a"})
+    status, body = _post(
+        f"{live_server}/tasks/{t1['id']}/edges",
+        {"to_id": t2["id"], "type": "blocks", "created_by": "a"},
+    )
+    assert status == 200
+    assert body["from_id"] == t1["id"]
+    assert body["to_id"] == t2["id"]
+    assert body["type"] == "blocks"
+    assert body["removed_ts"] is None
+
+
+def test_task_add_edge_bad_type(live_server):
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    status, body = _post(
+        f"{live_server}/tasks/{t1['id']}/edges",
+        {"to_id": t2["id"], "type": "badtype", "created_by": "a"},
+    )
+    assert status == 400
+
+
+def test_task_remove_edge(live_server):
+    """POST /tasks/{id}/edges/remove soft-removes a blocking edge."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "Blocker", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "Blocked", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t2["id"], "type": "blocks", "created_by": "a"})
+
+    # t2 should not be in ready queue
+    _, ready_body = _get(f"{live_server}/tasks/ready")
+    assert t2["id"] not in {t["id"] for t in ready_body["tasks"]}
+
+    # Remove the edge
+    status, body = _post(
+        f"{live_server}/tasks/{t1['id']}/edges/remove",
+        {"to_id": t2["id"], "type": "blocks"},
+    )
+    assert status == 200
+    assert body["removed_ts"] is not None
+
+    # t2 should now be in ready queue
+    _, ready_body = _get(f"{live_server}/tasks/ready")
+    assert t2["id"] in {t["id"] for t in ready_body["tasks"]}
+
+
+def test_task_remove_edge_not_found(live_server):
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    status, body = _post(
+        f"{live_server}/tasks/{t1['id']}/edges/remove",
+        {"to_id": t2["id"], "type": "blocks"},
+    )
+    assert status == 400
+
+
+def test_task_404_unknown_id(live_server):
+    """POST /tasks/{unknown-non-t-id} should 404 when id segment is empty."""
+    # The dispatch only routes /tasks/{id} where id is non-empty; an unknown
+    # ID with valid format returns 400 from the update handler (task not found)
+    status, body = _post(f"{live_server}/tasks/t-000000000000", {"status": "closed"})
+    assert status == 400
+    assert "not found" in body["error"]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,437 @@
+"""Tests for taosmd.tasks — dependency-aware task graph.
+
+Covers:
+- Hash-ID stability (same triple -> same ID; distinct triple -> different ID)
+- ready-view correctness including transitive chains and edge soft-removal
+- prime token budget (text under cap, all four sections represented)
+- archive round-trip (create tasks + edges, rebuild_from_archive, assert match)
+- status enum rejection
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from taosmd import api as taosmd_api
+import taosmd.tasks as tasks_mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    """Isolated data dir for each test; wipe task db cache between tests."""
+    d = tmp_path / "tdata"
+    d.mkdir()
+    # Clear all caches so each test is isolated
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    monkeypatch.setattr(tasks_mod, "_db_cache", {})
+    return str(d)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Hash-ID stability
+# ---------------------------------------------------------------------------
+
+
+def test_hash_id_stable():
+    """Same (title, project, ts) triple must always give the same ID."""
+    t = 1234567890.123
+    id1 = tasks_mod._make_task_id("Fix the bug", "proj-abc", t)
+    id2 = tasks_mod._make_task_id("Fix the bug", "proj-abc", t)
+    assert id1 == id2
+    assert id1.startswith("t-")
+    assert len(id1) == 14  # "t-" + 12 hex chars
+
+
+def test_hash_id_different_title():
+    t = 1234567890.0
+    id1 = tasks_mod._make_task_id("Task A", None, t)
+    id2 = tasks_mod._make_task_id("Task B", None, t)
+    assert id1 != id2
+
+
+def test_hash_id_different_project():
+    t = 1234567890.0
+    id1 = tasks_mod._make_task_id("Task A", "proj-1", t)
+    id2 = tasks_mod._make_task_id("Task A", "proj-2", t)
+    assert id1 != id2
+
+
+def test_hash_id_different_ts():
+    id1 = tasks_mod._make_task_id("Task A", None, 1000.0)
+    id2 = tasks_mod._make_task_id("Task A", None, 1001.0)
+    assert id1 != id2
+
+
+def test_hash_id_no_project_is_distinct_from_project():
+    t = 1234567890.0
+    id1 = tasks_mod._make_task_id("Task A", None, t)
+    id2 = tasks_mod._make_task_id("Task A", "", t)
+    # Both use "" for project, so should be equal
+    assert id1 == id2
+
+
+# ---------------------------------------------------------------------------
+# Basic CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_returns_task(data_dir):
+    task = run(tasks_mod.create_task(
+        "Write tests",
+        created_by="agent-x",
+        data_dir=data_dir,
+    ))
+    assert task["id"].startswith("t-")
+    assert task["title"] == "Write tests"
+    assert task["status"] == "open"
+    assert task["created_by"] == "agent-x"
+    assert task["priority"] == 0
+
+
+def test_create_task_with_all_fields(data_dir):
+    task = run(tasks_mod.create_task(
+        "Deploy service",
+        body="Deploy the updated image",
+        project="proj-abc",
+        assignee="agent-y",
+        priority=5,
+        created_by="agent-x",
+        data_dir=data_dir,
+    ))
+    assert task["body"] == "Deploy the updated image"
+    assert task["project"] == "proj-abc"
+    assert task["assignee"] == "agent-y"
+    assert task["priority"] == 5
+
+
+def test_create_task_missing_created_by(data_dir):
+    with pytest.raises(ValueError, match="created_by"):
+        run(tasks_mod.create_task("A task", created_by="", data_dir=data_dir))
+
+
+def test_list_tasks_empty(data_dir):
+    result = run(tasks_mod.list_tasks(data_dir=data_dir))
+    assert result == []
+
+
+def test_list_tasks_with_filter(data_dir):
+    run(tasks_mod.create_task("T1", created_by="x", project="proj-1", data_dir=data_dir))
+    run(tasks_mod.create_task("T2", created_by="x", project="proj-2", data_dir=data_dir))
+    result = run(tasks_mod.list_tasks(project="proj-1", data_dir=data_dir))
+    assert len(result) == 1
+    assert result[0]["title"] == "T1"
+
+
+def test_update_task_status(data_dir):
+    task = run(tasks_mod.create_task("Do work", created_by="x", data_dir=data_dir))
+    updated = run(tasks_mod.update_task(task["id"], status="in_progress", data_dir=data_dir))
+    assert updated["status"] == "in_progress"
+    assert updated["closed_ts"] is None
+
+
+def test_update_task_close_sets_closed_ts(data_dir):
+    task = run(tasks_mod.create_task("Close me", created_by="x", data_dir=data_dir))
+    updated = run(tasks_mod.update_task(task["id"], status="closed", data_dir=data_dir))
+    assert updated["status"] == "closed"
+    assert updated["closed_ts"] is not None
+
+
+def test_update_task_not_found(data_dir):
+    with pytest.raises(ValueError, match="task not found"):
+        run(tasks_mod.update_task("t-000000000000", status="closed", data_dir=data_dir))
+
+
+def test_update_task_invalid_status(data_dir):
+    task = run(tasks_mod.create_task("T", created_by="x", data_dir=data_dir))
+    with pytest.raises(ValueError, match="status"):
+        run(tasks_mod.update_task(task["id"], status="garbage", data_dir=data_dir))
+
+
+# ---------------------------------------------------------------------------
+# Ready view correctness
+# ---------------------------------------------------------------------------
+
+
+def test_ready_view_no_edges(data_dir):
+    """A task with no edges is ready."""
+    task = run(tasks_mod.create_task("Simple task", created_by="x", data_dir=data_dir))
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    assert any(t["id"] == task["id"] for t in ready)
+
+
+def test_ready_view_blocked_by_open(data_dir):
+    """A task blocked by an open task is NOT in the ready queue."""
+    blocker = run(tasks_mod.create_task("Blocker", created_by="x", data_dir=data_dir))
+    blocked = run(tasks_mod.create_task("Blocked", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(blocker["id"], blocked["id"], "blocks", "x", data_dir=data_dir))
+
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ready_ids = {t["id"] for t in ready}
+    assert blocked["id"] not in ready_ids
+    assert blocker["id"] in ready_ids  # blocker itself is ready
+
+
+def test_ready_view_blocked_by_closed(data_dir):
+    """A task blocked only by a closed task IS in the ready queue."""
+    blocker = run(tasks_mod.create_task("Blocker", created_by="x", data_dir=data_dir))
+    blocked = run(tasks_mod.create_task("Blocked", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(blocker["id"], blocked["id"], "blocks", "x", data_dir=data_dir))
+    # Close the blocker
+    run(tasks_mod.update_task(blocker["id"], status="closed", data_dir=data_dir))
+
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ready_ids = {t["id"] for t in ready}
+    assert blocked["id"] in ready_ids
+
+
+def test_ready_view_transitive_chain(data_dir):
+    """A blocks B blocks C: closing A makes B ready but C still needs B to close."""
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    c = run(tasks_mod.create_task("C", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(b["id"], c["id"], "blocks", "x", data_dir=data_dir))
+
+    # Initially only A is ready
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ready_ids = {t["id"] for t in ready}
+    assert a["id"] in ready_ids
+    assert b["id"] not in ready_ids
+    assert c["id"] not in ready_ids
+
+    # Close A: B becomes ready, C still blocked by B
+    run(tasks_mod.update_task(a["id"], status="closed", data_dir=data_dir))
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ready_ids = {t["id"] for t in ready}
+    assert b["id"] in ready_ids
+    assert c["id"] not in ready_ids
+
+
+def test_ready_view_edge_removal_restores(data_dir):
+    """Removing a blocks edge restores readiness of the downstream task."""
+    blocker = run(tasks_mod.create_task("Blocker", created_by="x", data_dir=data_dir))
+    blocked = run(tasks_mod.create_task("Blocked", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(blocker["id"], blocked["id"], "blocks", "x", data_dir=data_dir))
+
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    assert blocked["id"] not in {t["id"] for t in ready}
+
+    # Remove the edge
+    run(tasks_mod.remove_edge(blocker["id"], blocked["id"], "blocks", data_dir=data_dir))
+
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    assert blocked["id"] in {t["id"] for t in ready}
+
+
+def test_ready_view_priority_ordering(data_dir):
+    """Ready tasks are ordered priority DESC, created_ts ASC."""
+    t1 = run(tasks_mod.create_task("Low prio", created_by="x", priority=1, data_dir=data_dir))
+    t2 = run(tasks_mod.create_task("High prio", created_by="x", priority=10, data_dir=data_dir))
+    t3 = run(tasks_mod.create_task("Zero prio", created_by="x", priority=0, data_dir=data_dir))
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ids = [t["id"] for t in ready]
+    assert ids.index(t2["id"]) < ids.index(t1["id"])
+    assert ids.index(t1["id"]) < ids.index(t3["id"])
+
+
+# ---------------------------------------------------------------------------
+# Edges
+# ---------------------------------------------------------------------------
+
+
+def test_add_edge_invalid_type(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    with pytest.raises(ValueError, match="edge_type"):
+        run(tasks_mod.add_edge(a["id"], b["id"], "invalid", "x", data_dir=data_dir))
+
+
+def test_add_edge_missing_task(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    with pytest.raises(ValueError, match="task not found"):
+        run(tasks_mod.add_edge(a["id"], "t-000000000000", "blocks", "x", data_dir=data_dir))
+
+
+def test_remove_edge_not_found(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    with pytest.raises(ValueError, match="active edge not found"):
+        run(tasks_mod.remove_edge(a["id"], b["id"], "blocks", data_dir=data_dir))
+
+
+def test_remove_edge_already_removed(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.remove_edge(a["id"], b["id"], "blocks", data_dir=data_dir))
+    with pytest.raises(ValueError, match="active edge not found"):
+        run(tasks_mod.remove_edge(a["id"], b["id"], "blocks", data_dir=data_dir))
+
+
+# ---------------------------------------------------------------------------
+# depends_on in create_task
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_with_depends_on(data_dir):
+    """depends_on creates blocking edges automatically."""
+    blocker = run(tasks_mod.create_task("Blocker", created_by="x", data_dir=data_dir))
+    dep_task = run(tasks_mod.create_task(
+        "Dependent",
+        created_by="x",
+        depends_on=[blocker["id"]],
+        data_dir=data_dir,
+    ))
+    ready = run(tasks_mod.ready_tasks(data_dir=data_dir))
+    ready_ids = {t["id"] for t in ready}
+    assert dep_task["id"] not in ready_ids
+    assert blocker["id"] in ready_ids
+
+
+def test_create_task_depends_on_nonexistent(data_dir):
+    with pytest.raises(ValueError, match="depends_on task not found"):
+        run(tasks_mod.create_task(
+            "T",
+            created_by="x",
+            depends_on=["t-000000000000"],
+            data_dir=data_dir,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Prime token budget
+# ---------------------------------------------------------------------------
+
+
+def test_prime_empty(data_dir):
+    """prime() on an empty store returns a dict with text and empty tasks."""
+    result = run(tasks_mod.prime(data_dir=data_dir))
+    assert "text" in result
+    assert "tasks" in result
+    assert isinstance(result["text"], str)
+    assert isinstance(result["tasks"], list)
+
+
+def test_prime_under_cap(data_dir):
+    """prime() text stays within the character cap regardless of task count."""
+    for i in range(30):
+        run(tasks_mod.create_task(
+            f"Task {i:02d} — this is a somewhat long title to consume budget",
+            created_by="x",
+            data_dir=data_dir,
+        ))
+    result = run(tasks_mod.prime(data_dir=data_dir))
+    assert len(result["text"]) <= tasks_mod.PRIME_CHAR_CAP
+
+
+def test_prime_sections_present(data_dir):
+    """prime() text mentions ready, in-progress, and blocked sections."""
+    t_ready = run(tasks_mod.create_task("Ready task", created_by="x", data_dir=data_dir))
+    t_ip = run(tasks_mod.create_task("In-progress task", created_by="x", data_dir=data_dir))
+    run(tasks_mod.update_task(t_ip["id"], status="in_progress", data_dir=data_dir))
+
+    blocker = run(tasks_mod.create_task("Blocker", created_by="x", data_dir=data_dir))
+    blocked = run(tasks_mod.create_task("Blocked task", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(blocker["id"], blocked["id"], "blocks", "x", data_dir=data_dir))
+
+    t_closed = run(tasks_mod.create_task("Recent closed", created_by="x", data_dir=data_dir))
+    run(tasks_mod.update_task(t_closed["id"], status="closed", data_dir=data_dir))
+
+    result = run(tasks_mod.prime(data_dir=data_dir))
+    text = result["text"]
+    assert "READY" in text
+    assert "IN PROGRESS" in text
+    assert "BLOCKED" in text
+    assert "RECENTLY CLOSED" in text
+
+
+def test_prime_tasks_only_referenced(data_dir):
+    """prime() tasks list only contains tasks actually referenced in text."""
+    for i in range(5):
+        run(tasks_mod.create_task(f"Task {i}", created_by="x", data_dir=data_dir))
+    result = run(tasks_mod.prime(data_dir=data_dir))
+    referenced_ids = set()
+    for t in result["tasks"]:
+        referenced_ids.add(t["id"])
+    # Every referenced task ID should appear in the text
+    for t_id in referenced_ids:
+        assert t_id in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Archive round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_archive_round_trip(data_dir, monkeypatch):
+    """Create tasks + edges, rebuild from archive, assert identical projection."""
+    # Create tasks
+    t1 = run(tasks_mod.create_task("Task One", created_by="agent-a", project="p1", data_dir=data_dir))
+    t2 = run(tasks_mod.create_task("Task Two", created_by="agent-b", priority=3, data_dir=data_dir))
+    t3 = run(tasks_mod.create_task("Task Three", created_by="agent-a", data_dir=data_dir))
+
+    # Add edges
+    run(tasks_mod.add_edge(t1["id"], t2["id"], "blocks", "agent-a", data_dir=data_dir))
+    run(tasks_mod.add_edge(t2["id"], t3["id"], "parent", "agent-b", data_dir=data_dir))
+
+    # Update a task
+    run(tasks_mod.update_task(t1["id"], status="in_progress", data_dir=data_dir))
+
+    # Capture current projection
+    all_before = run(tasks_mod.list_tasks(data_dir=data_dir))
+    ready_before = run(tasks_mod.ready_tasks(data_dir=data_dir))
+
+    # Rebuild from archive
+    result = run(tasks_mod.rebuild_from_archive(data_dir=data_dir))
+    assert result["tasks_rebuilt"] >= 3
+
+    # Assert identical projection
+    all_after = run(tasks_mod.list_tasks(data_dir=data_dir))
+    ready_after = run(tasks_mod.ready_tasks(data_dir=data_dir))
+
+    before_ids = {t["id"] for t in all_before}
+    after_ids = {t["id"] for t in all_after}
+    assert before_ids == after_ids
+
+    # Status should match
+    before_map = {t["id"]: t["status"] for t in all_before}
+    after_map = {t["id"]: t["status"] for t in all_after}
+    assert before_map == after_map
+
+    # Ready set should match
+    assert {t["id"] for t in ready_before} == {t["id"] for t in ready_after}
+
+
+def test_rebuild_from_archive_with_edge_removal(data_dir):
+    """Edge removal is replayed correctly."""
+    t1 = run(tasks_mod.create_task("T1", created_by="x", data_dir=data_dir))
+    t2 = run(tasks_mod.create_task("T2", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(t1["id"], t2["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.remove_edge(t1["id"], t2["id"], "blocks", data_dir=data_dir))
+
+    ready_before = {t["id"] for t in run(tasks_mod.ready_tasks(data_dir=data_dir))}
+
+    run(tasks_mod.rebuild_from_archive(data_dir=data_dir))
+
+    ready_after = {t["id"] for t in run(tasks_mod.ready_tasks(data_dir=data_dir))}
+    assert ready_before == ready_after
+    # Both should be ready after edge removal
+    assert t1["id"] in ready_after
+    assert t2["id"] in ready_after


### PR DESCRIPTION
## Summary

- Adds `taosmd/tasks.py`: SQLite-backed task graph with `tasks`, `task_edges` tables and a `ready_tasks` SQL view stored in `tasks.db` under the data dir. Every mutation is archive-first (zero-loss guarantee); `rebuild_from_archive()` replays the full event history into fresh tables.
- Content-hash task IDs (`t-<sha256[:12]>`) are safe for concurrent multi-agent creation without coordination.
- Seven HTTP endpoints: `POST /tasks`, `GET /tasks`, `GET /tasks/ready`, `GET /tasks/prime`, `POST /tasks/{id}`, `POST /tasks/{id}/edges`, `POST /tasks/{id}/edges/remove`.
- Seven CLI subcommands under `taosmd tasks`: `add`, `list`, `ready`, `prime`, `start`, `close`, `block`.
- Five MCP tools: `task_add`, `task_ready`, `task_prime`, `task_update`, `task_edge`.
- Service layer wrappers in `service.py` with remote-forwarding pattern; matching methods on `RemoteClient` in `remote.py`.
- Concept credit: the dependency-graph, ready-queue, and prime ideas come from beads (github.com/gastownhall/beads). This is an independent minimal implementation on the taosmd SQLite substrate.
- Spec: `docs/superpowers/specs/2026-06-10-task-graph-design.md`

## Test coverage

- `tests/test_tasks.py` (32 tests): hash-ID stability, ready-view correctness (no edges, blocked by open, blocked by closed, transitive A->B->C chain, edge soft-removal restores readiness), prime token budget under cap, archive round-trip (create+edges -> rebuild_from_archive -> assert identical projection), status enum rejection, depends_on auto-edge creation.
- `tests/test_http_server.py` (15 new tests): create, list, status filter, ready queue, prime, update, bad-status 400, not-found 400, add edge, bad-edge-type 400, remove edge (restores readiness), remove edge not-found 400.
- Full suite: 702 tests, 0 failures.