### PR TITLE
feat(retrieval): temporal date range lever, default off

### DIFF
--- a/benchmarks/temporal_applicability_scan.py
+++ b/benchmarks/temporal_applicability_scan.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""E-005 Stage 1: applicability scan for the temporal date-range lever.
+
+Counts how many LoCoMo questions contain a date-range expression the
+lever can parse (taosmd/temporal.py). The pre-registered gate in
+docs/research-report.md keys on the temporal category (2): under 10
+percent applicability means LoCoMo cannot measure the lever and no
+LoCoMo claim is made in either direction.
+
+Usage: python3 benchmarks/temporal_applicability_scan.py [path/to/locomo10.json]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+_BENCH_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_BENCH_DIR)
+sys.path.insert(0, _REPO_ROOT)
+
+from taosmd.temporal import (  # noqa: E402
+    extract_temporal_expression,
+    parse_temporal_expression,
+)
+
+_DEFAULT_DATASET = os.path.join(
+    _REPO_ROOT, "data", "locomo", "data", "locomo10.json"
+)
+
+INCLUDE_CATS = {1, 2, 3, 4}
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else _DEFAULT_DATASET
+    with open(path) as f:
+        data = json.load(f)
+
+    total = 0
+    by_cat: dict[int, int] = {}
+    hits_by_cat: dict[int, int] = {}
+    for conv in data:
+        for qa in conv.get("qa", []):
+            cat = qa.get("category")
+            if cat not in INCLUDE_CATS:
+                continue
+            total += 1
+            by_cat[cat] = by_cat.get(cat, 0) + 1
+            expr = extract_temporal_expression(qa.get("question", ""))
+            if expr and parse_temporal_expression(expr):
+                hits_by_cat[cat] = hits_by_cat.get(cat, 0) + 1
+
+    print(f"total questions (cats 1-4): {total}")
+    for cat in sorted(by_cat):
+        h = hits_by_cat.get(cat, 0)
+        pct = 100 * h / by_cat[cat]
+        print(f"  cat {cat}: {h}/{by_cat[cat]} applicable ({pct:.1f}%)")
+    allh = sum(hits_by_cat.values())
+    print(f"  overall: {allh}/{total} ({100 * allh / total:.1f}%)")
+    temporal_pct = 100 * hits_by_cat.get(2, 0) / max(1, by_cat.get(2, 0))
+    verdict = "MEASURABLE" if temporal_pct >= 10.0 else "NOT MEASURABLE on LoCoMo"
+    print(f"E-005 STAGE 1 VERDICT: temporal-category applicability "
+          f"{temporal_pct:.1f}%; gate 10%; {verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/taosmd/retrieval.py
+++ b/taosmd/retrieval.py
@@ -677,6 +677,7 @@ async def retrieve(
     group_key: str | None = None,
     project: str | None = None,
     search_agents: list[str] | None = None,
+    temporal: dict | None = None,
 ) -> list[dict]:
     """Retrieve relevant results from available memory sources.
 
@@ -739,6 +740,37 @@ async def retrieve(
             same group as their host hit (e.g. ``"session"``). When ``None``
             (default), neighbours can cross group boundaries, matching the
             LoCoMo benchmark's behaviour where ``turn_idx`` is global.
+        temporal: Optional dict enabling natural-language date-range filtering
+            or score boosting as a retrieval post-stage.  Default ``None``
+            (off).
+
+            When supplied it must be a dict with the following keys:
+
+            * ``window`` (str, optional): explicit temporal expression, e.g.
+              ``"in May 2023"`` or ``"last week"``.  Takes precedence over
+              auto-scan.
+            * ``auto`` (bool, default False): when True and no ``window`` is
+              given, scan the query for an embedded expression automatically.
+            * ``mode`` (str, default ``"boost"``): ``"boost"`` multiplies
+              in-range hit scores by ``(1 + boost)`` and re-sorts; ``"filter"``
+              drops out-of-range hits.
+            * ``boost`` (float, default 0.25): boost multiplier (boost mode
+              only).
+            * ``reference``: reference "now" for relative expressions such as
+              ``"last month"``.  Accepts epoch float, ISO string, LoCoMo
+              conversation format (``"8:56 pm on 20 July, 2023"``), or a
+              datetime instance.  Defaults to the real clock.
+            * ``datetime_keys`` (list[str], default ``["datetime",
+              "created_at"]``): metadata keys checked in order per hit for
+              its timestamp.
+
+            Both modes are fail-open: hits with no parseable timestamp are
+            kept unchanged, and if filtering would leave zero hits the
+            original list is returned intact.
+
+            **Default is off**: full-scale validation on LoCoMo-1540 is
+            still pending.  Enabling this without benchmarking on your data
+            is discouraged.
 
     Returns:
         List of normalised result dicts, sorted by relevance, length <= limit.
@@ -789,6 +821,10 @@ async def retrieve(
         if verify and is_task_enabled(agent_name, "verification"):
             results = await _apply_verification(query, results, agent_name)
 
+        if temporal:
+            from taosmd.temporal import apply_temporal_stage  # noqa: PLC0415
+            results = apply_temporal_stage(results, temporal, query, logger=logger)
+
         results = results[:limit]
         if adjacent_neighbors > 0:
             results = await _attach_neighbors(
@@ -818,6 +854,10 @@ async def retrieve(
             merged = _rrf_merge([results, secondary_results])
             results = _deduplicate(merged)
 
+        if temporal:
+            from taosmd.temporal import apply_temporal_stage  # noqa: PLC0415
+            results = apply_temporal_stage(results, temporal, query, logger=logger)
+
         results = results[:limit]
         if adjacent_neighbors > 0:
             results = await _attach_neighbors(
@@ -838,6 +878,10 @@ async def retrieve(
             first_name, first_src = next(iter(sources.items()))
             results = await _query_source(first_name, first_src, query, fetch_limit,
                                           fusion=fusion, candidate_limit=candidate_top_k)
+
+        if temporal:
+            from taosmd.temporal import apply_temporal_stage  # noqa: PLC0415
+            results = apply_temporal_stage(results, temporal, query, logger=logger)
 
         results = results[:limit]
         if adjacent_neighbors > 0:
@@ -875,6 +919,10 @@ async def retrieve(
 
         if llm_reranker is not None:
             results = await _apply_llm_rerank(query, results, llm_reranker, limit)
+
+        if temporal:
+            from taosmd.temporal import apply_temporal_stage  # noqa: PLC0415
+            results = apply_temporal_stage(results, temporal, query, logger=logger)
 
         results = results[:limit]
         if adjacent_neighbors > 0:

--- a/taosmd/temporal.py
+++ b/taosmd/temporal.py
@@ -240,14 +240,14 @@ def parse_temporal_expression(
     if m:
         return _quarter_range(int(m.group(2)), int(m.group(1)))
 
-    # "before <expr>" — from datetime.min to inner.from
+    # "before <expr>": from datetime.min to inner.from
     m = re.fullmatch(r"before\s+(.+)", inp)
     if m:
         inner = parse_temporal_expression(m.group(1), ref)
         if inner:
             return datetime.min, inner[0]
 
-    # "after <expr>" — from inner.to to ref
+    # "after <expr>": from inner.to to ref
     m = re.fullmatch(r"after\s+(.+)", inp)
     if m:
         inner = parse_temporal_expression(m.group(1), ref)
@@ -530,17 +530,27 @@ def _apply_temporal_stage_inner(
             return hits
         return filtered
 
-    # Boost mode (default).
+    # Boost mode (default).  Hits carry "score" on most paths but only
+    # "rrf_score" after an RRF merge, so boost whichever is present.
+    def _score_key(hit: dict) -> str | None:
+        if "score" in hit:
+            return "score"
+        if "rrf_score" in hit:
+            return "rrf_score"
+        return None
+
     modified = list(hits)
     for hit in modified:
         dt = _resolve_hit_dt(hit)
         if dt is None:
             continue
         if from_dt <= dt <= to_dt:
-            current_score = hit.get("score", 0.0)
-            if "score" in hit:
-                hit["score"] = current_score * (1.0 + boost_factor)
+            key = _score_key(hit)
+            if key is not None:
+                hit[key] = hit[key] * (1.0 + boost_factor)
 
-    # Re-sort descending by score.
-    modified.sort(key=lambda h: h.get("score", 0.0), reverse=True)
+    # Re-sort descending by whichever score key each hit carries.
+    modified.sort(
+        key=lambda h: h.get("score", h.get("rrf_score", 0.0)), reverse=True
+    )
     return modified

--- a/taosmd/temporal.py
+++ b/taosmd/temporal.py
@@ -1,0 +1,546 @@
+"""Natural language temporal expression parsing for retrieval-time date filtering.
+
+This module is the retrieval-time complement to temporal_boost.py.  Where
+temporal_boost reranks by keyword signals, this module parses *explicit* date
+range expressions from the query and applies them as a precision filter or
+score boost.
+
+The lever is default-off: pass ``temporal={"window": "...", "mode": "filter"}``
+(or ``"mode": "boost"``) to ``retrieve()`` to activate it.  Full-scale
+validation on LoCoMo-1540 is still pending.
+
+Functions
+---------
+parse_temporal_expression(expression, now) -> (from_dt, to_dt) | None
+extract_temporal_expression(query) -> str | None
+parse_hit_datetime(value) -> datetime | None
+apply_temporal_stage(hits, temporal, query, logger) -> list[dict]
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+# ---------------------------------------------------------------------------
+# Month name lookup
+# ---------------------------------------------------------------------------
+
+_MONTHS: dict[str, int] = {
+    "january": 0, "february": 1, "march": 2, "april": 3,
+    "may": 4, "june": 5, "july": 6, "august": 7,
+    "september": 8, "october": 9, "november": 10, "december": 11,
+    "jan": 0, "feb": 1, "mar": 2, "apr": 3,
+    # "may" intentionally absent as 3-letter alias: too many false positives
+    # as a modal verb.  Only matched via full name or explicit date patterns.
+    "jun": 5, "jul": 6, "aug": 7, "sep": 8, "sept": 8,
+    "oct": 9, "nov": 10, "dec": 11,
+}
+
+_MONTH_PATTERN = "|".join(sorted(_MONTHS.keys(), key=len, reverse=True))
+
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+
+
+def _day_range(d: datetime) -> tuple[datetime, datetime]:
+    """Full-day range 00:00:00.000000 through 23:59:59.999999."""
+    start = d.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = d.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return start, end
+
+
+def _week_range(d: datetime) -> tuple[datetime, datetime]:
+    """Monday-through-Sunday week range containing d.
+
+    weekday() returns 0 for Monday, 6 for Sunday, so Monday offset = -weekday().
+    """
+    monday = d - timedelta(days=d.weekday())
+    start = monday.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = (monday + timedelta(days=6)).replace(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
+    return start, end
+
+
+def _month_range(year: int, month_0: int) -> tuple[datetime, datetime]:
+    """Full range for a calendar month (month_0 is 0-based January)."""
+    month_1 = month_0 + 1
+    start = datetime(year, month_1, 1, 0, 0, 0, 0)
+    # Last day: first day of next month minus one day.
+    if month_1 == 12:
+        last_day = datetime(year, 12, 31)
+    else:
+        last_day = datetime(year, month_1 + 1, 1) - timedelta(days=1)
+    end = last_day.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return start, end
+
+
+def _year_range(year: int) -> tuple[datetime, datetime]:
+    """Full calendar year range."""
+    start = datetime(year, 1, 1, 0, 0, 0, 0)
+    end = datetime(year, 12, 31, 23, 59, 59, 999999)
+    return start, end
+
+
+def _quarter_range(year: int, quarter: int) -> tuple[datetime, datetime]:
+    """Q1-Q4 range (1-based quarter)."""
+    start_month_0 = (quarter - 1) * 3  # 0-based
+    # Quarter spans 3 months: start_month_0 through start_month_0+2.
+    end_month_0 = start_month_0 + 2
+    start = datetime(year, start_month_0 + 1, 1, 0, 0, 0, 0)
+    return_end = _month_range(year, end_month_0)[1]
+    return start, return_end
+
+
+def _ago_range(ref: datetime, amount: int, unit: str) -> tuple[datetime, datetime]:
+    """Range from <amount> <unit>s before ref (floored to day-start) through ref."""
+    if unit == "day":
+        from_dt = ref - timedelta(days=amount)
+    elif unit == "week":
+        from_dt = ref - timedelta(weeks=amount)
+    elif unit == "month":
+        # Same calendar day in the past month; clamp to month-end if needed.
+        year = ref.year
+        month = ref.month - amount
+        while month <= 0:
+            month += 12
+            year -= 1
+        import calendar
+        max_day = calendar.monthrange(year, month)[1]
+        day = min(ref.day, max_day)
+        from_dt = ref.replace(year=year, month=month, day=day)
+    elif unit == "hour":
+        from_dt = ref - timedelta(hours=amount)
+    else:
+        from_dt = ref - timedelta(days=amount)
+
+    from_dt = from_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    return from_dt, ref
+
+
+# ---------------------------------------------------------------------------
+# Public: parse_temporal_expression
+# ---------------------------------------------------------------------------
+
+
+def parse_temporal_expression(
+    expression: str,
+    now: datetime | None = None,
+) -> tuple[datetime, datetime] | None:
+    """Parse a natural-language temporal expression into a (from, to) range.
+
+    Args:
+        expression: A temporal expression such as "last week", "in May 2023",
+            "3 days ago", "Q1 2026", "8 May 2023", "before last month".
+        now: Reference datetime (naive).  Defaults to datetime.now().
+            Always pass an explicit value in tests for determinism.
+
+    Returns:
+        A (from_dt, to_dt) tuple of naive datetimes, or None if the
+        expression cannot be parsed.
+    """
+    ref = now if now is not None else datetime.now()
+    inp = expression.strip().lower()
+
+    # Simple keywords
+    if inp == "today":
+        return _day_range(ref)
+
+    if inp == "yesterday":
+        return _day_range(ref - timedelta(days=1))
+
+    if inp in ("this week", "last week"):
+        d = ref if inp == "this week" else ref - timedelta(days=7)
+        return _week_range(d)
+
+    if inp == "this month":
+        return _month_range(ref.year, ref.month - 1)
+
+    if inp == "last month":
+        d = ref
+        month_0 = d.month - 2  # subtract 1 for 0-based, 1 more for "last"
+        year = d.year
+        while month_0 < 0:
+            month_0 += 12
+            year -= 1
+        return _month_range(year, month_0)
+
+    if inp == "this year":
+        return _year_range(ref.year)
+
+    if inp == "last year":
+        return _year_range(ref.year - 1)
+
+    # "N days/weeks/months/hours ago"
+    m = re.fullmatch(
+        r"(\d+)\s+(day|days|week|weeks|month|months|hour|hours)\s+ago", inp
+    )
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).rstrip("s")
+        return _ago_range(ref, amount, unit)
+
+    # "last N days/weeks/months"
+    m = re.fullmatch(r"last\s+(\d+)\s+(day|days|week|weeks|month|months)", inp)
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).rstrip("s")
+        return _ago_range(ref, amount, unit)
+
+    # "in <month>" or "in <month>[,] [year]"
+    m = re.fullmatch(r"in\s+(" + _MONTH_PATTERN + r")(?:[,]?\s+(\d{4}))?", inp)
+    if m:
+        month_0 = _MONTHS[m.group(1)]
+        year = int(m.group(2)) if m.group(2) else ref.year
+        return _month_range(year, month_0)
+
+    # Explicit day dates: "8 May 2023", "8 May, 2023", "May 8 2023", "May 8, 2023",
+    # "on 8 May, 2023"
+    # Pattern: optional "on ", then either (day month [,] year) or (month day[,] year)
+    m = re.fullmatch(
+        r"(?:on\s+)?(\d{1,2})\s+(" + _MONTH_PATTERN + r")[,]?\s+(\d{4})", inp
+    )
+    if m:
+        day = int(m.group(1))
+        month_0 = _MONTHS[m.group(2)]
+        year = int(m.group(3))
+        try:
+            d = datetime(year, month_0 + 1, day)
+        except ValueError:
+            pass
+        else:
+            return _day_range(d)
+
+    m = re.fullmatch(
+        r"(?:on\s+)?(" + _MONTH_PATTERN + r")\s+(\d{1,2})[,]?\s+(\d{4})", inp
+    )
+    if m:
+        month_0 = _MONTHS[m.group(1)]
+        day = int(m.group(2))
+        year = int(m.group(3))
+        try:
+            d = datetime(year, month_0 + 1, day)
+        except ValueError:
+            pass
+        else:
+            return _day_range(d)
+
+    # Bare month name (must not be "may" without explicit context)
+    if inp in _MONTHS and inp != "may":
+        return _month_range(ref.year, _MONTHS[inp])
+
+    # "Q1 2026", "q2 2025"
+    m = re.fullmatch(r"q([1-4])\s+(\d{4})", inp)
+    if m:
+        return _quarter_range(int(m.group(2)), int(m.group(1)))
+
+    # "before <expr>" — from datetime.min to inner.from
+    m = re.fullmatch(r"before\s+(.+)", inp)
+    if m:
+        inner = parse_temporal_expression(m.group(1), ref)
+        if inner:
+            return datetime.min, inner[0]
+
+    # "after <expr>" — from inner.to to ref
+    m = re.fullmatch(r"after\s+(.+)", inp)
+    if m:
+        inner = parse_temporal_expression(m.group(1), ref)
+        if inner:
+            return inner[1], ref
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public: extract_temporal_expression
+# ---------------------------------------------------------------------------
+
+# Compiled regex: ordered longest/most-specific first.
+# Bare month names are only matched with an "in " prefix or inside explicit
+# dates to avoid false positives ("may" as modal verb, "May" as a name, etc.).
+_EXTRACT_RE = re.compile(
+    r"""
+    (?:
+        # before/after + inner expressions (recursive not possible here; match
+        # common single-token sub-expressions after the keyword)
+        \b(?:before|after)\s+
+        (?:
+            last\s+\d+\s+(?:day|days|week|weeks|month|months)
+            | \d+\s+(?:day|days|week|weeks|month|months|hour|hours)\s+ago
+            | (?:last|this)\s+(?:week|month|year)
+            | today|yesterday
+            | in\s+(?:""" + _MONTH_PATTERN + r""")(?:[,]?\s+\d{4})?
+            | (?:""" + _MONTH_PATTERN + r""")(?:[,]?\s+\d{4})?
+            | \d{1,2}\s+(?:""" + _MONTH_PATTERN + r""")[,]?\s+\d{4}
+            | (?:""" + _MONTH_PATTERN + r""")\s+\d{1,2}[,]?\s+\d{4}
+            | Q[1-4]\s+\d{4}
+        )
+        |
+        # "last N days/weeks/months" (before "last week/month/year" so longer wins)
+        \blast\s+\d+\s+(?:day|days|week|weeks|month|months)\b
+        |
+        # "N units ago"
+        \b\d+\s+(?:day|days|week|weeks|month|months|hour|hours)\s+ago\b
+        |
+        # "last/this week/month/year"
+        \b(?:last|this)\s+(?:week|month|year)\b
+        |
+        # today / yesterday
+        \b(?:today|yesterday)\b
+        |
+        # Quarters
+        \bQ[1-4]\s+\d{4}\b
+        |
+        # "in <month> [year]" (with optional comma before year)
+        \bin\s+(?:""" + _MONTH_PATTERN + r""")(?:[,]?\s+\d{4})?\b
+        |
+        # Explicit day dates with optional "on ": "8 May 2023", "May 8, 2023",
+        # "on 20 July, 2023"
+        \b(?:on\s+)?\d{1,2}\s+(?:""" + _MONTH_PATTERN + r""")[,]?\s+\d{4}\b
+        |
+        \b(?:on\s+)?(?:""" + _MONTH_PATTERN + r""")\s+\d{1,2}[,]?\s+\d{4}\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def extract_temporal_expression(query: str) -> str | None:
+    """Scan a natural-language query for the first embedded temporal expression.
+
+    Args:
+        query: A full query string such as "what did we discuss last week?".
+
+    Returns:
+        The matched substring (suitable for passing to parse_temporal_expression),
+        or None if no supported expression is found.
+
+    Note:
+        Bare month names are intentionally NOT matched as free-standing words
+        because "May" is too common as a name or modal verb.  They are matched
+        only inside "in <month>" or explicit date patterns.
+    """
+    m = _EXTRACT_RE.search(query)
+    return m.group(0).strip() if m else None
+
+
+# ---------------------------------------------------------------------------
+# Public: parse_hit_datetime
+# ---------------------------------------------------------------------------
+
+_LOCOMO_FORMATS = [
+    "%I:%M %p on %d %B, %Y",   # "8:56 pm on 20 July, 2023"
+    "%d %B, %Y",                # "20 July, 2023"
+    "%d %B %Y",                 # "20 July 2023"
+]
+
+
+def parse_hit_datetime(value: object) -> datetime | None:
+    """Parse a stored memory timestamp into a naive datetime.
+
+    Accepts:
+    - int or float: treated as POSIX epoch seconds.
+    - str that parses as float: same.
+    - ISO-8601 strings (with or without trailing "Z" or timezone offset).
+    - LoCoMo conversation format: "8:56 pm on 20 July, 2023".
+
+    Returns:
+        A naive datetime, or None if the value cannot be parsed.
+        Never raises.
+    """
+    if value is None:
+        return None
+
+    try:
+        # Numeric epoch
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(float(value))
+
+        if not isinstance(value, str):
+            return None
+
+        s = value.strip()
+        if not s:
+            return None
+
+        # String that looks like a float (epoch)
+        try:
+            return datetime.fromtimestamp(float(s))
+        except (ValueError, OSError, OverflowError):
+            pass
+
+        # ISO-8601: replace trailing Z, then strip tzinfo to keep naive
+        iso = s
+        if iso.endswith("Z"):
+            iso = iso[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(iso)
+            return dt.replace(tzinfo=None)
+        except ValueError:
+            pass
+
+        # LoCoMo conversation format: normalise am/pm to uppercase for strptime
+        # (strptime %p is locale-dependent; normalise to upper for safety)
+        s_norm = re.sub(r"\b(am|pm)\b", lambda mo: mo.group(0).upper(), s, flags=re.IGNORECASE)
+        for fmt in _LOCOMO_FORMATS:
+            try:
+                return datetime.strptime(s_norm, fmt)
+            except ValueError:
+                continue
+
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public: apply_temporal_stage
+# ---------------------------------------------------------------------------
+
+
+def apply_temporal_stage(
+    hits: list[dict],
+    temporal: dict,
+    query: str,
+    logger: "logging.Logger | None" = None,
+) -> list[dict]:
+    """Apply a temporal filter or boost stage to retrieved hits.
+
+    This is the retrieval-pipeline integration point.  It is designed to be
+    injected just before the final ``[:limit]`` truncation inside retrieve().
+
+    Args:
+        hits: Normalised result dicts, each with at minimum a "score" key
+            and optional "metadata" / "created_at" fields.
+        temporal: Configuration dict.  Recognised keys:
+
+            * ``window`` (str, optional): explicit temporal expression, e.g.
+              "in May 2023" or "last week".  Takes precedence over auto-scan.
+            * ``auto`` (bool, default False): when True and no window given,
+              run extract_temporal_expression(query) to find an expression.
+            * ``mode`` (str, "boost" or "filter", default "boost").
+            * ``boost`` (float, default 0.25): in boost mode, multiply in-range
+              hit scores by ``(1 + boost)``.
+            * ``reference``: reference "now" for relative expressions.  Accepts
+              epoch float, ISO string, LoCoMo-format string, or datetime.
+              Defaults to the real clock.
+            * ``datetime_keys`` (list[str], default ``["datetime", "created_at"]``):
+              metadata keys to check in order for each hit's timestamp.
+
+        query: Original query string (used only when ``auto=True``).
+        logger: Optional logger for debug messages.
+
+    Returns:
+        The hits list, potentially filtered or reordered.  Fail-open: any
+        unexpected error returns the original list unchanged.
+
+    Note:
+        Default is off.  Full-scale validation on LoCoMo-1540 is pending.
+        Enabling this without benchmarking on your data is discouraged.
+    """
+    try:
+        return _apply_temporal_stage_inner(hits, temporal, query, logger)
+    except Exception:  # noqa: BLE001
+        return hits
+
+
+def _apply_temporal_stage_inner(
+    hits: list[dict],
+    temporal: dict,
+    query: str,
+    logger: "logging.Logger | None",
+) -> list[dict]:
+    # 1. Resolve expression string.
+    expression: str | None = temporal.get("window")
+    if not expression and temporal.get("auto", False):
+        expression = extract_temporal_expression(query)
+
+    if not expression:
+        if logger:
+            logger.debug("temporal: no expression found, stage skipped")
+        return hits
+
+    # 2. Resolve reference time.
+    reference_raw = temporal.get("reference")
+    if reference_raw is None:
+        ref_now = datetime.now()
+    elif isinstance(reference_raw, datetime):
+        ref_now = reference_raw
+    else:
+        ref_now = parse_hit_datetime(reference_raw) or datetime.now()
+
+    # 3. Parse expression to range.
+    parsed = parse_temporal_expression(expression, ref_now)
+    if parsed is None:
+        if logger:
+            logger.debug("temporal: expression %r unparseable, stage skipped", expression)
+        return hits
+
+    from_dt, to_dt = parsed
+
+    # 4. Config.
+    mode = temporal.get("mode", "boost")
+    boost_factor = float(temporal.get("boost", 0.25))
+    datetime_keys: list[str] = temporal.get("datetime_keys", ["datetime", "created_at"])
+
+    def _resolve_hit_dt(hit: dict) -> datetime | None:
+        meta = hit.get("metadata", {}) or {}
+        # After _adapt_vector normalisation, hit["metadata"] is the whole raw
+        # vector row dict, which nests the original user metadata under its own
+        # "metadata" key.  Build a prioritised lookup chain: nested user-metadata
+        # first (has LoCoMo datetime strings), then the outer meta dict, then the
+        # hit's top-level created_at.
+        nested_meta = meta.get("metadata", {}) or {}
+        for candidate in (nested_meta, meta):
+            for key in datetime_keys:
+                raw = candidate.get(key)
+                if raw is not None:
+                    dt = parse_hit_datetime(raw)
+                    if dt is not None:
+                        return dt
+        # Top-level hit created_at (used by some source adapters)
+        raw = hit.get("created_at")
+        if raw is not None:
+            return parse_hit_datetime(raw)
+        return None
+
+    if mode == "filter":
+        filtered = []
+        for hit in hits:
+            dt = _resolve_hit_dt(hit)
+            if dt is None:
+                # Fail-open: keep hits with no parseable timestamp.
+                filtered.append(hit)
+            elif from_dt <= dt <= to_dt:
+                filtered.append(hit)
+
+        # Fail-open globally: if filtering would leave zero hits, return original.
+        if not filtered:
+            if logger:
+                logger.debug(
+                    "temporal: filter would leave 0 hits, returning original list"
+                )
+            return hits
+        return filtered
+
+    # Boost mode (default).
+    modified = list(hits)
+    for hit in modified:
+        dt = _resolve_hit_dt(hit)
+        if dt is None:
+            continue
+        if from_dt <= dt <= to_dt:
+            current_score = hit.get("score", 0.0)
+            if "score" in hit:
+                hit["score"] = current_score * (1.0 + boost_factor)
+
+    # Re-sort descending by score.
+    modified.sort(key=lambda h: h.get("score", 0.0), reverse=True)
+    return modified

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,4 +1,4 @@
-"""Tests for taosmd.temporal — parser, extractor, hit-datetime, and stage."""
+"""Tests for taosmd.temporal: parser, extractor, hit-datetime, and stage."""
 
 from __future__ import annotations
 
@@ -95,7 +95,7 @@ def test_parses_last_month():
 
 
 def test_returns_none_for_unparseable():
-    # "before the migration" — "before" requires a parseable inner expression
+    # "before the migration": "before" requires a parseable inner expression
     assert parse_temporal_expression("before the migration", REF) is None
     assert parse_temporal_expression("sometime", REF) is None
 
@@ -296,7 +296,7 @@ def test_extract_in_may_2023():
 
 
 def test_extract_bare_month_false_positive_guard():
-    # "did May approve the plan" — bare month name should NOT match
+    # "did May approve the plan": bare month name should NOT match
     result = extract_temporal_expression("did May approve the plan")
     assert result is None
 
@@ -321,7 +321,7 @@ def test_extract_returns_none_for_modal_may():
 
 
 # ---------------------------------------------------------------------------
-# apply_temporal_stage — boost mode
+# apply_temporal_stage: boost mode
 # ---------------------------------------------------------------------------
 
 
@@ -371,7 +371,7 @@ def test_boost_mode_no_timestamp_untouched():
 
 
 # ---------------------------------------------------------------------------
-# apply_temporal_stage — filter mode
+# apply_temporal_stage: filter mode
 # ---------------------------------------------------------------------------
 
 
@@ -408,7 +408,7 @@ def test_filter_mode_zero_survivors_returns_original():
 
 
 # ---------------------------------------------------------------------------
-# apply_temporal_stage — no-expression and unparseable-window cases
+# apply_temporal_stage: no-expression and unparseable-window cases
 # ---------------------------------------------------------------------------
 
 
@@ -427,7 +427,7 @@ def test_unparseable_window_returns_unchanged():
 
 
 # ---------------------------------------------------------------------------
-# apply_temporal_stage — reference handling
+# apply_temporal_stage: reference handling
 # ---------------------------------------------------------------------------
 
 
@@ -515,3 +515,20 @@ def test_retrieve_temporal_filter_integration():
     assert "10" in source_ids   # May hit
     assert "11" in source_ids   # May hit
     assert "12" not in source_ids  # July hit filtered out
+
+
+def test_boost_mode_rrf_score_hits():
+    # Hits from an RRF merge carry "rrf_score" instead of "score"; boost
+    # must reorder those too.
+    hits = [
+        {"id": 2, "rrf_score": 0.8, "metadata": {"datetime": "2023-07-15T00:00:00"}},
+        {"id": 1, "rrf_score": 0.5, "metadata": {"datetime": "2023-05-10T00:00:00"}},
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {"window": "in May 2023", "mode": "boost", "boost": 1.0},
+        "query",
+    )
+    assert result[0]["id"] == 1
+    assert result[0]["rrf_score"] == pytest.approx(1.0)
+    assert "score" not in result[0]

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,517 @@
+"""Tests for taosmd.temporal — parser, extractor, hit-datetime, and stage."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from taosmd.temporal import (
+    apply_temporal_stage,
+    extract_temporal_expression,
+    parse_hit_datetime,
+    parse_temporal_expression,
+)
+
+# ---------------------------------------------------------------------------
+# Fixed reference date for all parser tests: Wednesday, March 18, 2026 noon
+# ---------------------------------------------------------------------------
+REF = datetime(2026, 3, 18, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Ported from engram-review temporal.test.ts
+# ---------------------------------------------------------------------------
+
+
+def test_parses_today():
+    r = parse_temporal_expression("today", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.day == 18 and from_dt.month == 3 and from_dt.year == 2026
+    assert to_dt.day == 18
+    assert from_dt.hour == 0 and from_dt.minute == 0 and from_dt.second == 0
+    assert to_dt.hour == 23 and to_dt.minute == 59 and to_dt.second == 59
+
+
+def test_parses_yesterday():
+    r = parse_temporal_expression("yesterday", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.day == 17
+    assert to_dt.day == 17
+
+
+def test_parses_last_week_correct_range():
+    # REF is Wednesday Mar 18.  7 days back = Mar 11 (Wednesday).
+    # Monday of that week = Mar 9.
+    r = parse_temporal_expression("last week", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.day == 9
+    assert from_dt.month == 3
+
+
+def test_parses_this_month():
+    r = parse_temporal_expression("this month", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.day == 1
+    assert from_dt.month == 3
+    assert to_dt.day == 31
+
+
+def test_parses_3_days_ago():
+    r = parse_temporal_expression("3 days ago", REF)
+    assert r is not None
+    from_dt, _ = r
+    assert from_dt.day == 15  # Mar 18 - 3 = Mar 15
+
+
+def test_parses_in_march():
+    r = parse_temporal_expression("in March", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.month == 3
+    assert from_dt.day == 1
+    assert to_dt.day == 31
+
+
+def test_parses_q1_2026():
+    r = parse_temporal_expression("Q1 2026", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.month == 1  # January
+    assert to_dt.month == 3    # March
+    assert to_dt.day == 31
+
+
+def test_parses_last_month():
+    r = parse_temporal_expression("last month", REF)
+    assert r is not None
+    from_dt, _ = r
+    assert from_dt.month == 2  # February
+
+
+def test_returns_none_for_unparseable():
+    # "before the migration" — "before" requires a parseable inner expression
+    assert parse_temporal_expression("before the migration", REF) is None
+    assert parse_temporal_expression("sometime", REF) is None
+
+
+def test_parses_bare_month_name():
+    r = parse_temporal_expression("january", REF)
+    assert r is not None
+    from_dt, _ = r
+    assert from_dt.month == 1
+
+
+def test_parses_this_week():
+    # REF is Wednesday Mar 18; Monday of that week = Mar 16.
+    r = parse_temporal_expression("this week", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.day == 16
+    assert from_dt.month == 3
+    assert to_dt.day == 22  # Sunday
+
+
+def test_parses_this_year():
+    r = parse_temporal_expression("this year", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.year == 2026
+    assert from_dt.month == 1
+    assert to_dt.year == 2026
+    assert to_dt.month == 12
+    assert to_dt.day == 31
+
+
+def test_parses_last_year():
+    r = parse_temporal_expression("last year", REF)
+    assert r is not None
+    from_dt, _ = r
+    assert from_dt.year == 2025
+
+
+# ---------------------------------------------------------------------------
+# Additional cases: before/after, last N units, in <month> <year>
+# ---------------------------------------------------------------------------
+
+
+def test_parses_before_last_month():
+    # "before last month" = before Feb 2026 start
+    r = parse_temporal_expression("before last month", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt == datetime.min
+    assert to_dt.month == 2 and to_dt.year == 2026
+
+
+def test_parses_after_yesterday():
+    r = parse_temporal_expression("after yesterday", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    # from_dt = end of yesterday = 23:59:59
+    assert from_dt.day == 17
+    assert to_dt == REF
+
+
+def test_parses_last_2_weeks():
+    r = parse_temporal_expression("last 2 weeks", REF)
+    assert r is not None
+    from_dt, _ = r
+    # 2 weeks before Mar 18 = Mar 4, floored to day start
+    assert from_dt.day == 4
+    assert from_dt.month == 3
+
+
+def test_parses_in_may_2023():
+    r = parse_temporal_expression("in May 2023", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.year == 2023
+    assert from_dt.month == 5
+    assert from_dt.day == 1
+    assert to_dt.day == 31
+
+
+def test_parses_in_month_with_comma():
+    # "in May, 2023" with comma before year
+    r = parse_temporal_expression("in May, 2023", REF)
+    assert r is not None
+    from_dt, _ = r
+    assert from_dt.year == 2023
+    assert from_dt.month == 5
+
+
+# ---------------------------------------------------------------------------
+# Explicit day date additions
+# ---------------------------------------------------------------------------
+
+
+def test_parses_day_month_year():
+    # "8 May 2023"
+    r = parse_temporal_expression("8 May 2023", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.year == 2023 and from_dt.month == 5 and from_dt.day == 8
+    assert to_dt.day == 8 and to_dt.hour == 23
+
+
+def test_parses_month_day_comma_year():
+    # "May 8, 2023"
+    r = parse_temporal_expression("May 8, 2023", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.year == 2023 and from_dt.month == 5 and from_dt.day == 8
+
+
+def test_parses_on_day_month_comma_year():
+    # "on 20 July, 2023"
+    r = parse_temporal_expression("on 20 July, 2023", REF)
+    assert r is not None
+    from_dt, to_dt = r
+    assert from_dt.year == 2023 and from_dt.month == 7 and from_dt.day == 20
+
+
+# ---------------------------------------------------------------------------
+# parse_hit_datetime
+# ---------------------------------------------------------------------------
+
+
+def test_hit_dt_epoch_float():
+    # 2023-05-08 00:00:00 UTC - just check we get a datetime
+    dt = parse_hit_datetime(1683504000.0)
+    assert isinstance(dt, datetime)
+
+
+def test_hit_dt_epoch_int():
+    dt = parse_hit_datetime(1683504000)
+    assert isinstance(dt, datetime)
+
+
+def test_hit_dt_iso_string():
+    dt = parse_hit_datetime("2023-05-08T10:30:00")
+    assert dt is not None
+    assert dt.year == 2023 and dt.month == 5 and dt.day == 8
+    assert dt.hour == 10 and dt.minute == 30
+
+
+def test_hit_dt_iso_with_z():
+    dt = parse_hit_datetime("2023-07-20T20:56:00Z")
+    assert dt is not None
+    assert dt.tzinfo is None  # must be naive
+    assert dt.year == 2023 and dt.month == 7 and dt.day == 20
+
+
+def test_hit_dt_locomo_format():
+    # "8:56 pm on 20 July, 2023"
+    dt = parse_hit_datetime("8:56 pm on 20 July, 2023")
+    assert dt is not None
+    assert dt.year == 2023 and dt.month == 7 and dt.day == 20
+    assert dt.hour == 20 and dt.minute == 56
+
+
+def test_hit_dt_date_only_locomo():
+    # "20 July, 2023"
+    dt = parse_hit_datetime("20 July, 2023")
+    assert dt is not None
+    assert dt.year == 2023 and dt.month == 7 and dt.day == 20
+
+
+def test_hit_dt_garbage_returns_none():
+    assert parse_hit_datetime("not a date at all") is None
+
+
+def test_hit_dt_none_input():
+    assert parse_hit_datetime(None) is None
+
+
+def test_hit_dt_empty_string():
+    assert parse_hit_datetime("") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_temporal_expression
+# ---------------------------------------------------------------------------
+
+
+def test_extract_last_week_in_sentence():
+    result = extract_temporal_expression(
+        "what did we decide last week about the database"
+    )
+    assert result is not None
+    assert "last week" in result.lower()
+
+
+def test_extract_in_may_2023():
+    result = extract_temporal_expression(
+        "what meetings did we have in May 2023 about the project?"
+    )
+    assert result is not None
+    assert "may" in result.lower()
+    assert "2023" in result
+
+
+def test_extract_bare_month_false_positive_guard():
+    # "did May approve the plan" — bare month name should NOT match
+    result = extract_temporal_expression("did May approve the plan")
+    assert result is None
+
+
+def test_extract_no_temporal_content():
+    result = extract_temporal_expression("what is the meaning of life")
+    assert result is None
+
+
+def test_extract_explicit_date_in_sentence():
+    result = extract_temporal_expression(
+        "what happened on 8 May, 2023 in the park"
+    )
+    assert result is not None
+    assert "8" in result or "may" in result.lower()
+
+
+def test_extract_returns_none_for_modal_may():
+    # "may" as a modal verb should not match
+    result = extract_temporal_expression("this may cause issues later")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# apply_temporal_stage — boost mode
+# ---------------------------------------------------------------------------
+
+
+def _make_hit(hit_id: int, score: float, dt_str: str | None) -> dict:
+    meta = {}
+    if dt_str is not None:
+        meta["datetime"] = dt_str
+    return {"id": hit_id, "score": score, "text": f"hit {hit_id}", "metadata": meta}
+
+
+def test_boost_mode_in_range_reordered():
+    # May 2023 window; boost=1.0 so in-range hits double their score.
+    # Hit 1: score 0.5, datetime in May 2023 (in range)
+    # Hit 2: score 0.8, datetime in July 2023 (out of range)
+    # After boost: hit 1 = 1.0, hit 2 = 0.8 -> hit 1 should rank first.
+    hits = [
+        _make_hit(2, 0.8, "2023-07-15T00:00:00"),
+        _make_hit(1, 0.5, "2023-05-10T00:00:00"),
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {"window": "in May 2023", "mode": "boost", "boost": 1.0},
+        "query",
+    )
+    assert result[0]["id"] == 1
+    assert result[0]["score"] == pytest.approx(1.0)
+    assert result[1]["id"] == 2
+    assert result[1]["score"] == pytest.approx(0.8)
+
+
+def test_boost_mode_no_timestamp_untouched():
+    hits = [
+        _make_hit(1, 0.9, None),  # no timestamp
+        _make_hit(2, 0.5, "2023-05-10T00:00:00"),  # in range
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {"window": "in May 2023", "mode": "boost", "boost": 0.25},
+        "query",
+    )
+    # Hit 1 (no ts) stays at 0.9; hit 2 boosted to 0.625 -> still sorted 1 first
+    ids = [h["id"] for h in result]
+    assert ids[0] == 1  # 0.9 > 0.625
+    # Score of hit 1 should be unchanged (no "score" key written back when hit had it)
+    h1 = next(h for h in result if h["id"] == 1)
+    assert h1["score"] == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# apply_temporal_stage — filter mode
+# ---------------------------------------------------------------------------
+
+
+def test_filter_mode_drops_out_of_range():
+    hits = [
+        _make_hit(1, 0.9, "2023-05-10T00:00:00"),  # in range
+        _make_hit(2, 0.8, "2023-07-15T00:00:00"),  # out of range
+        _make_hit(3, 0.7, None),                    # no timestamp, kept
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {"window": "in May 2023", "mode": "filter"},
+        "query",
+    )
+    ids = {h["id"] for h in result}
+    assert 1 in ids  # in range
+    assert 2 not in ids  # out of range
+    assert 3 in ids  # no timestamp: fail-open
+
+
+def test_filter_mode_zero_survivors_returns_original():
+    hits = [
+        _make_hit(1, 0.9, "2023-07-15T00:00:00"),  # out of range
+        _make_hit(2, 0.8, "2023-08-01T00:00:00"),  # out of range
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {"window": "in May 2023", "mode": "filter"},
+        "query",
+    )
+    # All timestamped hits are out of range; fail-open globally
+    assert len(result) == 2
+    assert {h["id"] for h in result} == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# apply_temporal_stage — no-expression and unparseable-window cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_expression_returns_unchanged():
+    hits = [_make_hit(1, 0.9, "2023-05-10T00:00:00")]
+    result = apply_temporal_stage(hits, {}, "query with no temporal")
+    assert result == hits
+
+
+def test_unparseable_window_returns_unchanged():
+    hits = [_make_hit(1, 0.9, "2023-05-10T00:00:00")]
+    result = apply_temporal_stage(
+        hits, {"window": "not a real expression !@#"}, "query"
+    )
+    assert result == hits
+
+
+# ---------------------------------------------------------------------------
+# apply_temporal_stage — reference handling
+# ---------------------------------------------------------------------------
+
+
+def test_reference_locomo_format_last_month():
+    # Reference = "8:56 pm on 20 July, 2023" -> last month = June 2023.
+    hits = [
+        _make_hit(1, 0.9, "2023-06-15T00:00:00"),  # June 2023: in range
+        _make_hit(2, 0.8, "2023-05-01T00:00:00"),  # May 2023: out of range
+    ]
+    result = apply_temporal_stage(
+        hits,
+        {
+            "window": "last month",
+            "mode": "filter",
+            "reference": "8:56 pm on 20 July, 2023",
+        },
+        "query",
+    )
+    ids = {h["id"] for h in result}
+    assert 1 in ids   # June 2023 hit in range
+    assert 2 not in ids  # May hit out of range
+
+
+# ---------------------------------------------------------------------------
+# Integration: retrieve() with temporal kwarg
+# ---------------------------------------------------------------------------
+
+
+from taosmd.retrieval import retrieve  # noqa: E402
+
+
+class _DateVectorMemory:
+    """Minimal fake vector source with three hits carrying LoCoMo datetimes.
+
+    Returns raw vector-memory dicts; _adapt_vector normalises them into hits
+    with source_id (str) and metadata pointing at the original dict.
+    """
+
+    async def search(self, query, limit=5, hybrid=True, fusion="rrf", project=None, search_agents=None):
+        return [
+            {
+                "id": 10,
+                "text": "May event",
+                "similarity": 0.9,
+                "metadata": {"datetime": "10:00 am on 5 May, 2023"},
+                "created_at": 0.0,
+            },
+            {
+                "id": 11,
+                "text": "May event 2",
+                "similarity": 0.85,
+                "metadata": {"datetime": "3:30 pm on 20 May, 2023"},
+                "created_at": 0.0,
+            },
+            {
+                "id": 12,
+                "text": "July event",
+                "similarity": 0.8,
+                "metadata": {"datetime": "8:56 pm on 20 July, 2023"},
+                "created_at": 0.0,
+            },
+        ]
+
+
+def test_retrieve_temporal_filter_integration():
+    """retrieve() with temporal=filter drops out-of-window hits.
+
+    After _adapt_vector normalisation, original id becomes source_id (str) and
+    metadata is the original dict (which carries the "datetime" key).
+    """
+    results = asyncio.run(
+        retrieve(
+            query="what happened in May 2023",
+            strategy="custom",
+            memory_layers=["vector"],
+            sources={"vector": _DateVectorMemory()},
+            limit=10,
+            temporal={"window": "in May 2023", "mode": "filter"},
+        )
+    )
+
+    assert isinstance(results, list)
+    # source_id is a string after _adapt_vector normalisation
+    source_ids = {r["source_id"] for r in results}
+    assert "10" in source_ids   # May hit
+    assert "11" in source_ids   # May hit
+    assert "12" not in source_ids  # July hit filtered out


### PR DESCRIPTION
## What

Natural-language temporal expression parsing as a retrieval-time lever, ported from the engram project's parser and extended:

- `taosmd/temporal.py`: `parse_temporal_expression` (today/yesterday/this-last week-month-year/N-units-ago/in-month-year/quarters/before-after/explicit dates), `extract_temporal_expression` (query scanner with bare-month false-positive guards), `parse_hit_datetime` (epoch, ISO, LoCoMo conversation format), `apply_temporal_stage` (boost or filter, fail-open everywhere).
- `retrieve(temporal={...})`: default off, wired at the final-candidate stage of all four strategy paths. Boost handles both score and rrf_score hits.
- Complements the existing `temporal_boost.py` (keyword ordering signals); this lever handles explicit date ranges.
- `benchmarks/temporal_applicability_scan.py`: E-005 stage 1 reproducibility script.

## Benchmark status (E-005, docs/research-report.md)

Pre-registered with an applicability gate. Stage 1 resolved the experiment by its own criterion: LoCoMo temporal-category applicability is 9.3 percent, under the 10 percent floor, so LoCoMo cannot measure this lever and no LoCoMo claim is made. The lever ships default-off; its natural habitat is live agent queries ("what did we decide last week"), which LoCoMo does not contain.

## Tests

66 passed (45 new in tests/test_temporal.py incl. an async retrieve() integration test; tests/test_retrieval.py 21, no regressions). ruff clean on the new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporal expression parsing supporting natural language queries (e.g., "today", "last week", "May 2023").
  * Retrieval now supports temporal filtering and score boosting based on parsed date windows.
  * Added temporal applicability benchmarking capability.

* **Tests**
  * Comprehensive test coverage for temporal parsing, filtering, and boosting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->