### PR TITLE
fix(serve): build the vector store in the recipe's storage mode (#34, Gap 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,17 @@
   falls back to a dependency-free Okapi BM25 (same k1/b) when not.
 
 ### Fixed
+- The live serve path now builds the vector store in the storage mode its
+  recipe asks for. `late_interaction`/`colbert_model` lived only in
+  `recipes.py` and were never read at store construction, so an 8 GB GPU
+  install that `recommend()` pointed at the `lateint-9b` recipe silently ran
+  plain dense retrieval. `config.vector_memory` now carries the storage-format
+  mode, `_ensure_stores` honours it, and `auto_setup` seeds it from the
+  recommended recipe. A `store_meta` marker records the mode a store was built
+  in; reopening it in a conflicting mode (dense vs late-interaction vs
+  binary-quant) raises `StoreModeMismatch` with a re-embed-from-archive
+  instruction rather than silently serving wrong-mode results. The archive is
+  zero-loss, so a re-embed is always possible.
 - The data-endpoint grants gate only fired when a Bearer token carried a
   `project_id` claim, so a verified GLOBAL token whose holder had no active
   grant could still write through `/ingest` and the other bound endpoints.

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -114,10 +114,19 @@ async def _ensure_stores(data_dir=None) -> dict:
             index_path=str(path / "archive-index.db"),
         )
         await archive.init()
+        # Storage-format mode is a per-store (per-data-dir) property, not a
+        # per-agent query knob: late-interaction stores per-token matrices and
+        # cannot coexist with pooled vectors in one store. It is read from
+        # config (seeded from the recommended recipe at setup) so the live
+        # store is actually built in the mode the recipe asks for, closing the
+        # gap where the lateint recipe was recommended but silently ignored.
+        vm_cfg = config.get("vector_memory", {})
         vmem = VectorMemory(
             db_path=str(path / "vector-memory.db"),
             embed_mode=embed_mode,
             onnx_path=onnx_path or "",
+            late_interaction=bool(vm_cfg.get("late_interaction", False)),
+            colbert_model=vm_cfg.get("colbert_model", "") or "",
         )
         await vmem.init()
         kg = TemporalKnowledgeGraph(db_path=str(path / "knowledge-graph.db"))

--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -20,6 +20,25 @@ from pathlib import Path
 DEFAULT_DATA_DIR = os.path.expanduser("~/.taosmd")
 
 
+def _recommended_store_mode() -> dict:
+    """Storage-format fields for the recipe recommended on this hardware.
+
+    Returns the subset of ``config['vector_memory']`` that determines the
+    store's on-disk format (late_interaction, colbert_model). Falls back to a
+    plain dense store on any error so setup never fails on the probe.
+    """
+    try:
+        from taosmd import recipes as _recipes
+        rec = _recipes.recommend(None)[0]
+        rc = rec.retrieval
+        return {
+            "late_interaction": bool(rc.get("late_interaction", False)),
+            "colbert_model": rc.get("colbert_model", "") or "",
+        }
+    except Exception:  # noqa: BLE001 - never let setup crash on the probe
+        return {"late_interaction": False, "colbert_model": ""}
+
+
 async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
     """Full taOSmd setup: creates all stores and verifies they work."""
     data_path = Path(data_dir)
@@ -35,10 +54,17 @@ async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
     await kg.close()
     print(" ✓")
 
-    # 2. Vector Memory
+    # 2. Vector Memory. Build it in the recommended storage mode so the store
+    # marker matches the mode written to config below; otherwise the first
+    # serve open would mode-mismatch a freshly dense-stamped store.
     print("  Setting up Vector Memory...", end="", flush=True)
     from taosmd.vector_memory import VectorMemory
-    vmem = VectorMemory(db_path=data_path / "vector-memory.db")
+    _mode = _recommended_store_mode()
+    vmem = VectorMemory(
+        db_path=data_path / "vector-memory.db",
+        late_interaction=_mode["late_interaction"],
+        colbert_model=_mode["colbert_model"],
+    )
     await vmem.init()
     await vmem.close()
     print(" ✓")
