### PR TITLE
feat(vector): arctic-embed ONNX support (query prefix + CLS pooling)

### DIFF
--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -98,6 +98,39 @@ def pack_sign_bits(embedding: list[float]) -> str:
     return base64.b64encode(bits.tobytes()).decode("ascii")
 
 
+# Query-time prefix for arctic-embed (asymmetric: queries only, no doc prefix).
+_ARCTIC_QUERY_PREFIX = "Represent this sentence for searching relevant passages: "
+
+
+def _onnx_apply_prefix(onnx_path, text: str, task: str) -> str:
+    """Apply a model-specific input prefix to ONNX embed text.
+
+    Asymmetric embedders need the right prefix or retrieval silently
+    degrades. nomic-embed prefixes both queries and documents with the
+    task name; arctic-embed prefixes only the query. MiniLM and anything
+    else gets no prefix. Detection is by model directory name.
+    """
+    path = str(onnx_path).lower() if onnx_path else ""
+    if "nomic" in path:
+        return f"{task}: {text}"
+    if "arctic" in path and task == "search_query":
+        return f"{_ARCTIC_QUERY_PREFIX}{text}"
+    return text
+
+
+def _onnx_pooling_mode(onnx_path) -> str:
+    """Pooling mode for an ONNX embedder: "cls" or "mean".
+
+    arctic-embed pools the CLS token (its 1_Pooling config sets
+    pooling_mode_cls_token true, mean false); the MiniLM default and
+    everything else mean-pool over the attention mask.
+    """
+    path = str(onnx_path).lower() if onnx_path else ""
+    if "arctic" in path:
+        return "cls"
+    return "mean"
+
+
 class VectorMemory:
     """SQLite-backed vector store with pluggable embeddings.
 
@@ -300,11 +333,8 @@ class VectorMemory:
         """Embed using ONNX Runtime (fast CPU inference, no PyTorch)."""
         import numpy as np
         try:
-            # Add task prefix for models that use it (nomic-embed)
-            # Detected by checking if the model config mentions "nomic" or has task_type support
-            embed_text = text[:512]
-            if self._onnx_path and "nomic" in str(self._onnx_path).lower():
-                embed_text = f"{task}: {embed_text}"
+            # Apply any model-specific input prefix (asymmetric embedders).
+            embed_text = _onnx_apply_prefix(self._onnx_path, text[:512], task)
 
             inputs = self._onnx_tokenizer(embed_text, return_tensors="np", padding=True, truncation=True)
             feed = {
@@ -317,13 +347,19 @@ class VectorMemory:
 
             outputs = self._onnx_session.run(None, feed)
 
-            # Check if model provides sentence_embedding directly
+            # Pool. A model that exposes a ready sentence_embedding wins; else
+            # pool per the model's documented mode (CLS for arctic-embed, mean
+            # otherwise). Getting this wrong silently degrades a model, so it
+            # is selected explicitly, not guessed.
             output_names = [o.name for o in self._onnx_session.get_outputs()]
             if "sentence_embedding" in output_names:
                 idx = output_names.index("sentence_embedding")
-                emb = outputs[idx][0]  # (384,)
+                emb = outputs[idx][0]
+            elif _onnx_pooling_mode(self._onnx_path) == "cls":
+                # CLS-token pooling: the first token of the last hidden state.
+                emb = outputs[0][0, 0]
             else:
-                # Manual mean pooling
+                # Mean pooling over the attention mask.
                 token_embeddings = outputs[0]
                 mask = inputs["attention_mask"][..., np.newaxis].astype(np.float32)
                 pooled = (token_embeddings * mask).sum(axis=1) / mask.sum(axis=1)

--- a/tests/test_arctic_embed.py
+++ b/tests/test_arctic_embed.py
@@ -1,0 +1,47 @@
+"""ONNX embed prefix and pooling selection for asymmetric models (arctic-embed).
+
+The actual embedding needs the model and runs on the bench host; these
+tests pin the prefix and pooling-mode logic that, if wrong, silently
+degrades a model and invalidates a benchmark comparison.
+"""
+
+from taosmd.vector_memory import (
+    _ARCTIC_QUERY_PREFIX,
+    _onnx_apply_prefix,
+    _onnx_pooling_mode,
+)
+
+
+def test_arctic_query_gets_prefix():
+    out = _onnx_apply_prefix("models/snowflake-arctic-embed-s", "who is alice", "search_query")
+    assert out == f"{_ARCTIC_QUERY_PREFIX}who is alice"
+
+
+def test_arctic_document_gets_no_prefix():
+    out = _onnx_apply_prefix("models/snowflake-arctic-embed-s", "alice adopted a dog", "search_document")
+    assert out == "alice adopted a dog"
+
+
+def test_nomic_prefixes_both_query_and_document():
+    q = _onnx_apply_prefix("models/nomic-embed-text-v1.5", "x", "search_query")
+    d = _onnx_apply_prefix("models/nomic-embed-text-v1.5", "x", "search_document")
+    assert q == "search_query: x"
+    assert d == "search_document: x"
+
+
+def test_minilm_gets_no_prefix():
+    for task in ("search_query", "search_document"):
+        assert _onnx_apply_prefix("models/cross-encoder-onnx-minilm", "x", task) == "x"
+
+
+def test_prefix_handles_none_path():
+    assert _onnx_apply_prefix(None, "x", "search_query") == "x"
+
+
+def test_arctic_pools_cls():
+    assert _onnx_pooling_mode("models/snowflake-arctic-embed-xs") == "cls"
+
+
+def test_default_pools_mean():
+    assert _onnx_pooling_mode("models/all-MiniLM-L6-v2-onnx") == "mean"
+    assert _onnx_pooling_mode(None) == "mean"


### PR DESCRIPTION
## What

Correct ONNX support for Snowflake arctic-embed models: a query-only input prefix ("Represent this sentence for searching relevant passages: ") and CLS-token pooling, both selected by model directory name. The existing path mean-pooled and applied no prefix, which would silently cripple arctic-embed.

Two small pure helpers (`_onnx_apply_prefix`, `_onnx_pooling_mode`) wired into `_embed_onnx`, with 7 unit tests pinning the prefix/pooling logic (the part that, if wrong, invalidates a benchmark).

## Why

Enables E-007 (arctic-embed vs MiniLM as the low-tier dense embedder). Default-off: nothing changes unless a caller points `--embed-mode onnx --onnx-path` at an arctic model. nomic and MiniLM behavior unchanged.

## Result it unlocked

E-007 Stage 1 (judge-free R@K, subset-200, matched harness, adj=2): MiniLM 0.6768, arctic-embed-s 0.8333 (+0.157), arctic-embed-xs 0.7374 (+0.061). Both clear the pre-registered +0.02 gate. A judged LoCoMo confirm runs before any default change (per the E-007 kill criterion).

## Tests

7 new (tests/test_arctic_embed.py), vector-memory suite green, smoke-tested on the bench host (relevant-sim 0.73 vs irrelevant 0.29).