### PR TITLE
docs(bench): pause/resume runbook + rebootwin.sh helper (#25 phases 2-3)

### DIFF
--- a/benchmarks/rebootwin.sh
+++ b/benchmarks/rebootwin.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# rebootwin.sh -- convenience wrapper over the taosmd bench pause-flag mechanism
+#
+# Subcommands:
+#   pause   [--flag PATH]  Touch the pause flag and wait for the runner to exit cleanly.
+#   status  [--flag PATH]  Report flag state, runner state, and newest sidecar.
+#   resume                 Clear the flag and print instructions to re-run with --resume.
+#
+# This script never starts or kills the benchmark runner. It only manages the
+# pause flag and reports process state. The runner checks the flag between
+# conversations and exits 3 when it finds the flag present.
+#
+# Safe to run from any directory; uses absolute detection logic.
+
+set -u
+
+DEFAULT_FLAG="/tmp/taosmd-bench-pause"
+RUNNER_PATTERN="locomo_runner.py"
+PAUSE_TIMEOUT_SECONDS=1800  # 30 minutes; a single conversation should never take this long
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <subcommand> [options]
+
+Subcommands:
+  pause   [--flag PATH]   Touch the pause flag and wait for the runner to exit.
+                          Exits 0 on clean pause, 0 if no runner was running,
+                          exits 1 on timeout (runner still alive after 30 min).
+  status  [--flag PATH]   Report flag state, runner state, and newest sidecar info.
+  resume                  Clear the pause flag and print resume instructions.
+
+Options:
+  --flag PATH   Override the default pause-flag path ($DEFAULT_FLAG).
+EOF
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+runner_pid() {
+    # Return the PID(s) of any running locomo_runner.py process, or empty string.
+    pgrep -f "$RUNNER_PATTERN" 2>/dev/null || true
+}
+
+runner_alive() {
+    local pid
+    pid="$(runner_pid)"
+    [ -n "$pid" ]
+}
+
+newest_sidecar() {
+    # Print the path of the newest .ckpt.jsonl under benchmarks/results/, or empty.
+    # Works regardless of cwd by searching relative paths from the script location.
+    local script_dir
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    local results_dir="$script_dir/results"
+    if [ ! -d "$results_dir" ]; then
+        return 0
+    fi
+    # Find the most recently modified sidecar file.
+    find "$results_dir" -name "*.ckpt.jsonl" -maxdepth 1 2>/dev/null \
+        | xargs ls -t 2>/dev/null \
+        | head -1
+}
+
+conv_count() {
+    # Count completed conversations in a sidecar. Handles both spacing variants.
+    local path="$1"
+    local n=0
+    if [ -f "$path" ]; then
+        # grep -c returns a non-zero exit code when nothing matches; treat that as 0.
+        n=$(grep -c '"kind": "conv"' "$path" 2>/dev/null || true)
+        if [ "$n" -eq 0 ]; then
+            n=$(grep -c '"kind":"conv"' "$path" 2>/dev/null || true)
+        fi
+    fi
+    echo "$n"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: pause
+# ---------------------------------------------------------------------------
+
+cmd_pause() {
+    local flag_path="$DEFAULT_FLAG"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --flag) flag_path="$2"; shift 2 ;;
+            *) echo "unknown option: $1"; usage ;;
+        esac
+    done
+
+    if ! runner_alive; then
+        echo "no benchmark running"
+        exit 0
+    fi
+
+    # Touch the flag to signal the runner.
+    touch "$flag_path"
+    echo "pause flag set at $flag_path"
+    echo "waiting for the current conversation to finish..."
+
+    local elapsed=0
+    while runner_alive; do
+        sleep 5
+        elapsed=$((elapsed + 5))
+        if [ "$elapsed" -ge "$PAUSE_TIMEOUT_SECONDS" ]; then
+            echo ""
+            echo "WARNING: runner is still alive after ${PAUSE_TIMEOUT_SECONDS}s."
+            echo "Something is wrong; investigate before rebooting."
+            echo "Do NOT kill the process -- that would lose the in-flight conversation."
+            exit 1
+        fi
+    done
+
+    echo "bench paused cleanly; safe to reboot"
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+
+cmd_status() {
+    local flag_path="$DEFAULT_FLAG"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --flag) flag_path="$2"; shift 2 ;;
+            *) echo "unknown option: $1"; usage ;;
+        esac
+    done
+
+    # Flag state.
+    if [ -e "$flag_path" ]; then
+        echo "pause flag:  PRESENT ($flag_path)"
+    else
+        echo "pause flag:  not present ($flag_path)"
+    fi
+
+    # Runner state.
+    local pid
+    pid="$(runner_pid)"
+    if [ -n "$pid" ]; then
+        echo "runner:      RUNNING (pid $pid)"
+    else
+        echo "runner:      not running"
+    fi
+
+    # Newest sidecar.
+    local sidecar
+    sidecar="$(newest_sidecar)"
+    if [ -n "$sidecar" ]; then
+        local n
+        n="$(conv_count "$sidecar")"
+        echo "newest sidecar: $sidecar ($n completed conversations)"
+    else
+        echo "newest sidecar: none found in benchmarks/results/"
+    fi
+
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: resume
+# ---------------------------------------------------------------------------
+
+cmd_resume() {
+    local flag_path="$DEFAULT_FLAG"
+
+    # Remove the flag if present.
+    if [ -e "$flag_path" ]; then
+        rm -f "$flag_path"
+        echo "pause flag cleared ($flag_path)"
+    else
+        echo "pause flag was not present ($flag_path)"
+    fi
+
+    echo ""
+    echo "Re-run your original launch command with --resume appended (same --out and same recipe flags)."
+    echo ""
+    echo "Example:"
+    echo "  python3 benchmarks/locomo_runner.py [your original flags] --resume"
+    echo ""
+    echo "The config hash must match; if you changed any flags, start a fresh run with a new --out path."
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+subcommand="$1"
+shift
+
+case "$subcommand" in
+    pause)  cmd_pause "$@" ;;
+    status) cmd_status "$@" ;;
+    resume) cmd_resume ;;
+    *)      echo "unknown subcommand: $subcommand"; usage ;;
+esac

