### PR TITLE
feat: retrieval-time TTL filter + three-number bench summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 ## Unreleased
 
 ### Added
+- **Retrieval-time TTL filter (`forget_after` / `forget_reason`).** Callers
+  may include `forget_after` (unix float) and an optional `forget_reason`
+  (string) in user metadata when calling `VectorMemory.add` or the HTTP
+  `POST /ingest` and `POST /ingest/batch` endpoints. Once `forget_after`
+  passes, the row is hidden from `search()` and `search_bm25()` exactly like
+  a superseded row. The raw row is never deleted (zero-loss: the archive is
+  untouched). Non-numeric or missing `forget_after` values are silently
+  ignored so existing memories are unaffected. The feature requires no schema
+  change; the fields live in the existing `metadata_json` column alongside
+  other user metadata. Inspired by supermemory's `forgetAfter` concept;
+  implemented as a zero-loss filter at retrieval time rather than a hard
+  delete. `_load_active_rows` accepts an optional `now` parameter (defaults
+  to `time.time()`) so tests can control the clock without monkey-patching.
+
+- **Three-number bench summary in the LoCoMo runner.** The `_summary`
+  aggregate and the `overall` block of the result JSON now carry
+  `mean_latency_ms` (mean per-row retrieval + generation time),
+  `p95_latency_ms`, and `mean_context_tokens` (mean context chars sent to
+  the generator divided by 4). `_process_qa` stores `context_chars` per row
+  so the estimate is exact. `_print_summary` displays the triple on its own
+  line below the accuracy table. The existing accuracy columns (F1, BLEU-1,
+  Judge, R@K) are preserved without modification. Inspired by supermemory's
+  MemScore philosophy of never collapsing accuracy, latency, and context cost
+  into a single number.
+
 - **Admin surface: shelf lifecycle and A2A channel admin (taOS#774).** New
   `taosmd/admin.py` module and six HTTP endpoints gated behind the configured
   server token (fail-closed: 403 when no token is set, 401 on wrong token).

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -1090,6 +1090,7 @@ async def _process_qa(
         "judge": round(judge, 4),
         "retrieval_ms": round(retrieval_ms, 2),
         "gen_ms": round(gen_ms, 2),
+        "context_chars": len(context),
         "evidence_hits": _evidence_hits(hits, evidence),
         "evidence_total": len(evidence),
     }
@@ -1097,16 +1098,40 @@ async def _process_qa(
 
 def _summary(rows: list[dict]) -> dict:
     if not rows:
-        return {"count": 0, "f1": 0.0, "bleu1": 0.0, "judge": 0.0, "retrieval_recall": 0.0}
+        return {
+            "count": 0, "f1": 0.0, "bleu1": 0.0, "judge": 0.0, "retrieval_recall": 0.0,
+            "mean_latency_ms": 0.0, "p95_latency_ms": 0.0, "mean_context_tokens": 0.0,
+        }
     n = len(rows)
     hit_rows = [r for r in rows if r.get("evidence_total", 0) > 0]
     recall = (sum(1 for r in hit_rows if r["evidence_hits"] > 0) / len(hit_rows)) if hit_rows else 0.0
+
+    # Per-row total latency = retrieval + generation (ms). Both fields are
+    # present on every row emitted by _process_qa; default to 0.0 for rows
+    # loaded from older result files that predate context_chars.
+    latencies = sorted(
+        r.get("retrieval_ms", 0.0) + r.get("gen_ms", 0.0) for r in rows
+    )
+    mean_lat = sum(latencies) / n
+    # p95: index at floor(0.95 * n) — 0-based into the sorted list, clamped
+    # to the last element. With n=1 this is index 0, which is correct.
+    p95_idx = min(int(math.floor(0.95 * n)), n - 1)
+    p95_lat = latencies[p95_idx]
+
+    # Context token estimate: total context chars / 4 (rough GPT-2-era heuristic,
+    # good enough for magnitude comparisons in bench summaries).
+    mean_ctx_chars = sum(r.get("context_chars", 0) for r in rows) / n
+    mean_ctx_tokens = mean_ctx_chars / 4.0
+
     return {
         "count": n,
         "f1": round(sum(r["f1"] for r in rows) / n, 4),
         "bleu1": round(sum(r["bleu1"] for r in rows) / n, 4),
         "judge": round(sum(r["judge"] for r in rows) / n, 4),
         "retrieval_recall": round(recall, 4),
+        "mean_latency_ms": round(mean_lat, 1),
+        "p95_latency_ms": round(p95_lat, 1),
+        "mean_context_tokens": round(mean_ctx_tokens, 1),
     }
 
 
@@ -1169,6 +1194,14 @@ def _print_summary(meta: dict, by_category: dict, overall: dict) -> None:
     print(f"{'Overall':<16} {overall['count']:>5} {overall['f1']:>7.2f} "
           f"{overall['bleu1']:>8.2f} {overall['judge']:>8.2f} "
           f"{overall['retrieval_recall']:>8.2f}")
+    print(sep)
+    # Three-number performance summary (accuracy / latency / context size).
+    # Never collapsed to a single score \u2014 each dimension is independent signal.
+    print(
+        f"Latency  p50={overall.get('mean_latency_ms', 0.0):.0f} ms  "
+        f"p95={overall.get('p95_latency_ms', 0.0):.0f} ms  |  "
+        f"Context ~{overall.get('mean_context_tokens', 0.0):.0f} tok/query (mean)"
+    )
     print(sep)
 
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -51,7 +51,13 @@ Endpoints
 ``GET  /ui``               -> alias of ``GET /``
 ``GET  /health``           -> ``{"status": "ok", "version": <str>}``
 ``POST /ingest``           ``{"text", "agent", "project"?}`` -> ingest result
-``POST /ingest/batch``     ``{"items": [{"text", "id"?, "metadata"?}], "agent", "project"?}`` -> ``{"ingested", "skipped", ...}``
+                           Metadata note: callers may include ``forget_after`` (unix float) and
+                           ``forget_reason`` (str) in the user metadata dict.  Rows whose
+                           ``forget_after`` has passed are hidden from retrieval (zero-loss:
+                           the raw row is never deleted).
+``POST /ingest/batch``     ``{"items": [{"text", "id"?, "metadata"?: {"forget_after"?: float, "forget_reason"?: str, ...}}], "agent", "project"?}`` -> ``{"ingested", "skipped", ...}``
+                           Per-item ``metadata`` may include ``forget_after`` (unix float) and
+                           ``forget_reason`` (str) with the same TTL semantics as single ingest.
 ``POST /search``           ``{"query", "agent", "limit"?, "project"?, "also_include"?, "mode"?}`` -> ``{"hits": [...]}``
 ``GET  /search?q=&agent=&limit=&project=&also_include=a,b&mode=bm25``  -> ``{"hits": [...]}``
 ``GET  /projects``                                         -> ``{"projects": [...]}``

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -554,26 +554,58 @@ class VectorMemory:
         self._bm25_dirty = True  # corpus changed; invalidate BM25 cache
         return cursor.lastrowid
 
-    def _load_active_rows(self, project: str | None = None, search_agents: list[str] | None = None):
+    def _load_active_rows(
+        self,
+        project: str | None = None,
+        search_agents: list[str] | None = None,
+        now: float | None = None,
+    ):
         """Fetch active (non-superseded) rows, scoped by project/agent.
 
         Untagged rows are kept by both filters so pre-project / standalone
         memory is never hidden. Shared by the semantic and BM25-only paths so
         scoping rules cannot drift between them.
+
+        TTL filter: rows whose metadata ``forget_after`` is a number and is
+        less than ``now`` are excluded from retrieval exactly like superseded
+        rows. The raw row is never deleted (zero-loss); only recall hides it.
+        Non-numeric or missing ``forget_after`` values are silently ignored so
+        existing memories are never affected. ``now`` defaults to
+        ``time.time()``; pass an explicit float in tests to control the clock.
         """
+        if now is None:
+            now = time.time()
+
         rows = self._conn.execute(
             "SELECT id, text, embedding, metadata_json, created_at FROM vector_memory "
             "WHERE valid_to IS NULL"
         ).fetchall()
 
-        if project is not None or search_agents is not None:
-            filtered = []
-            agent_set = set(search_agents) if search_agents else None
-            for row in rows:
+        filtered = []
+        agent_set = set(search_agents) if search_agents else None
+        for row in rows:
+            try:
+                meta = json.loads(row["metadata_json"])
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+
+            # TTL filter: if forget_after is a valid number and has passed,
+            # exclude the row from active recall. Non-numeric values are
+            # ignored (row stays visible) with a debug log so bad metadata
+            # never silently hides memories.
+            fa = meta.get("forget_after")
+            if fa is not None:
                 try:
-                    meta = json.loads(row["metadata_json"])
-                except (json.JSONDecodeError, TypeError):
-                    meta = {}
+                    if float(fa) < now:
+                        continue
+                except (TypeError, ValueError):
+                    logger.debug(
+                        "ignore non-numeric forget_after=%r on row id=%s",
+                        fa,
+                        row["id"],
+                    )
+
+            if project is not None or search_agents is not None:
                 # Project filter: skip rows positively tagged with a different
                 # project. Untagged (pre-project) rows are kept so existing
                 # standalone memory is never hidden.
@@ -585,9 +617,9 @@ class VectorMemory:
                 row_agent = meta.get("agent")
                 if agent_set is not None and row_agent is not None and row_agent not in agent_set:
                     continue
-                filtered.append(row)
-            rows = filtered
-        return rows
+
+            filtered.append(row)
+        return filtered
 
     def existing_source_ids(self, agent: str | None = None) -> set[str]:
         """Return the user-metadata ``source_id`` values already stored.

--- a/tests/test_locomo_memscore.py
+++ b/tests/test_locomo_memscore.py
@@ -1,0 +1,225 @@
+"""Tests for the three-number bench summary (MemScore-style) in locomo_runner.
+
+Covers:
+  - _summary returns mean_latency_ms, p95_latency_ms, mean_context_tokens.
+  - _print_summary emits a latency/context line alongside the accuracy table.
+  - Empty rows return zeros without crashing.
+  - p95 is correctly computed over sorted latencies.
+  - context_chars / 4 estimate is applied correctly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER_PATH = REPO_ROOT / "benchmarks" / "locomo_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("locomo_runner", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _capture(fn):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        fn()
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_empty_returns_zero_memscore_fields():
+    runner = _load_runner()
+    s = runner._summary([])
+    assert s["mean_latency_ms"] == 0.0
+    assert s["p95_latency_ms"] == 0.0
+    assert s["mean_context_tokens"] == 0.0
+    assert s["count"] == 0
+
+
+def test_summary_single_row():
+    runner = _load_runner()
+    row = {
+        "f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+        "retrieval_ms": 200.0, "gen_ms": 800.0,
+        "context_chars": 400,
+        "evidence_hits": 0, "evidence_total": 0,
+    }
+    s = runner._summary([row])
+    assert s["mean_latency_ms"] == 1000.0
+    assert s["p95_latency_ms"] == 1000.0
+    assert s["mean_context_tokens"] == 100.0  # 400 / 4
+
+
+def test_summary_multiple_rows_mean_latency():
+    runner = _load_runner()
+    rows = [
+        {"f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+         "retrieval_ms": 100.0, "gen_ms": 900.0, "context_chars": 800,
+         "evidence_hits": 0, "evidence_total": 0},
+        {"f1": 0.4, "bleu1": 0.3, "judge": 0.5,
+         "retrieval_ms": 200.0, "gen_ms": 300.0, "context_chars": 400,
+         "evidence_hits": 0, "evidence_total": 0},
+    ]
+    s = runner._summary(rows)
+    # Mean latency: (1000 + 500) / 2 = 750
+    assert s["mean_latency_ms"] == 750.0
+    # Mean context tokens: (800/4 + 400/4) / 2 = (200 + 100) / 2 = 150
+    assert s["mean_context_tokens"] == 150.0
+
+
+def test_summary_p95_with_20_rows():
+    """p95 index = floor(0.95 * 20) = 19 (last element when sorted)."""
+    runner = _load_runner()
+    rows = []
+    for i in range(20):
+        rows.append({
+            "f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+            "retrieval_ms": float(i * 10), "gen_ms": 0.0, "context_chars": 100,
+            "evidence_hits": 0, "evidence_total": 0,
+        })
+    s = runner._summary(rows)
+    # Sorted latencies: [0, 10, 20, ..., 190]. p95 index = min(floor(0.95*20), 19) = 19.
+    assert s["p95_latency_ms"] == 190.0
+
+
+def test_summary_p95_with_10_rows():
+    """p95 index = floor(0.95 * 10) = 9 (last element) for 10 rows."""
+    runner = _load_runner()
+    rows = []
+    for i in range(10):
+        rows.append({
+            "f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+            "retrieval_ms": float(i + 1) * 100.0, "gen_ms": 0.0, "context_chars": 0,
+            "evidence_hits": 0, "evidence_total": 0,
+        })
+    s = runner._summary(rows)
+    # Sorted latencies: [100, 200, ..., 1000]. p95 idx = min(9, 9) = 9.
+    assert s["p95_latency_ms"] == 1000.0
+
+
+def test_summary_context_tokens_estimate():
+    """mean_context_tokens = mean(context_chars) / 4."""
+    runner = _load_runner()
+    rows = [
+        {"f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+         "retrieval_ms": 0.0, "gen_ms": 0.0, "context_chars": 1200,
+         "evidence_hits": 0, "evidence_total": 0},
+        {"f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+         "retrieval_ms": 0.0, "gen_ms": 0.0, "context_chars": 800,
+         "evidence_hits": 0, "evidence_total": 0},
+    ]
+    s = runner._summary(rows)
+    # mean chars = 1000, tokens = 1000 / 4 = 250
+    assert s["mean_context_tokens"] == 250.0
+
+
+def test_summary_missing_context_chars_defaults_to_zero():
+    """Rows from older result files without context_chars default to 0."""
+    runner = _load_runner()
+    row = {
+        "f1": 0.5, "bleu1": 0.4, "judge": 0.6,
+        "retrieval_ms": 100.0, "gen_ms": 200.0,
+        # No context_chars key
+        "evidence_hits": 0, "evidence_total": 0,
+    }
+    s = runner._summary([row])
+    assert s["mean_context_tokens"] == 0.0
+    assert s["mean_latency_ms"] == 300.0
+
+
+# ---------------------------------------------------------------------------
+# _print_summary
+# ---------------------------------------------------------------------------
+
+
+def _make_meta(**overrides):
+    base = {
+        "git_sha": "abc1234",
+        "conversations": 2,
+        "total_qa": 5,
+        "model": "qwen3:4b",
+        "strategy": "vector-only",
+        "top_k": 10,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_overall(**overrides):
+    base = {
+        "count": 5,
+        "f1": 0.55,
+        "bleu1": 0.42,
+        "judge": 0.61,
+        "retrieval_recall": 0.78,
+        "mean_latency_ms": 1200.0,
+        "p95_latency_ms": 2500.0,
+        "mean_context_tokens": 320.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_print_summary_includes_latency_line():
+    runner = _load_runner()
+    overall = _make_overall()
+    meta = _make_meta()
+    out = _capture(lambda: runner._print_summary(meta, {}, overall))
+    assert "Latency" in out or "latency" in out.lower()
+    assert "p95" in out or "P95" in out
+    assert "1200" in out or "1200.0" in out  # mean latency
+    assert "2500" in out or "2500.0" in out  # p95
+
+
+def test_print_summary_includes_context_tokens():
+    runner = _load_runner()
+    overall = _make_overall()
+    meta = _make_meta()
+    out = _capture(lambda: runner._print_summary(meta, {}, overall))
+    # Context token count should appear
+    assert "320" in out
+
+
+def test_print_summary_still_has_accuracy_table():
+    """The existing accuracy columns must not be removed."""
+    runner = _load_runner()
+    overall = _make_overall()
+    by_cat = {
+        "1": {
+            "count": 3, "f1": 0.60, "bleu1": 0.45,
+            "judge": 0.70, "retrieval_recall": 0.80,
+            "mean_latency_ms": 1000.0, "p95_latency_ms": 2000.0,
+            "mean_context_tokens": 300.0,
+        }
+    }
+    meta = _make_meta()
+    out = _capture(lambda: runner._print_summary(meta, by_cat, overall))
+    assert "F1" in out
+    assert "Judge" in out
+    assert "R@K" in out
+    assert "Overall" in out
+    assert "Single-hop" in out
+
+
+def test_print_summary_zero_latency_does_not_crash():
+    """Overall with all zeros must print without errors."""
+    runner = _load_runner()
+    overall = _make_overall(
+        mean_latency_ms=0.0, p95_latency_ms=0.0, mean_context_tokens=0.0,
+    )
+    meta = _make_meta()
+    out = _capture(lambda: runner._print_summary(meta, {}, overall))
+    assert "Latency" in out or "latency" in out.lower()

--- a/tests/test_ttl_filter.py
+++ b/tests/test_ttl_filter.py
@@ -1,0 +1,221 @@
+"""Tests for retrieval-time TTL filter (forget_after / forget_reason).
+
+The forget_after field lives in user metadata; no schema change is needed.
+Behaviour contract:
+  - Expired row (forget_after < now): invisible to search() and search_bm25().
+  - Future-dated row (forget_after > now): visible.
+  - Non-numeric forget_after: ignored, row stays visible.
+  - Row without forget_after: always visible.
+  - Zero-loss: the raw row is never deleted; it still exists in the DB.
+  - Batch ingest with forget_after round-trips through metadata.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+
+from taosmd.vector_memory import VectorMemory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_embedder(vmem: VectorMemory) -> None:
+    """Patch embed() with a deterministic 16-dim hash vector (no ONNX/QMD)."""
+
+    async def _embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFFFFFFFFFF
+        return [((h >> (i * 3)) & 0xFF) / 255.0 - 0.5 for i in range(16)]
+
+    vmem.embed = _embed  # type: ignore[assignment]
+
+
+def _make_store(tmp_path) -> VectorMemory:
+    vmem = VectorMemory(
+        db_path=str(tmp_path / "vec.db"),
+        embed_mode="onnx",
+    )
+    asyncio.run(vmem.init())
+    _fake_embedder(vmem)
+    return vmem
+
+
+def _row_count(db_path) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute("SELECT COUNT(*) FROM vector_memory").fetchone()[0]
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_expired_row_invisible_to_search(tmp_path):
+    """An expired row is excluded from semantic search results."""
+    vmem = _make_store(tmp_path)
+    try:
+        past = time.time() - 3600  # one hour ago
+        rid = asyncio.run(
+            vmem.add("expired fact about cats", metadata={"forget_after": past})
+        )
+        asyncio.run(vmem.add("active fact about dogs"))
+
+        now = time.time()
+        # Pass explicit now to exercise the clock override path.
+        rows = vmem._load_active_rows(now=now)
+        ids = {r["id"] for r in rows}
+        assert rid not in ids, "expired row must be hidden from _load_active_rows"
+
+        hits = asyncio.run(vmem.search("cats", limit=10, hybrid=False, fusion="none"))
+        assert all(h["id"] != rid for h in hits), "expired row must be absent from search()"
+    finally:
+        asyncio.run(vmem.close())
+
+    # Zero-loss: the row is still in the database.
+    assert _row_count(tmp_path / "vec.db") == 2
+
+
+def test_expired_row_invisible_to_search_bm25(tmp_path):
+    """An expired row is excluded from BM25 search results."""
+    vmem = _make_store(tmp_path)
+    try:
+        past = time.time() - 3600
+        rid = asyncio.run(
+            vmem.add("expired keyword text here", metadata={"forget_after": past})
+        )
+        asyncio.run(vmem.add("active keyword text here"))
+
+        hits = asyncio.run(vmem.search_bm25("keyword", limit=10))
+        assert all(h["id"] != rid for h in hits), "expired row must be absent from search_bm25()"
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_future_dated_row_visible(tmp_path):
+    """A row with forget_after in the future is visible in search results."""
+    vmem = _make_store(tmp_path)
+    try:
+        future = time.time() + 86400  # tomorrow
+        rid = asyncio.run(
+            vmem.add("future fact about trains", metadata={"forget_after": future})
+        )
+
+        rows = vmem._load_active_rows()
+        ids = {r["id"] for r in rows}
+        assert rid in ids, "future-dated row must remain active"
+
+        hits = asyncio.run(vmem.search("trains", limit=10, hybrid=False, fusion="none"))
+        assert any(h["id"] == rid for h in hits), "future-dated row must appear in search()"
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_non_numeric_forget_after_is_ignored(tmp_path):
+    """A non-numeric forget_after value is silently ignored; row stays visible."""
+    vmem = _make_store(tmp_path)
+    try:
+        rid = asyncio.run(
+            vmem.add("row with bad ttl", metadata={"forget_after": "not-a-number"})
+        )
+
+        rows = vmem._load_active_rows()
+        ids = {r["id"] for r in rows}
+        assert rid in ids, "non-numeric forget_after must not hide the row"
+
+        hits = asyncio.run(vmem.search("bad ttl", limit=10, hybrid=False, fusion="none"))
+        assert any(h["id"] == rid for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_row_without_forget_after_always_visible(tmp_path):
+    """Rows with no forget_after field are unaffected by the TTL filter."""
+    vmem = _make_store(tmp_path)
+    try:
+        rid = asyncio.run(vmem.add("plain row no ttl"))
+
+        rows = vmem._load_active_rows()
+        assert any(r["id"] == rid for r in rows)
+
+        hits = asyncio.run(vmem.search("plain row", limit=5, hybrid=False, fusion="none"))
+        assert any(h["id"] == rid for h in hits)
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_forget_reason_stored_in_metadata(tmp_path):
+    """forget_reason is stored in metadata and round-trips correctly."""
+    vmem = _make_store(tmp_path)
+    try:
+        future = time.time() + 86400
+        rid = asyncio.run(
+            vmem.add(
+                "fact with reason",
+                metadata={"forget_after": future, "forget_reason": "test cleanup"},
+            )
+        )
+
+        hits = asyncio.run(vmem.search("fact with reason", limit=5, hybrid=False, fusion="none"))
+        matching = [h for h in hits if h["id"] == rid]
+        assert matching, "row must be visible (future-dated)"
+        meta = matching[0]["metadata"]
+        assert meta.get("forget_reason") == "test cleanup"
+        assert meta.get("forget_after") == future
+    finally:
+        asyncio.run(vmem.close())
+
+
+def test_batch_items_with_forget_after_round_trip(tmp_path):
+    """Batch-ingested items with forget_after respect the TTL at retrieval."""
+    # Simulate the batch ingest path by adding items individually (same code
+    # path as api.ingest_batch which calls vmem.add per item with its metadata).
+    vmem = _make_store(tmp_path)
+    try:
+        past = time.time() - 60
+        future = time.time() + 86400
+
+        rid_expired = asyncio.run(
+            vmem.add("batch item expired", metadata={"source_id": "b1", "forget_after": past})
+        )
+        rid_active = asyncio.run(
+            vmem.add("batch item active", metadata={"source_id": "b2", "forget_after": future})
+        )
+        rid_plain = asyncio.run(vmem.add("batch item no ttl", metadata={"source_id": "b3"}))
+
+        rows = vmem._load_active_rows()
+        ids = {r["id"] for r in rows}
+        assert rid_expired not in ids, "expired batch item must be hidden"
+        assert rid_active in ids, "future-dated batch item must be visible"
+        assert rid_plain in ids, "plain batch item must be visible"
+    finally:
+        asyncio.run(vmem.close())
+
+    # All three raw rows must still exist (zero-loss).
+    assert _row_count(tmp_path / "vec.db") == 3
+
+
+def test_ttl_filter_uses_now_override(tmp_path):
+    """Passing an explicit now value controls which rows are expired."""
+    vmem = _make_store(tmp_path)
+    try:
+        fixed_ts = 1_000_000.0
+        rid = asyncio.run(
+            vmem.add("time-controlled row", metadata={"forget_after": fixed_ts + 1})
+        )
+
+        # Before expiry: row visible.
+        rows_before = vmem._load_active_rows(now=fixed_ts)
+        assert any(r["id"] == rid for r in rows_before)
+
+        # After expiry: row hidden.
+        rows_after = vmem._load_active_rows(now=fixed_ts + 2)
+        assert all(r["id"] != rid for r in rows_after)
+    finally:
+        asyncio.run(vmem.close())


### PR DESCRIPTION
## Summary

- **Feature 1: retrieval-time TTL filter.** `VectorMemory.add` now accepts `forget_after` (unix float) and `forget_reason` (str) in user metadata. `_load_active_rows` excludes rows whose `forget_after` has passed, exactly like superseded rows. Zero-loss: the raw row is never deleted. Non-numeric values are silently ignored. `POST /ingest` and `POST /ingest/batch` docstrings document the new fields. Inspired by supermemory's `forgetAfter` concept.

- **Feature 2: three-number bench summary.** `_summary`, the `overall` JSON block, and `_print_summary` in `locomo_runner.py` now emit `mean_latency_ms`, `p95_latency_ms`, and `mean_context_tokens` (context chars / 4 per row). `_process_qa` stores `context_chars` per row. Existing accuracy columns (F1, BLEU-1, Judge, R@K) are untouched. Inspired by supermemory's MemScore philosophy of not collapsing three independent dimensions.

## Files changed

- `taosmd/vector_memory.py` -- `_load_active_rows` gains TTL filter + optional `now` param
- `taosmd/http_server.py` -- endpoint docstring updated with `forget_after`/`forget_reason` note
- `benchmarks/locomo_runner.py` -- `_summary`, `_print_summary`, `_process_qa` updated
- `CHANGELOG.md` -- two new Unreleased entries
- `tests/test_ttl_filter.py` -- 8 tests for the TTL filter
- `tests/test_locomo_memscore.py` -- 11 tests for the bench summary

## Test plan

- [x] `python3 -m pytest tests/test_ttl_filter.py tests/test_locomo_memscore.py -v` -- 19 passed
- [x] Full suite `python3 -m pytest --timeout=60 -q` -- 778 passed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory expiration control: records can now specify when they should no longer appear in search results while preserving raw data.
  * Enhanced benchmark metrics: performance reports now include latency percentiles and estimated context token usage.

* **Documentation**
  * Updated REST API documentation to reflect new optional metadata fields for memory ingestion.

* **Tests**
  * Added comprehensive test coverage for memory expiration behavior and benchmark metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->