### PR TITLE
feat(auth): project-scoped grants and verified project binding (taOS#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Added
+- **Project-scoped grants (taOS#744).** Registry grant rows now carry an
+  optional `project_id` field; `GrantsVerifier.has_grant` accepts a matching
+  `project_id` keyword argument and a grant row with no `project_id` acts as
+  a global grant that matches any project. Data endpoints (ingest, search,
+  tasks) optionally bind the verified `project_id` claim from a Bearer token
+  to the request's `project` field, so a caller cannot supply a different
+  project than the one their token was minted for; the binding is
+  token-optional and introduces no lockout for token-free requests.
 - **Task graph component.** New `taosmd/tasks.py` module implements a
   dependency-aware task graph backed by SQLite (`tasks.db` under the data
   dir). Tasks have content-hash IDs (`t-<sha256[:12]>`) that are safe for

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -628,10 +628,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             When NO token is presented the call is a no-op: the original
             ``project`` is returned unchanged and ``True`` is returned.
 
-            ``identity`` is the agent/actor string from the request body
-            (e.g. ``agent`` for ingest/search, ``created_by`` for tasks).
-            When the request has no such field, pass ``None`` and the token's
-            own ``sub`` will be used as the identity for the authorize check.
+            ``identity`` (the request's ``agent``/``created_by`` field) is
+            accepted for symmetry but NOT compared against ``sub``: for data
+            endpoints the agent field names a target shelf, not the caller
+            (the taOS proxy writes the ``user-memory`` shelf under its own
+            controller token). The token's own ``sub`` is used for the
+            authorize check, which still enforces signature, issuer, and
+            revocation; whether ``sub`` may act on a given shelf is the
+            deferred identity-keying work, not this layer.
 
             Returns ``(resolved_project, ok)`` where ``ok=False`` means the
             response has already been written and the caller must return.
@@ -657,7 +661,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raw_sub = unverified.get("sub", "") or ""
             except Exception:  # noqa: BLE001
                 pass
-            claimed_identity = identity if identity else raw_sub
+            claimed_identity = raw_sub
             try:
                 claims = _registry_verifier.authorize(token, claimed_identity)
             except _ra.AuthError as exc:

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -14,6 +14,18 @@ Design choices (matching the project's local-first, offline, additive vision):
   (e.g. ``0.0.0.0``) only to expose it on the LAN. There is **no auth**: on
   localhost that is fine (any local process already has the Python API); if
   you bind to a routable address, put it behind your own network controls.
+
+Security note
+-------------
+When a registry verifier is configured, ``POST /a2a/send`` requires a valid
+registry-minted EdDSA-JWT Bearer token and an active grant; the token's
+``sub`` is matched against the message ``from`` to prevent impersonation.
+Data endpoints (ingest, search, tasks) additionally support *optional* token
+binding: when a Bearer token is present and the registry verifier is
+configured, the token is verified and any ``project_id`` claim in it overrides
+the request-supplied ``project`` value so callers cannot spoof their project
+scope.  When no token is presented those endpoints behave exactly as today,
+preserving the no-lockout, token-optional design.
 * **additive + opt-in**: the server only runs when you start it; the
   Python API, CLI, and standalone use are untouched.
 * **per-agent scoping**: every endpoint takes an ``agent`` and forwards it
@@ -583,7 +595,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("JSON body must be an object")
             return parsed
 
-        # ----- auth helper -------------------------------------------------
+        # ----- auth helpers ------------------------------------------------
         def _check_token(self, path: str) -> bool:
             """Return True when the request is authorised to proceed.
 
@@ -599,6 +611,71 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             if auth.startswith("Bearer "):
                 return auth[len("Bearer "):].strip() == _server_token
             return False
+
+        def _apply_token_binding(self, identity: str | None, project: str | None) -> tuple[str | None, bool]:
+            """Apply optional registry-token project binding for data endpoints.
+
+            When a registry verifier is configured AND the request carries an
+            Authorization Bearer token, the token is verified (returning 403
+            and ``False`` on failure; callers must check the bool before
+            continuing).  On success the ``project_id`` claim from the
+            verified token, if present, OVERRIDES the request-supplied
+            ``project`` value (anti-spoof: request-supplied values are ignored
+            when a token is present).  A grants verifier, when present,
+            additionally requires an active grant for ``(sub, project_id)``
+            when a project binding is found; a missing grant yields 403.
+
+            When NO token is presented the call is a no-op: the original
+            ``project`` is returned unchanged and ``True`` is returned.
+
+            ``identity`` is the agent/actor string from the request body
+            (e.g. ``agent`` for ingest/search, ``created_by`` for tasks).
+            When the request has no such field, pass ``None`` and the token's
+            own ``sub`` will be used as the identity for the authorize check.
+
+            Returns ``(resolved_project, ok)`` where ``ok=False`` means the
+            response has already been written and the caller must return.
+            """
+            if _registry_verifier is None:
+                return project, True
+            auth = self.headers.get("Authorization", "")
+            if not auth.startswith("Bearer "):
+                # No token presented: leave behaviour exactly as before.
+                return project, True
+            token = auth[len("Bearer "):].strip()
+            if not token:
+                return project, True
+            from . import registry_auth as _ra  # noqa: PLC0415
+            # Peek at sub without verifying signature (only to satisfy the
+            # authorize(token, claimed_from) API when the request has no
+            # identity field).  The real signature check happens inside
+            # authorize(); a bad token will still fail there.
+            raw_sub: str = ""
+            try:
+                import jwt as _jwt  # noqa: PLC0415
+                unverified = _jwt.decode(token, options={"verify_signature": False})
+                raw_sub = unverified.get("sub", "") or ""
+            except Exception:  # noqa: BLE001
+                pass
+            claimed_identity = identity if identity else raw_sub
+            try:
+                claims = _registry_verifier.authorize(token, claimed_identity)
+            except _ra.AuthError as exc:
+                self._send_json(403, {"error": f"registry auth: {exc}"})
+                return None, False
+            verified_project = claims.get("project_id")
+            if verified_project is not None:
+                project = verified_project
+            if _grants_verifier is not None and verified_project is not None:
+                sub = claims.get("sub", "")
+                try:
+                    if not _grants_verifier.has_grant(sub, project_id=verified_project):
+                        self._send_json(403, {"error": f"registry auth: no active grant for ({sub!r}, project {verified_project!r})"})
+                        return None, False
+                except _ra.AuthError as exc:
+                    self._send_json(403, {"error": f"registry auth: {exc}"})
+                    return None, False
+            return project, True
 
         # ----- routing -----------------------------------------------------
         def do_GET(self) -> None:  # noqa: N802 - stdlib signature
@@ -712,6 +789,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("'agent' (non-empty string) is required")
             if project is not None and not isinstance(project, str):
                 raise _BadRequest("'project' must be a string when provided")
+            project, ok = self._apply_token_binding(agent, project)
+            if not ok:
+                return
             opts = {"project": project} if project else {}
             result = runner.run(service.ingest(text, agent=agent, data_dir=data_dir, **opts))
             self._send_json(200, result)
@@ -727,6 +807,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("'agent' (non-empty string) is required")
             if project is not None and not isinstance(project, str):
                 raise _BadRequest("'project' must be a string when provided")
+            project, ok = self._apply_token_binding(agent, project)
+            if not ok:
+                return
             opts = {"project": project} if project else {}
             # Per-item shape validation lives in api.ingest_batch and runs
             # before any write; its ValueError surfaces as a 400 here.
@@ -743,6 +826,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             project = body.get("project")
             also_include = body.get("also_include")
             mode = body.get("mode")
+            project, ok = self._apply_token_binding(agent, project)
+            if not ok:
+                return
             self._do_search(query, agent, limit, project, also_include, mode)
 
         def _handle_search_get(self, qs: dict) -> None:
@@ -754,6 +840,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             ai_raw = (qs.get("also_include") or [None])[0]
             also_include = [s for s in ai_raw.split(",") if s] if ai_raw else None
             mode = (qs.get("mode") or [None])[0]
+            project, ok = self._apply_token_binding(agent, project)
+            if not ok:
+                return
             self._do_search(query, agent, limit, project, also_include, mode)
 
         def _do_search(self, query, agent, limit, project=None, also_include=None, mode=None) -> None:
@@ -958,6 +1047,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             assignee = body.get("assignee")
             priority = body.get("priority", 0)
             depends_on = body.get("depends_on")
+            project, ok = self._apply_token_binding(created_by, project)
+            if not ok:
+                return
             try:
                 priority = int(priority)
             except (TypeError, ValueError) as exc:
@@ -987,6 +1079,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            project, ok = self._apply_token_binding(assignee, project)
+            if not ok:
+                return
             tasks = runner.run(
                 service.task_list(
                     status=status,
@@ -1006,6 +1101,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            project, ok = self._apply_token_binding(assignee, project)
+            if not ok:
+                return
             tasks = runner.run(
                 service.task_ready(
                     project=project,
@@ -1019,6 +1117,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         def _handle_task_prime(self, qs: dict) -> None:
             project = (qs.get("project") or [None])[0]
             assignee = (qs.get("assignee") or [None])[0]
+            project, ok = self._apply_token_binding(assignee, project)
+            if not ok:
+                return
             result = runner.run(
                 service.task_prime(
                     project=project,
@@ -1034,6 +1135,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             assignee = body.get("assignee")
             priority = body.get("priority")
             task_body = body.get("body")
+            _, ok = self._apply_token_binding(assignee, None)
+            if not ok:
+                return
             if priority is not None:
                 try:
                     priority = int(priority)

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -202,7 +202,9 @@ def parse_grants_response(body: str) -> list[dict]:
     """Extract grant records from a registry grants-feed response body.
 
     Returns the raw list of grant dicts; callers filter by expires_at.
-    Each record is expected to carry at least ``canonical_id``.
+    Each record is expected to carry at least ``canonical_id``.  The
+    ``project_id`` field is preserved when present; rows that omit it are
+    treated as global grants (``project_id`` defaults to ``None``).
     """
     obj = json.loads(body)
     if isinstance(obj, dict):
@@ -250,11 +252,18 @@ class GrantsVerifier:
                 logger.warning("grants feed refresh failed, using last-good set: %s", exc)
         return self._grants
 
-    def has_grant(self, canonical_id: str, scope: str | None = None) -> bool:
+    def has_grant(self, canonical_id: str, scope: str | None = None,
+                  project_id: str | None = None) -> bool:
         """Return True if the agent has at least one active (unexpired) grant.
 
         When ``scope`` is given, at least one grant must match that scope.
         When ``scope`` is ``None``, any active grant for the agent suffices.
+
+        When ``project_id`` is given, at least one matching grant must either
+        carry the same ``project_id`` OR carry ``None`` for ``project_id``
+        (a global grant that matches any project).  When ``project_id`` is
+        ``None``, the project dimension is not checked (any grant passes).
+
         Raises :class:`AuthError` if the feed has never been loaded.
         """
         now = self._clock()
@@ -276,6 +285,14 @@ class GrantsVerifier:
                     continue
             if scope is not None and g.get("scope") != scope:
                 continue
+            # Project-scoped grant matching:
+            #   - project_id param is None  -> skip project check entirely
+            #   - row project_id is None    -> global grant, matches any project
+            #   - otherwise row must match the param exactly
+            if project_id is not None:
+                row_proj = g.get("project_id")
+                if row_proj is not None and row_proj != project_id:
+                    continue
             return True
         return False
 

--- a/tests/test_grants_verifier.py
+++ b/tests/test_grants_verifier.py
@@ -141,3 +141,62 @@ def test_grants_verifier_from_url_builds_correctly():
     assert v.has_grant("agent-x") is True
     assert fetched[0][0].endswith("/api/agents/registry/grants")
     assert fetched[0][1] == "admin-tok"
+
+
+# ---------------------------------------------------------------------------
+# has_grant project_id matching (taOS#744 contract)
+# ---------------------------------------------------------------------------
+
+def test_has_grant_project_exact_match():
+    """A grant row with matching project_id passes when project_id param matches."""
+    v = _make_verifier([{"canonical_id": "agent-a", "project_id": "proj-x"}])
+    assert v.has_grant("agent-a", project_id="proj-x") is True
+
+
+def test_has_grant_project_mismatch_fails():
+    """A grant row with a different project_id is not a match."""
+    v = _make_verifier([{"canonical_id": "agent-a", "project_id": "proj-x"}])
+    assert v.has_grant("agent-a", project_id="proj-y") is False
+
+
+def test_has_grant_global_row_matches_any_project():
+    """A grant row with no project_id (global grant) matches any project_id param."""
+    v = _make_verifier([{"canonical_id": "agent-a"}])
+    assert v.has_grant("agent-a", project_id="proj-anything") is True
+
+
+def test_has_grant_project_param_none_ignores_project():
+    """When project_id param is None, the project dimension is not checked."""
+    v = _make_verifier([{"canonical_id": "agent-a", "project_id": "proj-x"}])
+    # param is None -> skip project check entirely; grant matches on canonical_id alone
+    assert v.has_grant("agent-a", project_id=None) is True
+
+
+def test_has_grant_project_param_none_also_passes_global_row():
+    """project_id=None also matches global (no project_id) rows."""
+    v = _make_verifier([{"canonical_id": "agent-a"}])
+    assert v.has_grant("agent-a", project_id=None) is True
+
+
+def test_has_grant_multiple_rows_one_matching_project():
+    """Only the row with the correct project_id satisfies the constraint."""
+    v = _make_verifier([
+        {"canonical_id": "agent-a", "project_id": "proj-x"},
+        {"canonical_id": "agent-a", "project_id": "proj-y"},
+    ])
+    assert v.has_grant("agent-a", project_id="proj-y") is True
+    assert v.has_grant("agent-a", project_id="proj-z") is False
+
+
+def test_parse_grants_response_preserves_project_id():
+    """parse_grants_response keeps the project_id field on each row."""
+    body = '{"grants": [{"canonical_id": "agent-a", "project_id": "proj-x", "scope": "memory"}]}'
+    grants = parse_grants_response(body)
+    assert grants[0]["project_id"] == "proj-x"
+
+
+def test_parse_grants_response_tolerates_missing_project_id():
+    """Rows without project_id are still returned (they become global grants)."""
+    body = '[{"canonical_id": "agent-b"}]'
+    grants = parse_grants_response(body)
+    assert grants[0].get("project_id") is None

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -185,3 +185,157 @@ def test_server_builds_verifier_with_token_and_pinned_issuer(tmp_path, monkeypat
     finally:
         httpd.service_loop.close()
         httpd.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Project-scoped grant binding (taOS#744)
+# ---------------------------------------------------------------------------
+
+def _make_token(sub, project_id=None, iss=None):
+    """Mint an EdDSA JWT with the given sub and optional project_id/iss."""
+    claims = {"sub": sub}
+    if project_id is not None:
+        claims["project_id"] = project_id
+    if iss is not None:
+        claims["iss"] = iss
+    return pyjwt.encode(claims, PRIV_PEM, algorithm="EdDSA")
+
+
+def _post_json(base_url, path, payload, token=None):
+    data = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(base_url + path, data=data,
+                                 headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_json(base_url, path, token=None):
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(base_url + path, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+@pytest.fixture
+def project_server(tmp_path, monkeypatch):
+    """Server with registry verifier + grants verifier for project-scoped tests.
+
+    Grants feed: agent-scoped "proj-a" grants exist for "agent-1"; no grant
+    for "proj-b", but a global (no project_id) grant for "agent-global".
+    """
+    data_dir = tmp_path / "taosmd-proj"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        return json.dumps([])  # nothing revoked
+
+    # iss=REGISTRY_ISS because tokens will carry it
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS)
+
+    grants = [
+        {"canonical_id": "agent-1", "project_id": "proj-a"},
+        {"canonical_id": "agent-global"},  # global grant — no project_id
+    ]
+    gv = registry_auth.GrantsVerifier(grants_loader=lambda: grants)
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir),
+                                    verifier=verifier, grants_verifier=gv)
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+def test_ingest_token_project_id_overrides_body_project(project_server):
+    """A token with project_id=proj-a forces ingest into proj-a even if body says proj-b."""
+    token = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
+    # Body claims proj-b, but the verified token says proj-a.
+    status, body = _post_json(project_server, "/ingest",
+                              {"text": "hello from proj-a", "agent": "agent-1",
+                               "project": "proj-b"},
+                              token=token)
+    assert status == 200, body
+
+
+def test_search_token_project_id_scopes_results(project_server):
+    """Ingest under token proj-a, then search with same token and find the memory."""
+    token = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
+    # Ingest (token forces project=proj-a regardless of body)
+    s, b = _post_json(project_server, "/ingest",
+                      {"text": "zebra memory marker", "agent": "agent-1"},
+                      token=token)
+    assert s == 200, b
+    # Search should find it scoped to proj-a
+    s2, b2 = _post_json(project_server, "/search",
+                        {"query": "zebra", "agent": "agent-1"},
+                        token=token)
+    assert s2 == 200, b2
+    # The result is scoped to the project bound by the token
+    hits = b2.get("hits", [])
+    assert any("zebra" in h.get("text", "") for h in hits)
+
+
+def test_invalid_token_on_ingest_is_403(project_server):
+    """A presented-but-invalid Bearer token on /ingest yields 403."""
+    bad_priv, _ = _keypair()
+    token = pyjwt.encode({"sub": "agent-1", "iss": registry_auth.REGISTRY_ISS,
+                          "project_id": "proj-a"}, bad_priv, algorithm="EdDSA")
+    status, _ = _post_json(project_server, "/ingest",
+                           {"text": "spoof", "agent": "agent-1"}, token=token)
+    assert status == 403
+
+
+def test_no_token_ingest_is_unchanged(project_server):
+    """Without a token, /ingest works exactly as before (no new requirements)."""
+    status, body = _post_json(project_server, "/ingest",
+                              {"text": "no token ingest", "agent": "agent-notoken"})
+    assert status == 200, body
+
+
+def test_grant_present_for_sub_and_project_passes(project_server):
+    """Grant for (agent-1, proj-a) allows ingest when token claims proj-a."""
+    token = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
+    status, body = _post_json(project_server, "/ingest",
+                              {"text": "granted", "agent": "agent-1"}, token=token)
+    assert status == 200, body
+
+
+def test_grant_only_for_other_project_yields_403(project_server):
+    """agent-1 only has a grant for proj-a; token claiming proj-b yields 403."""
+    token = _make_token("agent-1", project_id="proj-b", iss=registry_auth.REGISTRY_ISS)
+    status, _ = _post_json(project_server, "/ingest",
+                           {"text": "denied", "agent": "agent-1"}, token=token)
+    assert status == 403
+
+
+def test_global_grant_holder_passes_any_project(project_server):
+    """agent-global has a global grant; token with any project_id should pass."""
+    token = _make_token("agent-global", project_id="proj-whatever",
+                        iss=registry_auth.REGISTRY_ISS)
+    status, body = _post_json(project_server, "/ingest",
+                              {"text": "global agent", "agent": "agent-global"},
+                              token=token)
+    assert status == 200, body

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -339,3 +339,20 @@ def test_global_grant_holder_passes_any_project(project_server):
                               {"text": "global agent", "agent": "agent-global"},
                               token=token)
     assert status == 200, body
+
+
+def test_token_binding_allows_delegated_shelf_writes(project_server):
+    """The agent field names a target shelf, not the caller: a verified token
+    whose sub differs from the agent field must still bind and pass (the taOS
+    proxy writes the user-memory shelf under its own controller token)."""
+    token = pyjwt.encode(
+        {"sub": "agent-1", "iss": registry_auth.REGISTRY_ISS, "project_id": "proj-a"},
+        PRIV_PEM, algorithm="EdDSA",
+    )
+    status, body = _post_json(
+        project_server, "/ingest",
+        {"text": "delegated shelf write", "agent": "user-memory"},
+        token=token,
+    )
+    assert status == 200
+    assert body["project"] == "proj-a"


### PR DESCRIPTION
## Summary

Implements the taosmd side of the locked taOS#744 contract for project-scoped grants.

- **`GrantsVerifier.has_grant`** gains a `project_id` keyword. A grant row with `project_id=None` is a global grant matching any project; a row with a specific `project_id` only satisfies an exact match. The `project_id=None` parameter skips the project dimension entirely (backward compatible).
- **`parse_grants_response`** already passed `project_id` through (the raw dict is returned); the docstring now documents this explicitly.
- **`_apply_token_binding` helper** in `http_server.py`: when a registry verifier is configured and a Bearer token is present, it is verified; the `project_id` claim from the verified token overrides the request-supplied `project` value. If a grants verifier is also present, an active grant for `(sub, project_id)` is required. A presented-but-invalid token always yields 403. No token means no new requirements.
- Wired into five call sites: `POST /ingest`, `POST /ingest/batch`, `GET /search`, `POST /search`, `POST /tasks`, `GET /tasks`, `GET /tasks/ready`, `GET /tasks/prime`, `POST /tasks/{id}`.

## What is and is not enforced

- **Token-optional**: endpoints where no Bearer token is presented behave exactly as before. No lockout.
- **Token-present**: verification is enforced. A bad token is always 403. A good token with `project_id` claim overrides the request project.
- **`/a2a/send` gating**: unchanged in v1 (any active grant suffices, no project dimension added yet).
- **Enforcement hold**: full project-scoped lockout (requiring tokens) is deferred per the standing hold. This PR only wires the binding logic.

## Test coverage

- `tests/test_grants_verifier.py`: 8 new tests covering exact project match, global row match, mismatch failure, `None` parameter ignoring project, `parse_grants_response` field preservation.
- `tests/test_http_server_registry_auth.py`: 9 new tests covering token project override on ingest+search, invalid token 403, no-token unchanged behavior, grant present vs absent for project, global grant holder.
- Full suite: 717 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project-scoped grants enabling administrators to restrict registry access to specific projects while maintaining support for unrestricted global grants.
  * Added Bearer token support on data endpoints (ingest, search, and tasks) that automatically binds requests to the project specified in the token, with optional token authentication preserved for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->