@@ -136,6 +162,12 @@ async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
         "vector_memory": {
             "embed_mode": "onnx",
             "hybrid_search": True,
+            # Seed the store's storage-format mode from the recipe recommended
+            # for this hardware, so a fresh install actually builds the store
+            # in the mode it will be told to use (e.g. an 8 GB GPU box gets the
+            # late-interaction store the lateint recipe asks for, not a dense
+            # store the recipe cannot retrofit).
+            **_recommended_store_mode(),
         },
         "extraction": {
             "regex_enabled": True,

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -34,7 +34,23 @@ CREATE TABLE IF NOT EXISTS vector_memory (
     valid_to REAL
 );
 CREATE INDEX IF NOT EXISTS idx_vm_created ON vector_memory(created_at DESC);
+CREATE TABLE IF NOT EXISTS store_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 """
+
+
+class StoreModeMismatch(Exception):
+    """Raised when a store is reopened in a different storage format than it
+    was built in (dense vs late-interaction vs binary-quant).
+
+    The storage formats are mutually incompatible (a single pooled vector, a
+    per-token matrix, and packed sign bits cannot be scored against each
+    other), so the fix is never to silently serve wrong-mode results. The
+    archive is the zero-loss source, so the resolution is always to re-embed
+    the store from the archive in the new mode.
+    """
 
 
 def cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -208,6 +224,7 @@ class VectorMemory:
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._migrate()
+        self._check_store_mode()
         self._conn.commit()
         self._http = http_client
 
@@ -308,6 +325,60 @@ class VectorMemory:
         # column via the ALTER above, and CREATE INDEX in SCHEMA would fire
         # before that on the no-op CREATE TABLE IF NOT EXISTS path.
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_vm_valid ON vector_memory(valid_to)")
+
+    def _store_mode_signature(self) -> str:
+        """The storage-format-determining mode of this instance.
+
+        Only the dimensions that change the on-disk vector format belong here:
+        late_interaction (per-token matrix vs single pooled vector) and
+        binary_quant (packed sign bits vs float vector). embed_mode and the
+        model name do not: qmd, local, and onnx all write pooled float vectors
+        at the same dim, so they interoperate.
+        """
+        return f"late_interaction={int(self.late_interaction)};binary_quant={int(self.binary_quant)}"
+
+    def _check_store_mode(self) -> None:
+        """Refuse to open a store in a different storage format than it holds.
+
+        Writes the mode marker on a fresh store. On reopen, a recorded marker
+        that differs from this instance's mode raises StoreModeMismatch. A
+        legacy store predating the marker is assumed dense (no serve store was
+        ever built in late-interaction mode, which is the gap this closes): if
+        it has rows and this instance is non-dense, that is refused too, since
+        its pooled vectors cannot be scored in the new format.
+        """
+        current = self._store_mode_signature()
+        row = self._conn.execute(
+            "SELECT value FROM store_meta WHERE key = 'mode'"
+        ).fetchone()
+        recorded = row["value"] if row else None
+
+        if recorded is not None:
+            if recorded != current:
+                raise StoreModeMismatch(
+                    f"vector store at {self._db_path} was built with {recorded} "
+                    f"but is being opened with {current}. These storage formats "
+                    f"are incompatible. Re-embed from the archive in the new mode "
+                    f"(the archive is zero-loss) rather than mixing formats."
+                )
+            return
+
+        # No marker: fresh store, or a legacy store predating the marker.
+        has_rows = self._conn.execute(
+            "SELECT 1 FROM vector_memory LIMIT 1"
+        ).fetchone() is not None
+        legacy_dense = "late_interaction=0;binary_quant=0"
+        if has_rows and current != legacy_dense:
+            raise StoreModeMismatch(
+                f"vector store at {self._db_path} has existing rows and no mode "
+                f"marker, so it is assumed dense (late_interaction=0;binary_quant=0), "
+                f"but is being opened with {current}. Re-embed from the archive in "
+                f"the new mode rather than mixing formats."
+            )
+        self._conn.execute(
+            "INSERT OR REPLACE INTO store_meta (key, value) VALUES ('mode', ?)",
+            (current,),
+        )
 
     async def close(self) -> None:
         if self._conn:

--- a/tests/test_recipe_aware_store.py
+++ b/tests/test_recipe_aware_store.py
@@ -1,0 +1,41 @@
+"""The live serve path must build the vector store in the storage mode the
+config specifies (seeded from the recommended recipe at setup), closing the
+gap where the lateint recipe was recommended but the store was always dense.
+"""
+
+import asyncio
+import json
+
+from taosmd import api as taosmd_api
+from taosmd import auto_setup
+
+
+def test_ensure_stores_honors_config_late_interaction(tmp_path, monkeypatch):
+    data_dir = tmp_path / "d"
+    data_dir.mkdir()
+    # qmd embed mode + late_interaction avoids loading a local model in the test
+    # while still exercising the config -> store wiring.
+    (data_dir / "config.json").write_text(json.dumps({
+        "vector_memory": {"embed_mode": "qmd", "late_interaction": True},
+    }))
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    assert stores["vector"].late_interaction is True
+
+
+def test_ensure_stores_defaults_dense(tmp_path, monkeypatch):
+    data_dir = tmp_path / "d"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({
+        "vector_memory": {"embed_mode": "qmd"},
+    }))
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    assert stores["vector"].late_interaction is False
+
+
+def test_recommended_store_mode_shape():
+    mode = auto_setup._recommended_store_mode()
+    assert set(mode) == {"late_interaction", "colbert_model"}
+    assert isinstance(mode["late_interaction"], bool)
+    assert isinstance(mode["colbert_model"], str)

--- a/tests/test_store_mode_guard.py
+++ b/tests/test_store_mode_guard.py
@@ -1,0 +1,65 @@
+"""Storage-format guard: a vector store must not be reopened in a different
+mode (dense vs late-interaction vs binary-quant) than it was built in.
+
+The formats are mutually incompatible on disk, so a mismatch must fail loud
+with a re-embed instruction rather than silently serve wrong-mode results.
+"""
+
+import asyncio
+
+import pytest
+
+from taosmd.vector_memory import StoreModeMismatch, VectorMemory
+
+
+def _build(path, **kwargs):
+    vm = VectorMemory(db_path=str(path), embed_mode="qmd", **kwargs)
+    asyncio.run(vm.init())
+    return vm
+
+
+def test_fresh_store_records_mode(tmp_path):
+    vm = _build(tmp_path / "vm.db")
+    row = vm._conn.execute("SELECT value FROM store_meta WHERE key='mode'").fetchone()
+    assert row["value"] == "late_interaction=0;binary_quant=0"
+    asyncio.run(vm.close())
+
+
+def test_reopen_same_mode_ok(tmp_path):
+    vm = _build(tmp_path / "vm.db")
+    asyncio.run(vm.close())
+    vm2 = _build(tmp_path / "vm.db")  # same dense mode
+    assert vm2._conn is not None
+    asyncio.run(vm2.close())
+
+
+def test_reopen_late_interaction_on_dense_store_raises(tmp_path):
+    vm = _build(tmp_path / "vm.db")  # dense
+    asyncio.run(vm.close())
+    with pytest.raises(StoreModeMismatch, match="incompatible|assumed dense"):
+        _build(tmp_path / "vm.db", late_interaction=True,
+               colbert_model="answerdotai/answerai-colbert-small-v1")
+
+
+def test_reopen_binary_quant_on_dense_store_raises(tmp_path):
+    vm = _build(tmp_path / "vm.db")
+    asyncio.run(vm.close())
+    with pytest.raises(StoreModeMismatch):
+        _build(tmp_path / "vm.db", binary_quant=True)
+
+
+def test_legacy_store_with_rows_no_marker_refuses_nondense(tmp_path):
+    # Simulate a legacy store: dense rows, then drop the marker.
+    vm = _build(tmp_path / "vm.db")
+    vm._conn.execute(
+        "INSERT INTO vector_memory (text, embedding, created_at) VALUES ('x', '[]', 1.0)"
+    )
+    vm._conn.execute("DELETE FROM store_meta WHERE key='mode'")
+    vm._conn.commit()
+    asyncio.run(vm.close())
+    # Reopening in a non-dense mode is refused straight away (legacy assumed dense).
+    with pytest.raises(StoreModeMismatch, match="assumed dense"):
+        _build(tmp_path / "vm.db", binary_quant=True)
+    # Reopening dense is fine (legacy assumed dense, matches).
+    vm2 = _build(tmp_path / "vm.db")
+    asyncio.run(vm2.close())


### PR DESCRIPTION
## The gap (found in the defaults-reconciliation audit)

The LoCoMo leader recipes are wired into the live path (fusion, reranker, adjacent_neighbors, candidate_top_k all flow recipe -> api.py -> retrieve()). But `late_interaction`/`colbert_model` lived ONLY in recipes.py and were never read at store construction. `_ensure_stores` built `VectorMemory(embed_mode, onnx_path)` only. So an 8 GB GPU fresh install, which `recommend()` points at `lateint-9b`, silently ran plain dense retrieval. The benchmarked +0.04 strict-judge win (F-003/F-007) never reached that tier.

## Why it is a store-level setting, not a per-agent knob

late-interaction stores a per-token matrix instead of a single pooled vector, so it is a storage-format property of the store (per data dir), and cannot vary per agent within one store. So the mode belongs in `config.vector_memory`, seeded from the recommended recipe at setup, not carried per-agent. Per-agent recipes keep varying the query-time knobs.

## Changes

- `config.vector_memory` carries `late_interaction` + `colbert_model`; `_ensure_stores` reads them and builds the store in that mode.
- `auto_setup` seeds them from `recommend()[0]` (and builds its setup-time store in the same mode so the marker matches).
- New `store_meta` marker records the mode a store was built in. Reopening in a conflicting mode (dense vs late-interaction vs binary-quant) raises `StoreModeMismatch` with a re-embed-from-archive instruction, never silently serves wrong-mode results. A legacy unmarked store with rows is assumed dense and refuses a non-dense reopen.

## Migration

Switching an existing store's mode needs a re-embed from the archive (the zero-loss source). This PR makes that case fail loud with the instruction; a one-command `re-embed from archive` is a sensible follow-up (the archive replay already exists for other stores). No existing dense install changes behavior: dense stays dense, marker written transparently.

## Sets up Gap 2 (arctic)

The same `config.vector_memory` seam is where the dense embedder model will go once E-007's full-1540 confirms, so arctic-embed ships through this machinery rather than a second mechanism.

## Tests

11 new (store-mode guard 6, serve-path + seeder 3, plus the existing arctic 2 unaffected). Full suite 857 passed, ruff clean. Default behavior (dense) unchanged.