### PR TITLE
bench: pause/resume checkpointing for the LoCoMo runner

### DIFF
--- a/benchmarks/bench_checkpoint.py
+++ b/benchmarks/bench_checkpoint.py
@@ -1,0 +1,144 @@
+"""Conversation-level checkpoint sidecar for the LoCoMo benchmark runner.
+
+Each checkpoint is a newline-delimited JSON file (<out>.ckpt.jsonl) with one
+header line followed by one line per completed conversation.  A stable config
+hash guards against accidentally resuming a run that used different settings.
+
+File layout::
+
+    {"kind": "header", "config_hash": "<hex16>", "dataset": "<path>"}
+    {"kind": "conv", "conv_id": "<id>", "rows": [...]}
+    {"kind": "conv", "conv_id": "<id>", "rows": [...]}
+    ...
+
+Each line is written with os.fsync so a kill or power loss cannot corrupt a
+line that was already acknowledged.  A partial (truncated) FINAL line, which
+can happen if the process is killed mid-write, is silently skipped during load.
+A malformed line anywhere else raises ValueError to prevent silently mixing
+results from incompatible runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+
+# ---------------------------------------------------------------------------
+# Config hashing
+# ---------------------------------------------------------------------------
+
+_HASH_SKIP = frozenset({"timestamp", "git_sha", "run_id", "failed_qa"})
+
+
+def config_hash(meta_like: dict) -> str:
+    """Return a stable sha256[:16] of the run-defining config.
+
+    Keys in ``_HASH_SKIP`` (``timestamp``, ``git_sha``, ``run_id``,
+    ``failed_qa``) are excluded so the hash reflects only the settings that
+    determine which results are comparable.  Remaining keys are sorted before
+    serialisation so insertion order does not affect the hash.
+    """
+    filtered = {k: v for k, v in meta_like.items() if k not in _HASH_SKIP}
+    payload = json.dumps(filtered, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Write helpers
+# ---------------------------------------------------------------------------
+
+def write_header(path: str, cfg_hash: str, dataset: str) -> None:
+    """Create (or truncate) the sidecar file and write the header line."""
+    line = json.dumps({"kind": "header", "config_hash": cfg_hash, "dataset": dataset})
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def append_conversation(path: str, conv_id: str, rows: list[dict]) -> None:
+    """Append one conversation record and fsync so a kill cannot lose it."""
+    line = json.dumps({"kind": "conv", "conv_id": conv_id, "rows": rows})
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+# ---------------------------------------------------------------------------
+# Load helper
+# ---------------------------------------------------------------------------
+
+def load_checkpoint(path: str, expected_hash: str) -> tuple[set[str], list[dict]]:
+    """Read the sidecar and return (done_conv_ids, all_rows).
+
+    Raises ValueError if:
+    - The first line is not a header, or
+    - The header's config_hash differs from ``expected_hash``.
+
+    A malformed or truncated FINAL line is skipped with a warning (crash
+    mid-write tolerance).  A malformed line anywhere else raises ValueError.
+    """
+    with open(path, encoding="utf-8") as fh:
+        raw_lines = fh.readlines()
+
+    if not raw_lines:
+        raise ValueError("checkpoint file is empty: no header found")
+
+    # Parse header.
+    try:
+        header = json.loads(raw_lines[0])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"checkpoint header is not valid JSON: {exc}") from exc
+    if header.get("kind") != "header":
+        raise ValueError(
+            f"checkpoint first line is not a header (kind={header.get('kind')!r})"
+        )
+    stored_hash = header.get("config_hash", "")
+    if stored_hash != expected_hash:
+        raise ValueError(
+            f"checkpoint config_hash mismatch: stored={stored_hash!r} "
+            f"expected={expected_hash!r}"
+        )
+
+    done_ids: set[str] = set()
+    all_rows: list[dict] = []
+
+    body_lines = raw_lines[1:]
+    for idx, raw in enumerate(body_lines):
+        raw = raw.rstrip("\n")
+        if not raw:
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            is_last = idx == len(body_lines) - 1
+            if is_last:
+                print(
+                    f"WARNING: skipping truncated final checkpoint line "
+                    f"(crash mid-write): {exc}"
+                )
+                continue
+            raise ValueError(
+                f"malformed checkpoint line {idx + 2} (not the last line): {exc}"
+            ) from exc
+        if rec.get("kind") != "conv":
+            raise ValueError(
+                f"unexpected checkpoint record kind {rec.get('kind')!r} at line {idx + 2}"
+            )
+        cid = rec.get("conv_id", "")
+        done_ids.add(cid)
+        all_rows.extend(rec.get("rows") or [])
+
+    return done_ids, all_rows
+
+
+# ---------------------------------------------------------------------------
+# Pause flag
+# ---------------------------------------------------------------------------
+
+def pause_requested(flag_path: str) -> bool:
+    """Return True if the pause flag file exists."""
+    return os.path.exists(flag_path)

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -10,6 +10,32 @@ time; conversations themselves remain sequential so vmem instances do not
 fight over the tempdir / embedding model load. Concurrency requires the
 Ollama server to be configured with ``OLLAMA_NUM_PARALLEL`` at least as
 large as ``--concurrency`` or requests will serialise on the server side.
+
+Pause and resume
+----------------
+Three flags support checkpointing at conversation granularity:
+
+``--ckpt``
+    Enable sidecar checkpointing.  After each conversation's QAs are
+    gathered the runner appends a record to ``<out>.ckpt.jsonl`` (fsync'd
+    so a kill cannot lose an acknowledged conversation).  A stable config
+    hash in the header guards against resuming with different settings.
+
+``--resume``
+    Implies ``--ckpt``.  If the sidecar exists, load it, verify the
+    config hash (exit 2 on mismatch), and skip conversations already
+    recorded without re-ingesting them.  If no sidecar is present, run
+    fresh.
+
+``--pause-flag PATH``
+    Before each conversation the runner checks whether this file exists.
+    If it does it prints a resume hint and exits with code 3 (paused).
+    A pause waits for the current conversation's QAs to finish before
+    checking; it never interrupts mid-gather.  Default path:
+    ``/tmp/taosmd-bench-pause``.
+
+Exit codes: 3 = paused cleanly, 2 = checkpoint config mismatch or other
+startup error, 1 = all QAs failed, 0 = success.
 """
 
 from __future__ import annotations
