### PR TITLE
feat(claims): Provable Memory layer, default-off (v2 spine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## Unreleased
 
 ### Added
+- **Claims layer (Provable Memory), default-off.** A new additive `taosmd/claims/`
+  package that extracts facts as claims carrying their archive-span provenance,
+  verifies them asynchronously against only those source spans with a
+  cross-family local-LLM entailment judge (fail-closed: an unparseable or failed
+  verdict stays unverified, never promoted), and demotes (never deletes)
+  unverified/unsupported claims from recall behind a `prefer_verified` flag on
+  `search()` (default `off`, so existing behaviour is unchanged). New
+  `ClaimStore` (zero-loss sqlite, rebuildable from the archive, exposes the live
+  hallucination rate), `taosmd verify` and `taosmd claims status` CLI, and a
+  store-mode gate that is a pure function. This turns F-009 (the measured 18.8
+  percent extraction-hallucination rate) into a live always-on quality signal.
+  The default flip is gated on the pre-registered E-009 experiment.
 - **Temporal date-range lever (`retrieve(temporal={...})`), default off.** A
   deterministic natural-language temporal parser (`taosmd/temporal.py`) that
   turns expressions like "last week", "in May 2023", "Q1 2026", or "on 8 May,

--- a/docs/research-report.md
+++ b/docs/research-report.md
@@ -63,6 +63,7 @@ Every row is stable. IDs are never reused. E-ids carry over when an experiment m
 | E-006 | Write-skip floor: SAFE (delta +0.0051, zero evidence skipped) but fires on only 2.3 percent of turns, under the 5 percent shipping floor | [6](#6-ongoing-work-pre-registered) | resolved -> N-010 | VPS e1_write_skip_20260612_143625.json |
 | E-007 | Arctic-embed vs MiniLM low-tier dense: CONFIRMED full-1540 (judged +0.0565, 0.7305 vs 0.6740) + R@K +0.157; clear default-change-worthy win | [6](#6-ongoing-work-pre-registered) | resolved -> F-010 (full-1540) | bench host e007full_*_20260613_131837 |
 | E-008 | Surprisal as retention-priority signal: KILLED, worst of all policies at every budget (below random); length wins. Surprisal pillar dead, v2 pivots to provenance/claims | [6](#6-ongoing-work-pre-registered) | resolved -> N-011 | VPS e008_retention_20260613_115258.json |
+| E-009 | Claims gate (Provable Memory): does verified-preferred recall cut the served-hallucination rate without dropping judged accuracy/R@K? gate off vs prefer_verified vs strict | [6](#6-ongoing-work-pre-registered) | pre-registered | branch feat/claims-layer |
 
 ---
 
@@ -482,6 +483,16 @@ Quoting the criterion: "surprisal-priority retention must beat the best non-rand
 
 Status: resolved to N-011 (surprisal retention killed); v2 spine pivots to provenance/claims.
 
+**E-009. Does the claims gate improve answers without tanking recall?**
+
+The validation gate for the v2 claims layer (Provable Memory), the additive default-off layer that verifies extracted claims against their archive spans (cross-family local entailment, async) and demotes unverified/unsupported claims from recall. This experiment decides whether the gate ships default-on.
+
+Design: on a LoCoMo slice, ingest with claims extracted and a verify-pass run (real cross-family local judge), then answer the QAs three ways, gate off (baseline), prefer_verified (demote unsupported, prefer supported), and strict (also exclude unverified), judged externally. Report, per mode: judged accuracy, R@K (to confirm demotion does not discard needed evidence), and the served-hallucination rate (share of answers citing an unsupported claim). Harness: benchmarks/claims_gate_probe.py (to build), checkpointable.
+
+Kill criterion (verbatim): "the claims gate ships default-on only if it reduces the served-hallucination rate by a meaningful margin AND does not drop judged accuracy or R@K by more than 0.02. If it trades accuracy for purity, it ships default-OFF as an opt-in integrity mode with its measured trade documented; it is never silently enabled."
+
+Status: pre-registered before any run. The claims layer code (taosmd/claims/, default-off) is on branch feat/claims-layer; this experiment runs before the flag is flipped.
+
 ---
 
 ## 7. Revision Log
@@ -500,6 +511,7 @@ This log is append-only. History is never rewritten.
 | 2026-06-12 | 1.7 | E-004 root cause found: the pylate loader is exonerated (direct load test shows the trained 96-dim Stanford projection applied correctly); the 0.050 and 0.0 results came from the search gate bug plus a pre-fix checkout on the bench host. The earlier "96 vs 128" blocker note was a misdiagnosis. Full projected-space comparison re-running. Index status updated. |
 | 2026-06-12 | 1.8 | E-004 resolved to N-008: both ColBERT projected spaces 0.730 vs answerai backbone 0.760 on subset-200 gemma; decision rule quoted, no recipe upgrade; the 4x token-matrix footprint trade of the 96-dim space recorded. benchmarks.md late-interaction section updated with the projected-space table. |
 | 2026-06-12 | 1.9 | E-001 resolved to N-009: the matched-turn-budget control shows surprise-boundary chunking was a coverage artifact (baseline at k=120 beats chunks at k=20 by 0.15); kill criterion quoted; both surprisal retrieval arms now dead. Methods lesson recorded: compare chunking levers at matched turn budget, never matched k. |
+| 2026-06-13 | 1.16 | Pre-registered E-009, the validation gate for the v2 claims layer (Provable Memory): does verified-preferred recall cut the served-hallucination rate without dropping judged accuracy or R@K? Kill criterion written before any run; the default-off claims layer code is on branch feat/claims-layer. |
 | 2026-06-13 | 1.15 | E-007 (F-010) confirmed at full-1540: arctic-embed-s 0.7305 vs MiniLM 0.6740 judged, +0.0565, larger than the subset-200 delta. Default-change-worthy; ship-the-win PR is the next action. |
 | 2026-06-13 | 1.14 | E-008 resolved to N-011: surprisal is the worst retention-priority signal (below random at every budget); length wins. The v2 surprisal pillar is conclusively dead across retrieval (N-009/N-010) and consolidation, so the spine pivots to the provenance/claims layer (F-009) per the pre-registered criterion. Length flagged as a positive side-finding for future pre-registration. |
 | 2026-06-13 | 1.13 | E-007 resolved to F-010 on subset-200: arctic-embed-s beats MiniLM as the low-tier dense embedder, +0.157 R@K and +0.040 judged at the same dimension and latency, both stages passed. Added results subsection 3.7. Full-1540 judged confirm in flight before the user-facing default is switched. First positive finding after N-008/N-009/N-010. |

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -131,11 +131,15 @@ async def _ensure_stores(data_dir=None) -> dict:
         await vmem.init()
         kg = TemporalKnowledgeGraph(db_path=str(path / "knowledge-graph.db"))
         await kg.init()
+        from taosmd.claims.store import ClaimStore  # noqa: PLC0415
+        claims = ClaimStore(db_path=str(path / "claims.db"))
+        await claims.init()
 
         stores = {
             "archive": archive,
             "vector": vmem,
             "kg": kg,
+            "claims": claims,
             "data_dir": str(path),
         }
         _stores_cache[resolved] = stores
@@ -205,7 +209,7 @@ async def ingest(transcript, *, agent: str, project: str | None = None, data_dir
         text = str(item.get("content", "")).strip()
         if not text:
             continue
-        await stores["archive"].record(
+        span_id = await stores["archive"].record(
             "conversation",
             item,
             agent_name=agent,
@@ -219,7 +223,18 @@ async def ingest(transcript, *, agent: str, project: str | None = None, data_dir
             meta["role"] = item["role"]
         if "timestamp" in item:
             meta["timestamp"] = item["timestamp"]
+        # Provenance: tag the vector row with its archive span so the recall
+        # gate can look up the verification status of the claims it backs.
+        if isinstance(span_id, int) and span_id >= 0:
+            meta["archive_span_id"] = span_id
         await stores["vector"].add(text, metadata=meta)
+        # Claims layer (additive): extract facts as claims tagged with the same
+        # archive span. Stored unverified; the verify-pass checks them async.
+        if "claims" in stores and isinstance(span_id, int) and span_id >= 0:
+            from taosmd.claims.extract import claims_from_text  # noqa: PLC0415
+            for c in claims_from_text(text, span_id):
+                await stores["claims"].add_claim(
+                    c["text"], c["archive_span_ids"], c["source_extractor"])
         archived += 1
 
     update_stats(agent, last_ingest_at=int(time.time()))
@@ -318,6 +333,30 @@ async def ingest_batch(
     }
 
 
+async def _attach_and_gate_claims(hits: list[dict], claim_store, mode: str) -> list[dict]:
+    """Attach each hit's backing-claim status (looked up by its source archive
+    span) and apply the recall gate. ``mode`` "off" is a no-op passthrough.
+
+    Operates on formatted hits (which carry ``confidence``); the pure gate sorts
+    by ``score``, so a transient ``score`` mirror of ``confidence`` is set for
+    the gate and stripped afterward, leaving the hit contract clean. The store
+    lookup runs only when the gate is on.
+    """
+    if mode == "off" or not hits:
+        return hits
+    from taosmd.claims.gate import apply_claims_gate  # noqa: PLC0415
+    for h in hits:
+        span = (h.get("metadata") or {}).get("archive_span_id")
+        spans = [span] if isinstance(span, int) else []
+        h["claim_status"] = await claim_store.status_for_spans(spans)
+        h["score"] = h.get("confidence", 0.0)
+    gated = apply_claims_gate(hits, mode=mode)
+    for h in gated:
+        h.pop("score", None)
+        h.pop("claim_status", None)
+    return gated
+
+
 def _format_hit(hit: dict) -> dict:
     """Reshape a retrieve() hit into the agent-rules contract shape.
 
@@ -361,6 +400,7 @@ async def search(
     also_include: list[str] | None = None,
     limit: int = 5,
     mode: str | None = None,
+    prefer_verified: str = "off",
     data_dir=None,
 ) -> list[dict]:
     """Search the librarian's shelves for passages relevant to ``query``.
@@ -428,7 +468,7 @@ async def search(
                 "source_score": h.get("similarity", 0.0),
                 "metadata": md,
             }))
-        return hits
+        return await _attach_and_gate_claims(hits, stores.get("claims"), prefer_verified)
 
     # Resolve the active recipe (per-agent -> global default -> recommend()[0])
     # and map its retrieval knobs onto the retrieve() call below.
@@ -473,7 +513,7 @@ async def search(
     hits = [_format_hit(hit) for hit in raw]
     if degraded and hits:
         hits[0].setdefault("metadata", {})["recipe_degraded"] = degraded
-    return hits
+    return await _attach_and_gate_claims(hits, stores.get("claims"), prefer_verified)
 
 
 async def list_projects(*, data_dir=None) -> list[dict]:

--- a/taosmd/claims/__init__.py
+++ b/taosmd/claims/__init__.py
@@ -1,0 +1,8 @@
+"""taOSmd claims layer (Provable Memory): claims with archive-span provenance,
+asynchronous cross-family verification, and a default-off recall gate. Additive
+to v1; the archive remains the only permanent thing and the claims store is a
+rebuildable projection of it."""
+
+from taosmd.claims.store import ClaimStore, VALID_STATUSES
+
+__all__ = ["ClaimStore", "VALID_STATUSES"]

--- a/taosmd/claims/extract.py
+++ b/taosmd/claims/extract.py
@@ -1,0 +1,35 @@
+"""Turn archived text into claims with provenance.
+
+Wraps the existing regex fact extractor; the one thing this adds is the link
+back to the archive span the fact came from, which the verifier and the gate
+both need. LLM-based extractors can be added later behind the same shape.
+
+The extractor returns {subject, predicate, object} dicts; the claim text is
+their natural-language join (predicate underscores become spaces).
+"""
+from __future__ import annotations
+
+from taosmd.memory_extractor import extract_facts_from_text
+
+
+def claims_from_text(text: str, archive_span_id: int) -> list[dict]:
+    """Return claim dicts {text, archive_span_ids, source_extractor} for *text*.
+
+    Each fact extracted from *text* is tagged with the archive row id it was
+    drawn from, so a later verify-pass can fetch exactly that source span.
+    """
+    if not text or not text.strip():
+        return []
+    out = []
+    for fact in extract_facts_from_text(text):
+        subject = (fact.get("subject") or "").strip()
+        predicate = (fact.get("predicate") or "").replace("_", " ").strip()
+        obj = (fact.get("object") or "").strip()
+        ftext = " ".join(p for p in (subject, predicate, obj) if p).strip()
+        if ftext:
+            out.append({
+                "text": ftext,
+                "archive_span_ids": [archive_span_id],
+                "source_extractor": "regex",
+            })
+    return out

--- a/taosmd/claims/gate.py
+++ b/taosmd/claims/gate.py
@@ -1,0 +1,30 @@
+"""Pure recall gate: reorder/filter hits by the verification status of the
+claims their source spans back. No I/O. Each hit carries an optional
+``claim_status`` (None for raw non-claim memories), attached by the recall
+wiring before this runs.
+
+Modes:
+  off              identity (the flag is not set).
+  prefer_verified  drop hits whose claim is unsupported/contradicted; boost
+                   supported above the rest; keep unverified and raw hits.
+  strict           additionally drop unverified claim-backed hits (fail-closed:
+                   only proven-supported claim-backed hits survive; raw hits
+                   without a claim are still kept, they were never claims).
+"""
+from __future__ import annotations
+
+_DROP_LENIENT = ("unsupported", "contradicted")
+_DROP_STRICT = ("unsupported", "contradicted", "partial", "unverified")
+_BOOST = 1.0  # added to a supported claim-backed hit's score so it ranks first
+
+
+def apply_claims_gate(hits: list[dict], mode: str = "off") -> list[dict]:
+    if mode == "off" or not hits:
+        return hits
+    drop = _DROP_STRICT if mode == "strict" else _DROP_LENIENT
+    kept = [h for h in hits if (h.get("claim_status") not in drop)]
+    for h in kept:
+        if h.get("claim_status") == "supported":
+            h["score"] = h.get("score", 0.0) + _BOOST
+    kept.sort(key=lambda h: h.get("score", 0.0), reverse=True)
+    return kept

--- a/taosmd/claims/store.py
+++ b/taosmd/claims/store.py
@@ -1,0 +1,119 @@
+"""Zero-loss sqlite store for verifiable claims.
+
+A claim is an extracted fact plus the archive spans it derives from and a
+verification status. Status changes; rows are never deleted (zero-loss). The
+store is a compilation artifact, rebuildable from the archive.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+from taosmd import _db
+
+VALID_STATUSES = ("unverified", "supported", "partial", "unsupported", "contradicted")
+# What counts as a hallucination for the live rate (checked but not supported).
+_HALLUCINATED = ("unsupported", "partial", "contradicted")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claims (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT NOT NULL,
+    archive_span_ids TEXT NOT NULL DEFAULT '[]',
+    status TEXT NOT NULL DEFAULT 'unverified',
+    verifier_model TEXT,
+    last_checked REAL,
+    source_extractor TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_claims_status ON claims(status);
+"""
+
+
+class ClaimStore:
+    def __init__(self, db_path: str | Path = "data/claims.db"):
+        self._db_path = str(db_path)
+        self._conn: sqlite3.Connection | None = None
+
+    async def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = _db.connect(self._db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    async def add_claim(self, text: str, archive_span_ids: list[int],
+                        source_extractor: str, now: float | None = None) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO claims (text, archive_span_ids, status, source_extractor, created_at)"
+            " VALUES (?, ?, 'unverified', ?, ?)",
+            (text, json.dumps(archive_span_ids), source_extractor,
+             now if now is not None else time.time()),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    async def get(self, claim_id: int) -> dict | None:
+        row = self._conn.execute("SELECT * FROM claims WHERE id = ?", (claim_id,)).fetchone()
+        return self._row(row) if row else None
+
+    async def set_status(self, claim_id: int, status: str, verifier_model: str,
+                         now: float | None = None) -> None:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"unknown claim status: {status!r}")
+        self._conn.execute(
+            "UPDATE claims SET status = ?, verifier_model = ?, last_checked = ? WHERE id = ?",
+            (status, verifier_model, now if now is not None else time.time(), claim_id),
+        )
+        self._conn.commit()
+
+    async def pull_unverified(self, limit: int = 100) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT * FROM claims WHERE status = 'unverified' ORDER BY id LIMIT ?", (limit,)
+        ).fetchall()
+        return [self._row(r) for r in rows]
+
+    async def status_for_spans(self, span_ids: list[int]) -> str | None:
+        """Worst status among claims backed by any of these archive spans.
+
+        Used by the recall gate to judge a hit by the claims its source spans
+        back. Worst-wins so one unsupported claim demotes the hit. None when no
+        claim references these spans (a raw, non-claim memory)."""
+        if not span_ids:
+            return None
+        rows = self._conn.execute("SELECT archive_span_ids, status FROM claims").fetchall()
+        want = set(span_ids)
+        order = {s: i for i, s in enumerate(
+            ("supported", "unverified", "partial", "contradicted", "unsupported"))}
+        worst = None
+        for r in rows:
+            if want & set(json.loads(r["archive_span_ids"])):
+                if worst is None or order[r["status"]] > order[worst]:
+                    worst = r["status"]
+        return worst
+
+    async def rate(self) -> dict:
+        counts = {s: 0 for s in VALID_STATUSES}
+        for r in self._conn.execute("SELECT status, COUNT(*) c FROM claims GROUP BY status"):
+            counts[r["status"]] = r["c"]
+        checked = sum(counts[s] for s in VALID_STATUSES if s != "unverified")
+        hall = sum(counts[s] for s in _HALLUCINATED)
+        counts["hallucination_rate"] = (hall / checked) if checked else 0.0
+        return counts
+
+    @staticmethod
+    def _row(r: sqlite3.Row) -> dict:
+        return {
+            "id": r["id"], "text": r["text"],
+            "archive_span_ids": json.loads(r["archive_span_ids"]),
+            "status": r["status"], "verifier_model": r["verifier_model"],
+            "last_checked": r["last_checked"], "source_extractor": r["source_extractor"],
+            "created_at": r["created_at"],
+        }

--- a/taosmd/claims/verifier.py
+++ b/taosmd/claims/verifier.py
@@ -1,0 +1,71 @@
+"""Claim verifiers. A verifier is shown ONLY the cited spans and judges whether
+the claim is supported. Cross-family from the extractor (the F-009 method).
+Fail-closed: anything unparseable maps to 'unverified', never 'supported'.
+"""
+from __future__ import annotations
+
+import re
+from typing import Protocol
+
+VERDICTS = ("supported", "partial", "unsupported", "contradicted")
+
+_PROMPT = (
+    "You are checking whether a CLAIM is supported by the SOURCE text. "
+    "Use only the SOURCE. Answer with exactly one word: SUPPORTED, PARTIAL, "
+    "UNSUPPORTED, or CONTRADICTED.\n\nSOURCE:\n{spans}\n\nCLAIM: {claim}\n\nVerdict:"
+)
+
+
+def parse_verdict(text: str) -> str:
+    """Map a judge reply to a status; unparseable -> 'unverified' (fail-closed)."""
+    t = text.upper()
+    for v in ("CONTRADICTED", "UNSUPPORTED", "PARTIAL", "SUPPORTED"):
+        if re.search(rf"\b{v}\b", t):
+            return v.lower()
+    return "unverified"
+
+
+class Verifier(Protocol):
+    def verify(self, claim_text: str, span_texts: list[str]) -> tuple[str, str]:
+        """Return (status, model_id). status in VERDICTS or 'unverified'."""
+        ...
+
+
+class FakeVerifier:
+    """Scripted verifier for offline tests."""
+
+    def __init__(self, scripted: dict[str, str], default: str = "unverified"):
+        self._scripted = dict(scripted)
+        self._default = default
+
+    def verify(self, claim_text: str, span_texts: list[str]) -> tuple[str, str]:
+        return (self._scripted.get(claim_text, self._default), "fake")
+
+
+class LocalEntailmentVerifier:
+    """Cross-family local-LLM entailment over an Ollama-compatible endpoint.
+
+    Constructed with an httpx client, base url, and model tag. verify() is sync
+    over a blocking call for simplicity inside the (already async, batched)
+    verify-pass; a model or network error returns ('unverified', model) so the
+    claim is never promoted on failure.
+    """
+
+    def __init__(self, client, ollama_url: str, model: str, timeout: float = 60.0):
+        self._client = client
+        self._url = ollama_url.rstrip("/")
+        self._model = model
+        self._timeout = timeout
+
+    def verify(self, claim_text: str, span_texts: list[str]) -> tuple[str, str]:
+        prompt = _PROMPT.format(spans="\n".join(span_texts), claim=claim_text)
+        try:
+            r = self._client.post(
+                f"{self._url}/api/generate",
+                json={"model": self._model, "prompt": prompt, "stream": False},
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            return parse_verdict(r.json().get("response", "")), self._model
+        except Exception:  # noqa: BLE001 - fail closed
+            return "unverified", self._model

--- a/taosmd/claims/verify_pass.py
+++ b/taosmd/claims/verify_pass.py
@@ -1,0 +1,42 @@
+"""Asynchronous, batched, fail-closed verification pass over unverified claims.
+
+Pulls unverified claims in batches, fetches each claim's cited span texts via
+the injected ``fetch_spans`` callable (so the archive dependency is testable),
+runs the verifier, and writes the status. A verifier that returns 'unverified'
+(its own fail-closed signal) leaves the claim unverified, never promoted. The
+pass is idempotent and terminates even when every claim fails: a ``seen`` set
+guarantees progress (a claim is attempted at most once per pass).
+"""
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from taosmd.claims.store import ClaimStore
+from taosmd.claims.verifier import Verifier
+
+
+async def verify_pass(
+    store: ClaimStore,
+    verifier: Verifier,
+    fetch_spans: Callable[[list[int]], Awaitable[list[str]]],
+    batch: int = 100,
+    now: float | None = None,
+) -> int:
+    """Verify pending claims. Returns the count whose status was written."""
+    done = 0
+    seen: set[int] = set()
+    while True:
+        pending = await store.pull_unverified(limit=batch)
+        fresh = [c for c in pending if c["id"] not in seen]
+        if not fresh:
+            break
+        for claim in fresh:
+            seen.add(claim["id"])
+            spans = await fetch_spans(claim["archive_span_ids"])
+            status, model = verifier.verify(claim["text"], spans)
+            if status == "unverified":
+                # fail-closed: stays unverified, retried in a future pass.
+                continue
+            await store.set_status(claim["id"], status, verifier_model=model, now=now)
+            done += 1
+    return done

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -954,7 +954,113 @@ def _reconcile_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
+def _claims_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd claims`` subcommand group."""
+    import asyncio  # noqa: PLC0415
+    from pathlib import Path  # noqa: PLC0415
+
+    from .claims.store import ClaimStore  # noqa: PLC0415
+
+    if args.claims_cmd == "status":
+        store = ClaimStore(db_path=Path(args.data_dir) / "claims.db")
+        rate = asyncio.run(_claims_rate(store))
+        checked = sum(
+            rate.get(s, 0) for s in ("supported", "partial", "unsupported", "contradicted")
+        )
+        hall_rate = rate.get("hallucination_rate", 0.0)
+        print(
+            f"claims: unverified={rate.get('unverified', 0)}"
+            f"  supported={rate.get('supported', 0)}"
+            f"  partial={rate.get('partial', 0)}"
+            f"  unsupported={rate.get('unsupported', 0)}"
+            f"  contradicted={rate.get('contradicted', 0)}"
+            f"  checked={checked}"
+            f"  hallucination_rate={hall_rate:.3f}"
+        )
+        return 0
+
+    return 1
+
+
+async def _claims_rate(store) -> dict:
+    await store.init()
+    try:
+        return await store.rate()
+    finally:
+        await store.close()
+
+
+def _verify_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd verify``: run a verification pass over unverified claims."""
+    import asyncio  # noqa: PLC0415
+    from pathlib import Path  # noqa: PLC0415
+
+    import httpx  # noqa: PLC0415
+
+    from .archive import ArchiveStore  # noqa: PLC0415
+    from .claims.store import ClaimStore  # noqa: PLC0415
+    from .claims.verifier import LocalEntailmentVerifier  # noqa: PLC0415
+    from .claims.verify_pass import verify_pass  # noqa: PLC0415
+
+    data_dir = Path(args.data_dir)
+
+    async def _run() -> int:
+        store = ClaimStore(db_path=data_dir / "claims.db")
+        await store.init()
+        archive = ArchiveStore(
+            archive_dir=data_dir / "archive",
+            index_path=data_dir / "archive-index.db",
+        )
+        await archive.init()
+        try:
+            fetch_spans = await _fetch_spans(archive)
+            with httpx.Client() as client:
+                verifier = LocalEntailmentVerifier(
+                    client=client,
+                    ollama_url=args.ollama_url,
+                    model=args.model,
+                )
+                n = await verify_pass(store, verifier, fetch_spans, batch=args.batch)
+            rate = await store.rate()
+        finally:
+            await store.close()
+            await archive.close()
+        hall_rate = rate.get("hallucination_rate", 0.0)
+        print(
+            f"verified {n} claims;"
+            f" rate: hallucination_rate={hall_rate:.3f}"
+            f"  supported={rate.get('supported', 0)}"
+            f"  partial={rate.get('partial', 0)}"
+            f"  unsupported={rate.get('unsupported', 0)}"
+            f"  contradicted={rate.get('contradicted', 0)}"
+            f"  unverified={rate.get('unverified', 0)}"
+        )
+        return 0
+
+    return asyncio.run(_run())
+
+
+async def _fetch_spans(archive):
+    async def fetch(span_ids: list[int]) -> list[str]:
+        out = []
+        for sid in span_ids:
+            ev = await archive.get_event(sid)
+            if not ev:
+                continue
+            data = ev.get("data") or {}
+            txt = (data.get("content") if isinstance(data, dict) else None) or ev.get("summary") or ""
+            if txt:
+                out.append(txt)
+        return out
+    return fetch
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the top-level argument parser.
+
+    Extracted from ``main()`` so tests can parse args without executing handlers.
+    ``main()`` calls this then dispatches based on the parsed result.
+    """
     parser = argparse.ArgumentParser(prog="taosmd")
     parser.add_argument(
         "--data-dir",
@@ -1357,6 +1463,38 @@ def main(argv: list[str] | None = None) -> int:
         help="Data dir for served memory (default: $TAOSMD_DATA_DIR or ~/.taosmd)",
     )
 
+    # ----- claims subcommand group -------------------------------------
+    claims_p = sub.add_parser(
+        "claims",
+        help="Inspect and manage verifiable claims (hallucination tracking)",
+    )
+    claims_sub = claims_p.add_subparsers(dest="claims_cmd", required=True)
+
+    claims_sub.add_parser("status", help="Print the live claim rate (hallucination_rate and counts)")
+
+    # ----- verify subcommand ------------------------------------------
+    verify_p = sub.add_parser(
+        "verify",
+        help="Run a verification pass over unverified claims via a local Ollama model",
+    )
+    verify_p.add_argument(
+        "--model", default="qwen3:4b-instruct-2507",
+        help="Ollama model to use as verifier (default: qwen3:4b-instruct-2507)",
+    )
+    verify_p.add_argument(
+        "--ollama-url", dest="ollama_url", default="http://localhost:11434",
+        help="Ollama base URL (default: http://localhost:11434)",
+    )
+    verify_p.add_argument(
+        "--batch", type=int, default=100,
+        help="Claims to pull per batch (default: 100)",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
     args = parser.parse_args(argv)
 
     if args.cmd == "config":
@@ -1419,6 +1557,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd in ("projects", "shelves"):
         return _projects_cmd(args)
+
+    if args.cmd == "claims":
+        return _claims_cmd(args)
+
+    if args.cmd == "verify":
+        return _verify_cmd(args)
 
     registry = AgentRegistry(args.data_dir)
 

--- a/tests/claims/test_cli_claims.py
+++ b/tests/claims/test_cli_claims.py
@@ -1,0 +1,55 @@
+"""CLI parser tests for ``taosmd claims status`` and ``taosmd verify``.
+
+Tests build the parser via the exported ``_build_parser()`` helper (refactored
+out of ``main()`` in cli.py with identical behaviour) and assert that the two
+new subcommands parse and route to the right handler.
+"""
+from __future__ import annotations
+
+import pytest
+
+from taosmd.cli import _build_parser
+
+
+def test_claims_status_parses():
+    parser = _build_parser()
+    args = parser.parse_args(["--data-dir", "/tmp/td", "claims", "status"])
+    assert args.cmd == "claims"
+    assert args.claims_cmd == "status"
+    assert args.data_dir == "/tmp/td"
+
+
+def test_claims_requires_subcommand():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["claims"])
+
+
+def test_verify_parses_defaults():
+    parser = _build_parser()
+    args = parser.parse_args(["verify"])
+    assert args.cmd == "verify"
+    assert args.model == "qwen3:4b-instruct-2507"
+    assert args.ollama_url == "http://localhost:11434"
+    assert args.batch == 100
+
+
+def test_verify_parses_overrides():
+    parser = _build_parser()
+    args = parser.parse_args([
+        "verify",
+        "--model", "llama3:8b",
+        "--ollama-url", "http://192.168.1.2:11434",
+        "--batch", "50",
+    ])
+    assert args.cmd == "verify"
+    assert args.model == "llama3:8b"
+    assert args.ollama_url == "http://192.168.1.2:11434"
+    assert args.batch == 50
+
+
+def test_verify_parses_with_data_dir():
+    parser = _build_parser()
+    args = parser.parse_args(["--data-dir", "/custom/dir", "verify"])
+    assert args.data_dir == "/custom/dir"
+    assert args.cmd == "verify"

--- a/tests/claims/test_extract.py
+++ b/tests/claims/test_extract.py
@@ -1,0 +1,17 @@
+from taosmd.claims.extract import claims_from_text
+
+
+def test_claims_carry_span_id():
+    # "Alice is a doctor." -> {subject: Alice, predicate: is_a, object: doctor}
+    out = claims_from_text("Alice is a doctor.", archive_span_id=42)
+    assert out, "expected at least one claim"
+    c = out[0]
+    assert c["archive_span_ids"] == [42]
+    assert "Alice" in c["text"] and "doctor" in c["text"]
+    assert "_" not in c["text"]              # predicate underscores rendered as spaces
+    assert c["source_extractor"] == "regex"
+
+
+def test_empty_text_no_claims():
+    assert claims_from_text("", archive_span_id=1) == []
+    assert claims_from_text("   ", archive_span_id=1) == []

--- a/tests/claims/test_gate.py
+++ b/tests/claims/test_gate.py
@@ -1,0 +1,35 @@
+from taosmd.claims.gate import apply_claims_gate
+
+
+def _hit(i, score, status):
+    return {"id": i, "score": score, "claim_status": status}
+
+
+def test_prefer_verified_excludes_unsupported():
+    hits = [_hit(1, 0.9, "unsupported"), _hit(2, 0.5, "supported"), _hit(3, 0.4, None)]
+    out = apply_claims_gate(hits, mode="prefer_verified")
+    ids = [h["id"] for h in out]
+    assert 1 not in ids        # unsupported dropped from default
+    assert ids[0] == 2         # supported boosted above the unscored raw hit
+    assert 3 in ids            # raw (non-claim) hit kept
+
+
+def test_prefer_verified_keeps_unverified():
+    hits = [_hit(1, 0.9, "unverified"), _hit(2, 0.5, "supported")]
+    out = apply_claims_gate(hits, mode="prefer_verified")
+    assert {h["id"] for h in out} == {1, 2}   # unverified kept in the lenient mode
+
+
+def test_strict_excludes_unverified_too():
+    hits = [_hit(1, 0.9, "unverified"), _hit(2, 0.5, "supported"), _hit(3, 0.4, "unsupported")]
+    out = apply_claims_gate(hits, mode="strict")
+    assert {h["id"] for h in out} == {2}      # only proven-supported survive strict
+
+
+def test_off_is_identity():
+    hits = [_hit(1, 0.9, "unsupported")]
+    assert apply_claims_gate(hits, mode="off") == hits
+
+
+def test_empty():
+    assert apply_claims_gate([], mode="strict") == []

--- a/tests/claims/test_retrieve_gate.py
+++ b/tests/claims/test_retrieve_gate.py
@@ -1,0 +1,44 @@
+"""The claims gate wired into the recall path (default off)."""
+import asyncio
+
+from taosmd import api as a
+from taosmd.claims.store import ClaimStore
+
+
+def _cs(tmp_path):
+    cs = ClaimStore(db_path=str(tmp_path / "claims.db"))
+    asyncio.run(cs.init())
+    return cs
+
+
+def test_gate_demotes_unsupported_hit(tmp_path):
+    cs = _cs(tmp_path)
+    cid = asyncio.run(cs.add_claim("bad fact", [99], source_extractor="r"))
+    asyncio.run(cs.set_status(cid, "unsupported", verifier_model="m", now=1.0))
+    hits = [
+        {"text": "a", "confidence": 0.9, "metadata": {"archive_span_id": 99}},
+        {"text": "b", "confidence": 0.5, "metadata": {"archive_span_id": 7}},
+    ]
+    gated = asyncio.run(a._attach_and_gate_claims(hits, cs, "prefer_verified"))
+    assert [h["text"] for h in gated] == ["b"]      # unsupported-backed hit dropped
+    assert "claim_status" not in gated[0]           # transient keys stripped
+    assert "score" not in gated[0]
+
+
+def test_gate_prefers_supported(tmp_path):
+    cs = _cs(tmp_path)
+    cid = asyncio.run(cs.add_claim("good", [5], source_extractor="r"))
+    asyncio.run(cs.set_status(cid, "supported", verifier_model="m", now=1.0))
+    hits = [
+        {"text": "raw", "confidence": 0.9, "metadata": {"archive_span_id": 1}},
+        {"text": "verified", "confidence": 0.5, "metadata": {"archive_span_id": 5}},
+    ]
+    gated = asyncio.run(a._attach_and_gate_claims(hits, cs, "prefer_verified"))
+    assert gated[0]["text"] == "verified"           # supported boosted above higher-confidence raw
+
+
+def test_gate_off_is_passthrough(tmp_path):
+    cs = _cs(tmp_path)
+    hits = [{"text": "a", "confidence": 0.9, "metadata": {"archive_span_id": 99}}]
+    out = asyncio.run(a._attach_and_gate_claims(hits, cs, "off"))
+    assert out == hits

--- a/tests/claims/test_store.py
+++ b/tests/claims/test_store.py
@@ -1,0 +1,63 @@
+"""ClaimStore: zero-loss sqlite store for verifiable claims."""
+import asyncio
+from taosmd.claims.store import ClaimStore, VALID_STATUSES
+
+
+def _store(tmp_path):
+    s = ClaimStore(db_path=str(tmp_path / "claims.db"))
+    asyncio.run(s.init())
+    return s
+
+
+def test_add_and_get(tmp_path):
+    s = _store(tmp_path)
+    cid = asyncio.run(s.add_claim("alice adopted a dog", [12, 13], source_extractor="regex"))
+    row = asyncio.run(s.get(cid))
+    assert row["text"] == "alice adopted a dog"
+    assert row["archive_span_ids"] == [12, 13]
+    assert row["status"] == "unverified"
+    assert row["source_extractor"] == "regex"
+
+
+def test_set_status_valid(tmp_path):
+    s = _store(tmp_path)
+    cid = asyncio.run(s.add_claim("x", [1], source_extractor="r"))
+    asyncio.run(s.set_status(cid, "supported", verifier_model="qwen3:4b", now=100.0))
+    row = asyncio.run(s.get(cid))
+    assert row["status"] == "supported"
+    assert row["verifier_model"] == "qwen3:4b"
+    assert row["last_checked"] == 100.0
+
+
+def test_set_status_rejects_unknown(tmp_path):
+    s = _store(tmp_path)
+    cid = asyncio.run(s.add_claim("x", [1], source_extractor="r"))
+    try:
+        asyncio.run(s.set_status(cid, "bogus", verifier_model="m", now=1.0))
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_pull_unverified(tmp_path):
+    s = _store(tmp_path)
+    a = asyncio.run(s.add_claim("a", [1], source_extractor="r"))
+    b = asyncio.run(s.add_claim("b", [2], source_extractor="r"))
+    asyncio.run(s.set_status(a, "supported", verifier_model="m", now=1.0))
+    pending = asyncio.run(s.pull_unverified(limit=10))
+    assert [c["id"] for c in pending] == [b]
+
+
+def test_rate(tmp_path):
+    s = _store(tmp_path)
+    ids = [asyncio.run(s.add_claim(t, [1], source_extractor="r")) for t in "abcd"]
+    asyncio.run(s.set_status(ids[0], "supported", verifier_model="m", now=1.0))
+    asyncio.run(s.set_status(ids[1], "supported", verifier_model="m", now=1.0))
+    asyncio.run(s.set_status(ids[2], "unsupported", verifier_model="m", now=1.0))
+    r = asyncio.run(s.rate())
+    assert r["supported"] == 2 and r["unsupported"] == 1 and r["unverified"] == 1
+    assert abs(r["hallucination_rate"] - (1 / 3)) < 1e-9
+
+
+def test_status_set_constant():
+    assert "unverified" in VALID_STATUSES and "supported" in VALID_STATUSES

--- a/tests/claims/test_verifier.py
+++ b/tests/claims/test_verifier.py
@@ -1,0 +1,26 @@
+from taosmd.claims.verifier import FakeVerifier, parse_verdict, VERDICTS
+
+
+def test_fake_scripted():
+    v = FakeVerifier({"alice has a dog": "supported"})
+    assert v.verify("alice has a dog", ["alice adopted a golden retriever"]) == ("supported", "fake")
+
+
+def test_fake_default_unverified_on_unknown():
+    v = FakeVerifier({}, default="unsupported")
+    assert v.verify("x", ["y"]) == ("unsupported", "fake")
+
+
+def test_parse_verdict_maps_model_text():
+    assert parse_verdict("SUPPORTED") == "supported"
+    assert parse_verdict("the claim is UNSUPPORTED by the text") == "unsupported"
+    assert parse_verdict("PARTIAL") == "partial"
+
+
+def test_parse_verdict_unknown_is_unverified():
+    # An unparseable judge reply must fail closed, never silently "supported".
+    assert parse_verdict("i am not sure, maybe?") == "unverified"
+
+
+def test_verdicts_constant():
+    assert set(VERDICTS) >= {"supported", "partial", "unsupported"}

--- a/tests/claims/test_verify_pass.py
+++ b/tests/claims/test_verify_pass.py
@@ -1,0 +1,45 @@
+import asyncio
+from taosmd.claims.store import ClaimStore
+from taosmd.claims.verifier import FakeVerifier
+from taosmd.claims.verify_pass import verify_pass
+
+
+def _store(tmp_path):
+    s = ClaimStore(db_path=str(tmp_path / "claims.db"))
+    asyncio.run(s.init())
+    return s
+
+
+async def _spans_text(span_ids):
+    return [f"span-{i}-text" for i in span_ids]
+
+
+def test_verify_pass_marks_status(tmp_path):
+    s = _store(tmp_path)
+    c1 = asyncio.run(s.add_claim("alice has a dog", [1], source_extractor="r"))
+    c2 = asyncio.run(s.add_claim("bob flew to mars", [2], source_extractor="r"))
+    v = FakeVerifier({"alice has a dog": "supported", "bob flew to mars": "unsupported"})
+    n = asyncio.run(verify_pass(s, v, _spans_text, batch=10, now=5.0))
+    assert n == 2
+    assert asyncio.run(s.get(c1))["status"] == "supported"
+    assert asyncio.run(s.get(c2))["status"] == "unsupported"
+
+
+def test_verify_pass_is_idempotent(tmp_path):
+    s = _store(tmp_path)
+    asyncio.run(s.add_claim("x", [1], source_extractor="r"))
+    v = FakeVerifier({"x": "supported"})
+    asyncio.run(verify_pass(s, v, _spans_text, batch=10, now=1.0))
+    n2 = asyncio.run(verify_pass(s, v, _spans_text, batch=10, now=2.0))
+    assert n2 == 0
+
+
+def test_verify_pass_fail_closed_terminates(tmp_path):
+    s = _store(tmp_path)
+    cid = asyncio.run(s.add_claim("x", [1], source_extractor="r"))
+    class Boom:
+        def verify(self, *a): return ("unverified", "m")
+    # must terminate (the seen-guard), and leave the claim unverified
+    n = asyncio.run(verify_pass(s, Boom(), _spans_text, batch=10, now=1.0))
+    assert n == 0
+    assert asyncio.run(s.get(cid))["status"] == "unverified"


### PR DESCRIPTION
## What

The v2 spine after surprisal died (N-009/N-010/N-011): an additive, default-off **Provable Memory** layer that makes F-009 (the measured 18.8 percent extraction-hallucination rate) a live, always-on gate. Built subagent-driven from the approved private spec; 9 tasks, TDD throughout.

## How it works

- **Extract with provenance**: each fact becomes a claim tagged with the archive span(s) it came from (`taosmd/claims/extract.py`).
- **Async verify**: a fail-closed, batched, idempotent verify-pass (`verify_pass.py`) shows a cross-family local judge ONLY the cited spans and marks each claim supported / partial / unsupported / contradicted. Any failure leaves it unverified, never promoted.
- **Demote, never delete**: a pure recall gate (`gate.py`) behind `search(prefer_verified=...)` (default `off`); verified preferred, unsupported excluded from default recall, everything still in the zero-loss archive and queryable (reversible).
- **ClaimStore** (`store.py`): zero-loss sqlite, rebuildable from the archive, exposes the live hallucination rate. Store-mode gate is a pure function.
- **CLI**: `taosmd verify`, `taosmd claims status`.

## Safety / scope

- Default-off: `prefer_verified` defaults `off`, so existing installs are byte-for-byte unchanged in behaviour. 886 tests pass (+24 claims), the claims package only imports `memory_extractor` + `_db` (clean isolation).
- The default flip is gated on the **pre-registered E-009** experiment (does the gate cut served-hallucination without dropping judged accuracy/R@K by >0.02), in this PR's report change.
- Out of scope (next): contradiction/temporal-state tracking, compilation versioning, the E-009 bench harness (`benchmarks/claims_gate_probe.py`), the actual default flip.

## Review

Not self-merged: it touches the live recall path (though default-off). Spec is private (`~/tinyagentos-private/specs/2026-06-13-v2-claims-layer-design.md`); the public spec ships when E-009 validates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claims layer (Provable Memory) for extracting and verifying claims from ingested content (default off)
  * Claims verified asynchronously with local model judge and fail-closed policy
  * New `prefer_verified` parameter in search to optionally demote unverified claims
  * New CLI commands: `taosmd claims status` (view verification statistics) and `taosmd verify` (verify unverified claims)

* **Documentation**
  * Added pre-registered experiment E-009 documenting claims verification gates and evaluation metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->