--- a/docs/bench-pause-resume.md
+++ b/docs/bench-pause-resume.md
@@ -1,0 +1,114 @@
+# Bench Pause and Resume
+
+## What this is
+
+LoCoMo benchmark runs can take several hours. The runner supports conversation-granularity checkpointing so a run can be paused cleanly, the machine rebooted (or handed off for another purpose), and the run continued later with no repeated work. After each conversation the runner writes a record to a sidecar file (`<out>.ckpt.jsonl`, fsync'd to disk). When a pause flag file is present the runner finishes its current in-flight conversation, writes the checkpoint, prints a resume hint, and exits with code 3. The most you can lose to a clean pause is the conversation currently running when the flag is created; every earlier conversation is safe on disk.
+
+---
+
+## Starting a pausable run
+
+Pass `--ckpt` together with an explicit `--out` path. The sidecar is placed next to the output file and named `<out>.ckpt.jsonl`.
+
+```bash
+python3 benchmarks/locomo_runner.py \
+  --model gemma4:e2b \
+  --retrieval-top-k 50 --adjacent-turns 2 --reranker bge-v2-m3 --fusion mem0_additive \
+  --out benchmarks/results/locomo-rerank-gemma4e2b.json \
+  --ckpt
+```
+
+The sidecar for this run will be `benchmarks/results/locomo-rerank-gemma4e2b.json.ckpt.jsonl`.
+
+You can supply a custom pause-flag path with `--pause-flag /path/to/flag`. The default is `/tmp/taosmd-bench-pause`.
+
+---
+
+## Pausing a run (including before a Windows reboot)
+
+1. Create the pause-flag file:
+
+   ```bash
+   touch /tmp/taosmd-bench-pause
+   ```
+
+2. Wait. The runner checks the flag between conversations, not mid-conversation. Depending on how far through the current conversation it is, this can take a few minutes. That wait is correct behavior; the runner will not cut a conversation short.
+
+3. When the runner exits, verify it exited with code 3:
+
+   ```bash
+   echo $?   # expect: 3
+   ```
+
+4. Confirm the sidecar exists and has completed conversations:
+
+   ```bash
+   ls -lh benchmarks/results/locomo-rerank-gemma4e2b.json.ckpt.jsonl
+   grep -c '"kind": "conv"' benchmarks/results/locomo-rerank-gemma4e2b.json.ckpt.jsonl
+   ```
+
+5. It is now safe to reboot or shut down.
+
+The `rebootwin.sh` helper (see `benchmarks/rebootwin.sh`) automates steps 1 and 2: `bash benchmarks/rebootwin.sh pause`.
+
+---
+
+## Resuming after the box is back
+
+1. Remove the pause flag **before** re-running:
+
+   ```bash
+   rm -f /tmp/taosmd-bench-pause
+   ```
+
+2. Re-run the **identical** command with `--resume` appended:
+
+   ```bash
+   python3 benchmarks/locomo_runner.py \
+     --model gemma4:e2b \
+     --retrieval-top-k 50 --adjacent-turns 2 --reranker bge-v2-m3 --fusion mem0_additive \
+     --out benchmarks/results/locomo-rerank-gemma4e2b.json \
+     --resume
+   ```
+
+   `--resume` implies `--ckpt`. The runner loads the sidecar, verifies the config hash, skips every already-completed conversation (including their ingest), and picks up where it stopped.
+
+**Important:** every flag that affects the run config must match the original command. The runner computes a hash over the config at startup and compares it to the hash stored in the sidecar header. A mismatch exits with code 2 and refuses to proceed. If you need to change flags, start a fresh run with a different `--out` path.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Normal completion. All conversations finished. |
+| 3 | Clean pause. The pause-flag was found between conversations. Remove the flag and re-run with `--resume` to continue. |
+| 2 | Config mismatch or startup error. The flags on the resume command do not match the original run, or the sidecar is corrupt. Do not continue this run; investigate or start fresh with a new `--out`. |
+| 1 | All QAs failed. The run completed but every question failed to score. |
+
+---
+
+## Failure and recovery
+
+**Hard power loss or OOM kill mid-conversation:** the sidecar keeps every conversation that was already completed and fsync'd before the kill. The in-flight conversation (the one running when the process died) has no record in the sidecar and will be re-run from scratch on resume. No completed conversation is lost.
+
+**Truncated final line in the sidecar:** the runner detects a malformed final line and skips it with a warning on load, then re-runs that conversation. This is the expected crash-mid-write recovery path.
+
+**Sidecar missing on resume:** if you pass `--resume` and no sidecar exists, the runner starts fresh and logs that it is doing so. No error; the run proceeds from conversation 1.
+
+**Corrupt sidecar body (non-final line malformed):** the runner raises an error and refuses to load. This indicates data corruption beyond normal crash tolerance. Investigate or start a new run.
+
+---
+
+## Quick reference
+
+| Action | Command |
+|--------|---------|
+| Start a pausable run | `python3 benchmarks/locomo_runner.py ... --out benchmarks/results/<name>.json --ckpt` |
+| Pause (manual) | `touch /tmp/taosmd-bench-pause` |
+| Pause (helper, waits for clean exit) | `bash benchmarks/rebootwin.sh pause` |
+| Check pause/runner status | `bash benchmarks/rebootwin.sh status` |
+| Resume after reboot | Remove flag: `rm -f /tmp/taosmd-bench-pause`, then re-run original command with `--resume` |
+| Resume (helper prompt) | `bash benchmarks/rebootwin.sh resume` |
+| Check sidecar conversation count | `grep -c '"kind": "conv"' benchmarks/results/<name>.json.ckpt.jsonl` |
+| Check last exit code | `echo $?` immediately after the runner exits |


### PR DESCRIPTION
## What

Phases 2-3 of pausable benchmarks (#25), building on the merged phase-1 checkpointing:

- `docs/bench-pause-resume.md`: operator runbook. Start a pausable run (`--ckpt`), pause cleanly (including before a Fedora Windows reboot), resume after the box is back (`--resume`, same config), exit codes (0/3/2), hard-kill recovery, quick-reference table.
- `benchmarks/rebootwin.sh`: convenience wrapper for the hermes agent. `pause` (touch flag, wait for the runner to finish its in-flight conversation and exit, never kills, 30-min safety timeout), `status` (flag + runner + newest sidecar conversation count, read-only), `resume` (clear flag, print instructions, does not guess the original command).

## Scope

LoCoMo-runner-specific (that is where phase-1 checkpointing lives); the short judge-free probes are not checkpointed and out of scope. The helper never starts or kills the runner, it only manages the pause flag and reports state.

## Verification

`bash -n` clean; no-args prints usage exits 2; `status`/`pause` behave correctly with no runner present; flag names verified against `locomo_runner.py --help`; zero em dashes. Reviewed: process detection (`pgrep -f locomo_runner.py`), exit-code semantics, and the no-kill safety timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and resume functionality for benchmark runs with status monitoring capabilities.

* **Documentation**
  * Added comprehensive guide for managing, pausing, and resuming benchmarks including recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->