@@ -30,10 +56,18 @@ from pathlib import Path
 import httpx
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from taosmd.vector_memory import VectorMemory  # noqa: E402
 from taosmd.retrieval import retrieve  # noqa: E402
 from taosmd.llm_rerank import llm_listwise_rerank  # noqa: E402
+from bench_checkpoint import (  # noqa: E402
+    append_conversation,
+    config_hash,
+    load_checkpoint,
+    pause_requested,
+    write_header,
+)
 
 CATEGORY_NAMES = {
     1: "Single-hop (1)",
@@ -1229,9 +1263,98 @@ async def run(args: argparse.Namespace) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
+    # --resume implies --ckpt.
+    use_ckpt = args.ckpt or args.resume
+
+    # Resolve output path early so we can derive the sidecar path.
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        _ts_placeholder = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        _tag = f"_{args.run_id}" if args.run_id else ""
+        out_path = (
+            Path(os.path.dirname(os.path.abspath(__file__)))
+            / "results"
+            / f"locomo_{_ts_placeholder}{_tag}.json"
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path = str(out_path) + ".ckpt.jsonl"
+
+    # Build the run-defining config dict up-front for hashing.
+    # Excludes timestamp, git_sha, run_id, failed_qa — those are volatile or
+    # unknown at start time.  The final meta dict is assembled later with the
+    # same keys plus these excluded fields.
+    meta_for_hash: dict = {
+        "model": args.model,
+        "top_k": args.top_k,
+        "retrieval_top_k": args.retrieval_top_k if args.retrieval_top_k is not None else args.top_k,
+        "llm_backend": args.llm_backend,
+        "llm_server_url": args.llm_server_url if args.llm_backend == "llama-server" else "",
+        "expansion_model": args.expansion_model,
+        "context_format": args.context_format,
+        "adjacent_turns": args.adjacent_turns,
+        "llm_query_expansion": args.llm_query_expansion,
+        "reranker": args.reranker,
+        "multihop_decompose": args.multihop_decompose,
+        "full_context": args.full_context,
+        "thinking_mode": args.thinking_mode,
+        "temporal_boost": args.temporal_boost,
+        "fusion": args.fusion,
+        "multi_level_retrieval": args.multi_level_retrieval,
+        "hyde": args.hyde,
+        "no_think_prefix": args.no_think_prefix,
+        "few_shot": args.few_shot,
+        "emem_edu": args.emem_edu,
+        "emem_edu_extract_model": args.emem_edu_extract_model if args.emem_edu else "",
+        "emem_edu_filter": (args.emem_edu and not args.emem_edu_no_filter),
+        "emem_edu_filter_model": (
+            (args.emem_edu_filter_model or args.emem_edu_extract_model)
+            if args.emem_edu and not args.emem_edu_no_filter else ""
+        ),
+        "strategy": args.strategy,
+        "categories_included": sorted(
+            {1, 2, 3, 4} | ({5} if args.include_adversarial else set())
+            if args.category == "all"
+            else {int(args.category)}
+        ),
+        "conversations": min(args.conversations, len(conversations)),
+        "dataset": str(dataset_path),
+        "concurrency": max(1, int(args.concurrency)),
+    }
+    cfg_hash = config_hash(meta_for_hash)
+
     results: list[dict] = []
     total_seen = 0
     failed_qa = 0
+    done_conv_ids: set[str] = set()
+
+    # On --resume, try to load the sidecar.
+    if args.resume:
+        if os.path.exists(sidecar_path):
+            try:
+                done_conv_ids, loaded_rows = load_checkpoint(sidecar_path, cfg_hash)
+            except ValueError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 2
+            results.extend(loaded_rows)
+            total_seen = len(loaded_rows)
+            print(
+                f"Resumed from {sidecar_path}: "
+                f"{len(done_conv_ids)} conversations, {total_seen} rows loaded.",
+                flush=True,
+            )
+        else:
+            print(
+                f"No sidecar found at {sidecar_path}: starting fresh run.",
+                flush=True,
+            )
+            # Fall through to write_header below.
+
+    # Write the sidecar header when starting fresh (--ckpt without a loaded
+    # sidecar, or --resume with no existing sidecar).
+    if use_ckpt and not done_conv_ids:
+        write_header(sidecar_path, cfg_hash, str(dataset_path))
+
     concurrency = max(1, int(args.concurrency))
     sem = asyncio.Semaphore(concurrency)
     progress_lock = asyncio.Lock()
@@ -1296,6 +1419,23 @@ async def run(args: argparse.Namespace) -> int:
     async with httpx.AsyncClient(timeout=args.timeout) as client:
         for conv in conversations:
             conv_id = conv.get("sample_id", "unknown")
+
+            # Skip conversations already recorded in the sidecar.
+            if conv_id in done_conv_ids:
+                print(f"[{conv_id}] skipped (already checkpointed)", flush=True)
+                continue
+
+            # Check pause flag before doing any expensive work for this conversation.
+            if use_ckpt and pause_requested(args.pause_flag):
+                n_convs = len(done_conv_ids)
+                n_rows = len(results)
+                print(
+                    f"PAUSED before {conv_id}: {n_convs} conversations / {n_rows} rows "
+                    f"checkpointed. Resume with --resume (same --out and config). "
+                    f"Remove {args.pause_flag} first."
+                )
+                return 3
+
             tmp = tempfile.mkdtemp(prefix=f"locomo_{conv_id}_")
             vmem = VectorMemory(
                 db_path=os.path.join(tmp, "vmem.db"),
@@ -1348,6 +1488,7 @@ async def run(args: argparse.Namespace) -> int:
                     break
                 eligible.append(qa)
 
+            conv_rows: list[dict] = []
             if eligible:
                 tasks = [_guarded(qa, conv_id, vmem, client, turn_index) for qa in eligible]
                 gathered = await asyncio.gather(*tasks, return_exceptions=True)
@@ -1355,61 +1496,66 @@ async def run(args: argparse.Namespace) -> int:
                     if isinstance(outcome, Exception) or outcome is None:
                         continue
                     results.append(outcome)
+                    conv_rows.append(outcome)
             await vmem.close()
+
+            # Append this conversation to the sidecar after vmem is closed.
+            if use_ckpt:
+                append_conversation(sidecar_path, conv_id, conv_rows)
+                done_conv_ids.add(conv_id)
+
             if args.limit and total_seen >= args.limit:
                 break
 
     by_category, overall = _aggregate(results)
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    # Assemble final meta using the already-computed meta_for_hash base plus
+    # volatile fields (timestamp, git_sha) and run-time counts.  Shape is
+    # identical to before checkpointing was added.
     meta = {
         "run_id": args.run_id or "",
         "timestamp": timestamp,
-        "model": args.model,
-        "top_k": args.top_k,
-        "retrieval_top_k": retrieval_top_k,
-        "llm_backend": args.llm_backend,
-        "llm_server_url": args.llm_server_url if args.llm_backend == "llama-server" else "",
-        "expansion_model": args.expansion_model,
-        "context_format": args.context_format,
-        "adjacent_turns": args.adjacent_turns,
-        "llm_query_expansion": args.llm_query_expansion,
-        "reranker": args.reranker,
-        "multihop_decompose": args.multihop_decompose,
-        "full_context": args.full_context,
-        "thinking_mode": args.thinking_mode,
-        "temporal_boost": args.temporal_boost,
-        "fusion": args.fusion,
-        "multi_level_retrieval": args.multi_level_retrieval,
-        "hyde": args.hyde,
-        "no_think_prefix": args.no_think_prefix,
-        "few_shot": args.few_shot,
-        "emem_edu": args.emem_edu,
-        "emem_edu_extract_model": args.emem_edu_extract_model if args.emem_edu else "",
-        "emem_edu_filter": (args.emem_edu and not args.emem_edu_no_filter),
-        "emem_edu_filter_model": (
-            (args.emem_edu_filter_model or args.emem_edu_extract_model)
-            if args.emem_edu and not args.emem_edu_no_filter else ""
-        ),
-        "strategy": args.strategy,
+        "model": meta_for_hash["model"],
+        "top_k": meta_for_hash["top_k"],
+        "retrieval_top_k": meta_for_hash["retrieval_top_k"],
+        "llm_backend": meta_for_hash["llm_backend"],
+        "llm_server_url": meta_for_hash["llm_server_url"],
+        "expansion_model": meta_for_hash["expansion_model"],
+        "context_format": meta_for_hash["context_format"],
+        "adjacent_turns": meta_for_hash["adjacent_turns"],
+        "llm_query_expansion": meta_for_hash["llm_query_expansion"],
+        "reranker": meta_for_hash["reranker"],
+        "multihop_decompose": meta_for_hash["multihop_decompose"],
+        "full_context": meta_for_hash["full_context"],
+        "thinking_mode": meta_for_hash["thinking_mode"],
+        "temporal_boost": meta_for_hash["temporal_boost"],
+        "fusion": meta_for_hash["fusion"],
+        "multi_level_retrieval": meta_for_hash["multi_level_retrieval"],
+        "hyde": meta_for_hash["hyde"],
+        "no_think_prefix": meta_for_hash["no_think_prefix"],
+        "few_shot": meta_for_hash["few_shot"],
+        "emem_edu": meta_for_hash["emem_edu"],
+        "emem_edu_extract_model": meta_for_hash["emem_edu_extract_model"],
+        "emem_edu_filter": meta_for_hash["emem_edu_filter"],
+        "emem_edu_filter_model": meta_for_hash["emem_edu_filter_model"],
+        "strategy": meta_for_hash["strategy"],
         "total_qa": len(results),
-        "categories_included": sorted(include_cats),
-        "conversations": min(args.conversations, len(conversations)),
+        "categories_included": meta_for_hash["categories_included"],
+        "conversations": meta_for_hash["conversations"],
         "git_sha": _git_sha(),
-        "dataset": str(dataset_path),
-        "concurrency": concurrency,
+        "dataset": meta_for_hash["dataset"],
+        "concurrency": meta_for_hash["concurrency"],
         "failed_qa": failed_qa,
     }
 
-    if args.out:
-        out_path = Path(args.out)
-    else:
-        tag = f"_{args.run_id}" if args.run_id else ""
-        out_path = Path(os.path.dirname(os.path.abspath(__file__))) / "results" / f"locomo_{timestamp}{tag}.json"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(
         {"meta": meta, "by_category": by_category, "overall": overall, "results": results},
         indent=2,
     ))
+
+    # Sidecar served its purpose: remove it to avoid confusion on next run.
+    if use_ckpt and os.path.exists(sidecar_path):
+        os.unlink(sidecar_path)
 
     _print_summary(meta, by_category, overall)
     print(f"\nwrote {out_path}")
@@ -1444,7 +1590,8 @@ _DEFAULT_ONNX = os.environ.get(
 )
 
 
-def _parse_args() -> argparse.Namespace:
+def _build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser (split out so tests can introspect flags)."""
     p = argparse.ArgumentParser(description="LoCoMo benchmark runner for taosmd")
     p.add_argument("--dataset", default=_DEFAULT_DATASET,
                    help=f"LoCoMo dataset JSON. Env: LOCOMO_DATASET (default: {_DEFAULT_DATASET})")
@@ -1693,7 +1840,37 @@ def _parse_args() -> argparse.Namespace:
             "--embed-mode local. Example: answerdotai/answerai-colbert-small-v1"
         ),
     )
-    return p.parse_args()
+    # Pause / resume checkpointing flags.
+    p.add_argument(
+        "--ckpt", action="store_true", default=False,
+        help=(
+            "Enable conversation-level sidecar checkpointing. After each "
+            "conversation's QAs are gathered the runner appends a record to "
+            "<out>.ckpt.jsonl (fsync'd). A config hash in the header prevents "
+            "silently resuming with different settings."
+        ),
+    )
+    p.add_argument(
+        "--resume", action="store_true", default=False,
+        help=(
+            "Implies --ckpt. Load the sidecar if present, verify the config "
+            "hash (exit 2 on mismatch), and skip already-completed conversations "
+            "without re-ingesting them. If no sidecar exists, runs fresh."
+        ),
+    )
+    p.add_argument(
+        "--pause-flag", default="/tmp/taosmd-bench-pause", dest="pause_flag",
+        help=(
+            "Path to a flag file that triggers a clean pause between conversations. "
+            "When this file exists the runner prints a resume hint and exits 3. "
+            "Default: /tmp/taosmd-bench-pause"
+        ),
+    )
+    return p
+
+
+def _parse_args() -> argparse.Namespace:
+    return _build_parser().parse_args()
 
 
 if __name__ == "__main__":

--- a/tests/test_bench_checkpoint.py
+++ b/tests/test_bench_checkpoint.py
@@ -1,0 +1,217 @@
+"""Tests for benchmarks/bench_checkpoint.py and the runner's pause/resume flags.
+
+Covers:
+  1. config_hash: stable across key order, insensitive to excluded keys,
+     sensitive to a model change.
+  2. write_header + append_conversation + load_checkpoint round-trip.
+  3. load_checkpoint raises ValueError on hash mismatch (names both hashes).
+  4. Truncated final line is skipped with a warning; earlier content loads fine.
+  5. Malformed middle line raises ValueError.
+  6. pause_requested returns True/False based on flag file presence.
+  7. locomo_runner exposes --ckpt, --resume, and --pause-flag via _build_parser.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CKPT_PATH = REPO_ROOT / "benchmarks" / "bench_checkpoint.py"
+RUNNER_PATH = REPO_ROOT / "benchmarks" / "locomo_runner.py"
+
+
+def _load_ckpt():
+    spec = importlib.util.spec_from_file_location("bench_checkpoint", CKPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("locomo_runner", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. config_hash
+# ---------------------------------------------------------------------------
+
+def test_config_hash_stable_across_key_order():
+    ckpt = _load_ckpt()
+    a = {"model": "qwen3:4b", "top_k": 10, "strategy": "vector-only"}
+    b = {"strategy": "vector-only", "top_k": 10, "model": "qwen3:4b"}
+    assert ckpt.config_hash(a) == ckpt.config_hash(b)
+
+
+def test_config_hash_insensitive_to_excluded_keys():
+    ckpt = _load_ckpt()
+    base = {"model": "qwen3:4b", "top_k": 10}
+    with_extras = {
+        "model": "qwen3:4b",
+        "top_k": 10,
+        "timestamp": "20260611_120000",
+        "git_sha": "abc1234",
+        "run_id": "my-run",
+        "failed_qa": 3,
+    }
+    assert ckpt.config_hash(base) == ckpt.config_hash(with_extras)
+
+
+def test_config_hash_sensitive_to_model_change():
+    ckpt = _load_ckpt()
+    a = {"model": "qwen3:4b", "top_k": 10}
+    b = {"model": "llama3.1:8b", "top_k": 10}
+    assert ckpt.config_hash(a) != ckpt.config_hash(b)
+
+
+# ---------------------------------------------------------------------------
+# 2. Round-trip: write_header + append_conversation + load_checkpoint
+# ---------------------------------------------------------------------------
+
+def test_round_trip_two_conversations():
+    ckpt = _load_ckpt()
+    cfg = {"model": "qwen3:4b", "top_k": 10}
+    h = ckpt.config_hash(cfg)
+
+    rows_a = [{"conv_id": "c1", "f1": 0.5, "judge": 1.0}]
+    rows_b = [{"conv_id": "c2", "f1": 0.3, "judge": 0.0},
+              {"conv_id": "c2", "f1": 0.7, "judge": 1.0}]
+
+    with tempfile.NamedTemporaryFile(suffix=".ckpt.jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        ckpt.write_header(path, h, "/data/locomo10.json")
+        ckpt.append_conversation(path, "c1", rows_a)
+        ckpt.append_conversation(path, "c2", rows_b)
+
+        done_ids, all_rows = ckpt.load_checkpoint(path, h)
+
+        assert done_ids == {"c1", "c2"}
+        assert all_rows == rows_a + rows_b
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 3. load_checkpoint raises ValueError on hash mismatch
+# ---------------------------------------------------------------------------
+
+def test_load_raises_on_hash_mismatch():
+    ckpt = _load_ckpt()
+    cfg = {"model": "qwen3:4b"}
+    h = ckpt.config_hash(cfg)
+
+    with tempfile.NamedTemporaryFile(suffix=".ckpt.jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        ckpt.write_header(path, h, "/data/locomo10.json")
+        wrong_hash = "deadbeef00000000"
+        with pytest.raises(ValueError) as exc_info:
+            ckpt.load_checkpoint(path, wrong_hash)
+        msg = str(exc_info.value)
+        assert h in msg
+        assert wrong_hash in msg
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 4. Truncated final line is skipped with a warning
+# ---------------------------------------------------------------------------
+
+def test_truncated_final_line_skipped(capsys):
+    ckpt = _load_ckpt()
+    cfg = {"model": "qwen3:4b"}
+    h = ckpt.config_hash(cfg)
+
+    rows_a = [{"f1": 0.5}]
+
+    with tempfile.NamedTemporaryFile(suffix=".ckpt.jsonl", delete=False,
+                                     mode="w") as tf:
+        path = tf.name
+        tf.write(json.dumps({"kind": "header", "config_hash": h, "dataset": "d"}) + "\n")
+        tf.write(json.dumps({"kind": "conv", "conv_id": "c1", "rows": rows_a}) + "\n")
+        # Partial line, no closing brace or newline: simulate crash mid-write.
+        tf.write('{"kind": "conv", "conv_id": "c2", "rows": [{"f1"')
+    try:
+        done_ids, all_rows = ckpt.load_checkpoint(path, h)
+        assert done_ids == {"c1"}
+        assert all_rows == rows_a
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out or "truncated" in captured.out.lower()
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 5. Malformed middle line raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_malformed_middle_line_raises():
+    ckpt = _load_ckpt()
+    cfg = {"model": "qwen3:4b"}
+    h = ckpt.config_hash(cfg)
+
+    with tempfile.NamedTemporaryFile(suffix=".ckpt.jsonl", delete=False,
+                                     mode="w") as tf:
+        path = tf.name
+        tf.write(json.dumps({"kind": "header", "config_hash": h, "dataset": "d"}) + "\n")
+        tf.write("{not valid json\n")
+        tf.write(json.dumps({"kind": "conv", "conv_id": "c2", "rows": []}) + "\n")
+    try:
+        with pytest.raises(ValueError, match="malformed checkpoint line"):
+            ckpt.load_checkpoint(path, h)
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 6. pause_requested
+# ---------------------------------------------------------------------------
+
+def test_pause_requested_false_when_no_file():
+    ckpt = _load_ckpt()
+    with tempfile.TemporaryDirectory() as d:
+        flag = os.path.join(d, "pause-flag")
+        assert ckpt.pause_requested(flag) is False
+
+
+def test_pause_requested_true_when_file_exists():
+    ckpt = _load_ckpt()
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        flag = tf.name
+    try:
+        assert ckpt.pause_requested(flag) is True
+    finally:
+        os.unlink(flag)
+
+
+# ---------------------------------------------------------------------------
+# 7. locomo_runner exposes --ckpt, --resume, --pause-flag via _build_parser
+# ---------------------------------------------------------------------------
+
+def test_runner_parser_has_checkpoint_flags():
+    runner = _load_runner()
+    assert hasattr(runner, "_build_parser"), (
+        "locomo_runner must expose _build_parser() for parser introspection"
+    )
+    parser = runner._build_parser()
+    args = parser.parse_args([])
+    # Verify the three new flags exist with their defaults.
+    assert hasattr(args, "ckpt"), "--ckpt flag missing from parser"
+    assert args.ckpt is False
+    assert hasattr(args, "resume"), "--resume flag missing from parser"
+    assert args.resume is False
+    assert hasattr(args, "pause_flag"), "--pause-flag flag missing from parser"
+    assert args.pause_flag == "/tmp/taosmd-bench-pause"


### PR DESCRIPTION
## What

Phase 1 of pausable benchmarks (#25): conversation-granularity checkpointing so a long LoCoMo run can be paused or killed and resumed without losing completed work or re-ingesting finished conversations.

- `benchmarks/bench_checkpoint.py`: sidecar module, pure stdlib. Config-hash guard (sha256 of the run-defining meta, volatile fields excluded) so a checkpoint can never silently resume under a different config; fsync'd per-conversation appends; tolerant of a truncated final line (crash mid-write), strict on corruption anywhere else.
- Runner flags: `--ckpt` (write sidecar `<out>.ckpt.jsonl`), `--resume` (load sidecar, verify hash, skip done conversations including their ingest), `--pause-flag PATH` (default `/tmp/taosmd-bench-pause`; checked between conversations, exits 3 with resume instructions).
- Resumed rows flow into the same results list before the loop, so aggregation, failed-QA accounting, and `--limit` math are identical to an uninterrupted run. Final JSON shape unchanged; sidecar deleted on success.
- Granularity is the conversation because QAs within one run concurrently: a pause waits for the in-flight conversation, and the most that can be lost to a hard kill is one conversation's QA loop, never its acknowledged predecessors.

## Why conversation-level

Ingest is the expensive non-resumable prefix per conversation; skipping completed conversations on resume skips their ingest entirely. Per-QA granularity would need concurrent-safe appends for marginal gain.

## Tests

10 new tests (hash stability, round-trip, hash mismatch, truncated/malformed lines, pause flag, parser flags). Full suite 792 passed. `--help` surfaces all three flags. Exit codes: 3 paused, 2 checkpoint config mismatch.

Next phases (separate): Fedora PAUSE-on-boot orchestration + the hermes rebootwin runbook.