### PR TITLE
bench(e012): LongMemEval end-to-end Judge harness + score-up levers

### DIFF
--- a/benchmarks/e012_ablation.sh
+++ b/benchmarks/e012_ablation.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# E-012 score-up ablation. Sweeps the lever arms SEQUENTIALLY (one Ollama job
+# at a time per the GPU-contention rule) and records each arm's overall and
+# per-type Judge accuracy.
+#
+# Usage: benchmarks/e012_ablation.sh [LIMIT]
+#   LIMIT defaults to 100 (screening pass). Use 500 for the full oracle set.
+#
+# Required env (export before running):
+#   TAOSMD_OLLAMA_MODEL   generator (e.g. qwen3.5:9b)
+#   TAOSMD_JUDGE_MODEL    external judge (e.g. qwen3:4b-instruct-2507)
+#   TAOSMD_OLLAMA_URL     Ollama base URL (default http://localhost:11434)
+# Fixed substrate (depth + rerank context-release = lever 1) is set per arm.
+set -u
+LIMIT="${1:-100}"
+PY=".venv/bin/python"
+OUT="benchmarks/results/e012_ablation_$(date -u +%Y%m%d_%H%M%S).log"
+RUNNER="benchmarks/longmemeval_runner.py"
+
+run_arm () {
+  local name="$1"; shift
+  echo "==================== ARM: $name (limit=$LIMIT) ====================" | tee -a "$OUT"
+  # Reset all levers off, then apply this arm's env (passed as VAR=VAL args).
+  env -u TAOSMD_DECOMPOSE -u TAOSMD_SELF_VERIFY -u TAOSMD_RERANK \
+      TAOSMD_ASSEMBLE_TOKENS="${TAOSMD_ASSEMBLE_TOKENS:-4000}" \
+      TAOSMD_RETRIEVE_LIMIT="${TAOSMD_RETRIEVE_LIMIT:-12}" \
+      TAOSMD_FTS_LIMIT="${TAOSMD_FTS_LIMIT:-5}" \
+      TAOSMD_CONTEXT_CHARS="${TAOSMD_CONTEXT_CHARS:-16000}" \
+      "$@" \
+      "$PY" "$RUNNER" --llm --limit "$LIMIT" 2>&1 | tee -a "$OUT"
+  echo "" | tee -a "$OUT"
+}
+
+# Arms. Lever 1 = TAOSMD_RERANK=1, lever 2 = TAOSMD_DECOMPOSE=1, lever 3 = TAOSMD_SELF_VERIFY=1.
+run_arm "baseline"
+run_arm "L1_context_release"  TAOSMD_RERANK=1
+run_arm "L2_decompose"        TAOSMD_DECOMPOSE=1
+run_arm "L3_self_verify"      TAOSMD_SELF_VERIFY=1
+run_arm "L1+L2"               TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1
+run_arm "L1+L3"               TAOSMD_RERANK=1 TAOSMD_SELF_VERIFY=1
+run_arm "L2+L3"               TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
+run_arm "L1+L2+L3"            TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
+
+echo "Ablation complete. Full log: $OUT" | tee -a "$OUT"
+echo "Per-arm overall accuracy:" | tee -a "$OUT"
+grep -E "ARM:|Overall:" "$OUT" | tee -a "$OUT"

--- a/benchmarks/e012_ablation.sh
+++ b/benchmarks/e012_ablation.sh
@@ -31,15 +31,22 @@ run_arm () {
   echo "" | tee -a "$OUT"
 }
 
-# Arms. Lever 1 = TAOSMD_RERANK=1, lever 2 = TAOSMD_DECOMPOSE=1, lever 3 = TAOSMD_SELF_VERIFY=1.
-run_arm "baseline"
-run_arm "L1_context_release"  TAOSMD_RERANK=1
+# Arms. Lever 1a = depth (the tuned defaults), lever 1b = TAOSMD_RERANK=1,
+# lever 2 = TAOSMD_DECOMPOSE=1, lever 3 = TAOSMD_SELF_VERIFY=1.
+# Per-arm env after "$@" overrides run_arm's defaults (env: last assignment wins).
+# F-012 anchor: starved depth reproduces the published 47.2% control, tying the
+# screen back to the headline.
+run_arm "F012_anchor_starved" TAOSMD_ASSEMBLE_TOKENS=2000 TAOSMD_RETRIEVE_LIMIT=5 TAOSMD_FTS_LIMIT=3 TAOSMD_CONTEXT_CHARS=3000
+# Baseline = tuned depth (lever 1a, the shipped default). Its delta over the
+# anchor is the depth-tuning gain; the levers below build on this substrate.
+run_arm "baseline_tuned_depth"
+run_arm "L1b_rerank"          TAOSMD_RERANK=1
 run_arm "L2_decompose"        TAOSMD_DECOMPOSE=1
 run_arm "L3_self_verify"      TAOSMD_SELF_VERIFY=1
-run_arm "L1+L2"               TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1
-run_arm "L1+L3"               TAOSMD_RERANK=1 TAOSMD_SELF_VERIFY=1
+run_arm "L1b+L2"              TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1
+run_arm "L1b+L3"              TAOSMD_RERANK=1 TAOSMD_SELF_VERIFY=1
 run_arm "L2+L3"               TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
-run_arm "L1+L2+L3"            TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
+run_arm "all_L1b+L2+L3"       TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
 
 echo "Ablation complete. Full log: $OUT" | tee -a "$OUT"
 echo "Per-arm overall accuracy:" | tee -a "$OUT"

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -372,6 +372,8 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
             t_llm = time.time()
             # Step 1: LLM generates answer from recalled context
             answer = await llm_answer(llm_client, full_context, question)
+            if SELF_VERIFY:
+                answer = await self_verify_answer(llm_client, full_context, question, answer)
             # Step 2: LLM judges whether answer matches gold (official eval method)
             if answer and not any(idk in answer.lower() for idk in ("i don't know", "i do not know", "i'm sorry", "not in the context", "does not contain", "no information")):
                 correct = await score_answer_llm(llm_client, answer, gold_answer, question)

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -37,9 +37,14 @@ REMOTE_LLM_MODEL = os.environ.get("TAOSMD_OLLAMA_MODEL", "qwen2.5:3b")
 # CORRECT, which zeroed the qwen3.5:9b run). Defaults to the generator for
 # back-compat; set TAOSMD_JUDGE_MODEL to a different, non-thinking model.
 JUDGE_MODEL = os.environ.get("TAOSMD_JUDGE_MODEL", REMOTE_LLM_MODEL)
-# Context fed to the generator. 3000 chars truncated multi-session evidence;
-# default higher and make it tunable.
-CONTEXT_CHARS = int(os.environ.get("TAOSMD_CONTEXT_CHARS", "8000"))
+# Evidence pipeline depth. E-012 diagnosis: the generator was STARVED of
+# evidence (assembler capped at 2000 tok, 5 vector chunks, 3 FTS hits), which
+# craters multi-session/temporal questions that need several sessions in view.
+# All tunable so we can sweep "get the scores up" configs.
+CONTEXT_CHARS = int(os.environ.get("TAOSMD_CONTEXT_CHARS", "16000"))
+ASSEMBLE_TOKENS = int(os.environ.get("TAOSMD_ASSEMBLE_TOKENS", "4000"))
+RETRIEVE_LIMIT = int(os.environ.get("TAOSMD_RETRIEVE_LIMIT", "12"))
+FTS_LIMIT = int(os.environ.get("TAOSMD_FTS_LIMIT", "5"))
 
 ANSWER_PROMPT = """Based on the following context from past conversations, answer the question.
 If the answer is not in the context, say "I don't know."
@@ -217,7 +222,7 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
         ctx = await assembler.assemble(
             query=question,
             depth="auto",
-            max_total_tokens=2000,
+            max_total_tokens=ASSEMBLE_TOKENS,
         )
 
         # Also do FTS search over raw archive (the MemPalace approach — verbatim recall)
@@ -227,14 +232,14 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
         for term in search_terms:
             if len(term) > 3:  # Skip short words
                 try:
-                    fts_results = await archive.search_fts(term, limit=3)
+                    fts_results = await archive.search_fts(term, limit=FTS_LIMIT)
                     for r in fts_results:
                         archive_text += " " + r.get("data_json", "") + " " + r.get("summary", "")
                 except Exception:
                     pass
 
         # Also do semantic vector search (the MemPalace approach)
-        vector_results = await vmem.search(question, limit=5)
+        vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
         vector_text = " ".join(r["text"] for r in vector_results)
 
         query_time = time.time() - t1

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -345,7 +345,19 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
         # Also do semantic vector search (the MemPalace approach). Retrieve a
         # wider pool, then rerank/prune to the clean top-K (intelligent context
         # release) so the generator is not buried in redundant chunks.
-        vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
+        if DECOMPOSE and llm_client is not None:
+            sub_queries = await decompose_query(llm_client, question)
+            seen_texts = set()
+            vector_results = []
+            for sq in sub_queries:
+                for r in await vmem.search(sq, limit=RETRIEVE_LIMIT):
+                    t = r.get("text", "")
+                    if t and t not in seen_texts:
+                        seen_texts.add(t)
+                        vector_results.append(r)
+            vector_results = vector_results[:RETRIEVE_LIMIT]
+        else:
+            vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
         rr = _get_reranker()
         if rr is not None and getattr(rr, "available", False) and vector_results:
             vector_results = rr.rerank(question, vector_results, RERANK_TOP_K)

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -45,6 +45,23 @@ CONTEXT_CHARS = int(os.environ.get("TAOSMD_CONTEXT_CHARS", "16000"))
 ASSEMBLE_TOKENS = int(os.environ.get("TAOSMD_ASSEMBLE_TOKENS", "4000"))
 RETRIEVE_LIMIT = int(os.environ.get("TAOSMD_RETRIEVE_LIMIT", "12"))
 FTS_LIMIT = int(os.environ.get("TAOSMD_FTS_LIMIT", "5"))
+# Intelligent context release (Jay's idea): retrieve MORE, then RERANK and keep
+# only the clean top-K before generation, so the generator reasons over the
+# relevant subset, not a noisy pile. Drops REDUNDANT context (the claims layer
+# already drops INCORRECT). bge-v2-m3 cross-encoder, already in the stack.
+RERANK = os.environ.get("TAOSMD_RERANK", "0") == "1"
+RERANK_PATH = os.environ.get("TAOSMD_RERANK_PATH", "models/bge-reranker-v2-m3-onnx")
+RERANK_TOP_K = int(os.environ.get("TAOSMD_RERANK_TOP_K", "8"))
+_reranker = None
+
+
+def _get_reranker():
+    """Lazy-load the cross-encoder reranker once; None if disabled/unavailable."""
+    global _reranker
+    if _reranker is None and RERANK:
+        from taosmd.cross_encoder import CrossEncoderReranker  # noqa: PLC0415
+        _reranker = CrossEncoderReranker(onnx_path=RERANK_PATH)
+    return _reranker
 
 ANSWER_PROMPT = """Based on the following context from past conversations, answer the question.
 If the answer is not in the context, say "I don't know."
@@ -238,8 +255,13 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
                 except Exception:
                     pass
 
-        # Also do semantic vector search (the MemPalace approach)
+        # Also do semantic vector search (the MemPalace approach). Retrieve a
+        # wider pool, then rerank/prune to the clean top-K (intelligent context
+        # release) so the generator is not buried in redundant chunks.
         vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
+        rr = _get_reranker()
+        if rr is not None and getattr(rr, "available", False) and vector_results:
+            vector_results = rr.rerank(question, vector_results, RERANK_TOP_K)
         vector_text = " ".join(r["text"] for r in vector_results)
 
         query_time = time.time() - t1

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -52,6 +52,15 @@ FTS_LIMIT = int(os.environ.get("TAOSMD_FTS_LIMIT", "5"))
 RERANK = os.environ.get("TAOSMD_RERANK", "0") == "1"
 RERANK_PATH = os.environ.get("TAOSMD_RERANK_PATH", "models/bge-reranker-v2-m3-onnx")
 RERANK_TOP_K = int(os.environ.get("TAOSMD_RERANK_TOP_K", "8"))
+# E-012 lever 2: query decomposition with iterative retrieval. Split the
+# question into 2-3 sub-queries, retrieve for each, union deduplicated. Ported
+# from locomo_runner._decompose_query. Default off.
+DECOMPOSE = os.environ.get("TAOSMD_DECOMPOSE", "0") == "1"
+DECOMPOSE_MODEL = os.environ.get("TAOSMD_DECOMPOSE_MODEL", "gemma4:e2b")
+# E-012 lever 3: CoVe-style answer self-verification. After the first answer,
+# one extra generator pass keeps the draft if it is fully supported by the
+# context, else rewrites it from the context. Default off.
+SELF_VERIFY = os.environ.get("TAOSMD_SELF_VERIFY", "0") == "1"
 _reranker = None
 
 
@@ -141,6 +150,84 @@ async def llm_answer(client, context: str, question: str) -> str:
     except Exception:
         pass
     return ""
+
+
+MULTIHOP_PROMPT = """Split this question into 2 or 3 shorter, focused sub-queries that together cover everything needed to answer it. Respond with one sub-query per line. No numbering, no explanation.
+
+Question: {question}"""
+
+
+async def decompose_query(client, question: str) -> list:
+    """Split a question into 2-3 sub-queries via a small utility model.
+
+    Returns a list of >=2 stripped lines, or [question] on failure or if fewer
+    than two lines come back (so callers can iterate uniformly).
+    """
+    try:
+        resp = await client.post(
+            f"{REMOTE_LLM_URL}/api/chat",
+            json={
+                "model": DECOMPOSE_MODEL,
+                "messages": [{"role": "user", "content": MULTIHOP_PROMPT.format(question=question) + " /no_think"}],
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0, "num_predict": 80},
+            },
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            raw = resp.json().get("message", {}).get("content", "")
+            lines = [l.strip() for l in raw.splitlines() if l.strip()]
+            if len(lines) >= 2:
+                return lines
+    except Exception:
+        pass
+    return [question]
+
+
+VERIFY_PROMPT = """You are checking a draft answer against the context.
+If every part of the draft answer is supported by the context, repeat the draft answer exactly.
+If any part is unsupported or contradicted by the context, write a corrected answer using ONLY the context.
+Answer concisely in 1-2 sentences, no explanation. /no_think
+
+Context:
+{context}
+
+Question: {question}
+
+Draft answer: {answer}
+
+Final answer:"""
+
+
+async def self_verify_answer(client, context: str, question: str, answer: str) -> str:
+    """One CoVe-style verification pass.
+
+    Keeps the draft if it is supported by the context, otherwise returns a
+    corrected answer. Falls back to the original draft on empty draft, empty
+    revision, or any failure, so it can never make an answer worse by erroring.
+    """
+    if not answer:
+        return answer
+    try:
+        resp = await client.post(
+            f"{REMOTE_LLM_URL}/api/chat",
+            json={
+                "model": REMOTE_LLM_MODEL,
+                "messages": [{"role": "user", "content": VERIFY_PROMPT.format(context=context[:CONTEXT_CHARS], question=question, answer=answer)}],
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0, "num_predict": 100},
+            },
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            revised = resp.json().get("message", {}).get("content", "").strip()
+            if revised:
+                return revised
+    except Exception:
+        pass
+    return answer
 
 
 async def run_benchmark(limit: int = 50, question_type: str | None = None, use_llm: bool = False):

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -32,10 +32,18 @@ DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "longmemeval_oracle.
 # Remote LLM for answer generation (override via TAOSMD_OLLAMA_URL env var)
 REMOTE_LLM_URL = os.environ.get("TAOSMD_OLLAMA_URL", "http://localhost:11434")
 REMOTE_LLM_MODEL = os.environ.get("TAOSMD_OLLAMA_MODEL", "qwen2.5:3b")
+# E-012: the judge MUST be external to the generator (same-model judging
+# inflates, and a same-model thinking judge emits CoT and never cleanly says
+# CORRECT, which zeroed the qwen3.5:9b run). Defaults to the generator for
+# back-compat; set TAOSMD_JUDGE_MODEL to a different, non-thinking model.
+JUDGE_MODEL = os.environ.get("TAOSMD_JUDGE_MODEL", REMOTE_LLM_MODEL)
+# Context fed to the generator. 3000 chars truncated multi-session evidence;
+# default higher and make it tunable.
+CONTEXT_CHARS = int(os.environ.get("TAOSMD_CONTEXT_CHARS", "8000"))
 
 ANSWER_PROMPT = """Based on the following context from past conversations, answer the question.
 If the answer is not in the context, say "I don't know."
-Answer concisely in 1-2 sentences. /nothink
+Answer concisely in 1-2 sentences. /no_think
 
 Context:
 {context}
@@ -66,17 +74,18 @@ Question: {question}
 Reference answer: {gold}
 Predicted answer: {predicted}
 
-Verdict:"""
+Verdict: /no_think"""
     try:
         resp = await client.post(
             f"{REMOTE_LLM_URL}/api/chat",
             json={
-                "model": REMOTE_LLM_MODEL,
+                "model": JUDGE_MODEL,
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
-                "options": {"temperature": 0, "num_predict": 10},
+                "think": False,
+                "options": {"temperature": 0, "num_predict": 16},
             },
-            timeout=15,
+            timeout=30,
         )
         if resp.status_code == 200:
             judgment = resp.json().get("message", {}).get("content", "").strip().upper()
@@ -98,7 +107,7 @@ async def llm_answer(client, context: str, question: str) -> str:
             f"{REMOTE_LLM_URL}/api/chat",
             json={
                 "model": REMOTE_LLM_MODEL,
-                "messages": [{"role": "user", "content": ANSWER_PROMPT.format(context=context[:3000], question=question)}],
+                "messages": [{"role": "user", "content": ANSWER_PROMPT.format(context=context[:CONTEXT_CHARS], question=question)}],
                 "stream": False,
                 "think": False,
                 "options": {"temperature": 0, "num_predict": 100},

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -61,7 +61,27 @@ DECOMPOSE_MODEL = os.environ.get("TAOSMD_DECOMPOSE_MODEL", "gemma4:e2b")
 # one extra generator pass keeps the draft if it is fully supported by the
 # context, else rewrites it from the context. Default off.
 SELF_VERIFY = os.environ.get("TAOSMD_SELF_VERIFY", "0") == "1"
+# Representative sampling. The oracle set is ordered by question type, so a head
+# slice dataset[:limit] is single-type (the first ~133 questions are all
+# temporal). Set TAOSMD_SAMPLE_SEED to shuffle deterministically before slicing
+# so a screen at limit<500 covers all six types. Unset = head slice (back-compat).
+SAMPLE_SEED = os.environ.get("TAOSMD_SAMPLE_SEED")
 _reranker = None
+
+
+def sample_dataset(dataset, limit, seed=None):
+    """Return `limit` items from the dataset.
+
+    With a seed, shuffle representatively first (the oracle set is type-ordered,
+    so a head slice would be a single question type); without a seed, take the
+    head slice for back-compat.
+    """
+    if seed is not None:
+        import random  # noqa: PLC0415
+        ds = list(dataset)
+        random.Random(int(seed)).shuffle(ds)
+        return ds[:limit]
+    return dataset[:limit]
 
 
 def _get_reranker():
@@ -243,8 +263,8 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
         dataset = [q for q in dataset if q["question_type"] == question_type]
         print(f"Filtered to type: {question_type} ({len(dataset)} questions)")
 
-    dataset = dataset[:limit]
-    print(f"Running {len(dataset)} questions")
+    dataset = sample_dataset(dataset, limit, SAMPLE_SEED)
+    print(f"Running {len(dataset)} questions" + (f" (sampled, seed={SAMPLE_SEED})" if SAMPLE_SEED else ""))
 
     results_by_type = {}
     total_correct = 0

--- a/docs/superpowers/plans/2026-06-14-e012-score-up-ablation.md
+++ b/docs/superpowers/plans/2026-06-14-e012-score-up-ablation.md
@@ -1,0 +1,457 @@
+# E-012 Score-Up Ablation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two independent, default-off reasoning levers (query decomposition with iterative retrieval; CoVe-style answer self-verification) to the LongMemEval Judge harness, plus an ablation runner, so we can attribute any Judge-score gain over the 47.2% baseline to a specific lever.
+
+**Architecture:** Both levers are env-gated toggles on `benchmarks/longmemeval_runner.py`. Decomposition replaces the single vector search with a fan-out over sub-queries (deduplicated union). Self-verification adds one extra generator pass after the first answer. Default off means the baseline arm is byte-for-byte the current behavior. A bash matrix runner sweeps the arms sequentially (one Ollama job at a time per the GPU-contention rule).
+
+**Tech Stack:** Python 3, httpx async, Ollama HTTP API, pytest. No GPU needed to build or unit-test; the matrix run itself needs the bench-host GPU.
+
+**Branch:** `bench/e012-judge-harness` (already checked out; the harness and the depth/rerank levers already live here).
+
+---
+
+## File Structure
+
+- Modify `benchmarks/longmemeval_runner.py`: add `MULTIHOP_PROMPT`, `VERIFY_PROMPT`, the `TAOSMD_DECOMPOSE`/`TAOSMD_DECOMPOSE_MODEL`/`TAOSMD_SELF_VERIFY` env flags, `decompose_query()`, `self_verify_answer()`, and wire both into `run_benchmark()`.
+- Create `tests/test_e012_levers.py`: unit tests for the two helpers using a fake Ollama client (no live LLM).
+- Create `benchmarks/e012_ablation.sh`: the matrix runner that sweeps arms by setting env and invoking the harness.
+
+The runner is a single benchmark script and stays one file; the new helpers are small and belong beside the existing `llm_answer`/`score_answer_llm`.
+
+---
+
+## Task 1: Query decomposition helper (TAOSMD_DECOMPOSE)
+
+**Files:**
+- Modify: `benchmarks/longmemeval_runner.py` (config block after line 54; new helper after `llm_answer`, ~line 143)
+- Test: `tests/test_e012_levers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_e012_levers.py`:
+
+```python
+import importlib.util
+import pathlib
+import asyncio
+
+_RUNNER = pathlib.Path(__file__).resolve().parent.parent / "benchmarks" / "longmemeval_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("lme_runner", _RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeResp:
+    def __init__(self, content, status=200):
+        self.status_code = status
+        self._content = content
+
+    def json(self):
+        return {"message": {"content": self._content}}
+
+
+class _FakeClient:
+    """Returns a fixed Ollama chat response for any .post()."""
+    def __init__(self, content, status=200):
+        self._content = content
+        self._status = status
+
+    async def post(self, *args, **kwargs):
+        return _FakeResp(self._content, self._status)
+
+
+class _BoomClient:
+    async def post(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_decompose_returns_lines_when_two_or_more():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_FakeClient("who did she marry\nwhen did they meet"), "Q"))
+    assert out == ["who did she marry", "when did they meet"]
+
+
+def test_decompose_falls_back_when_fewer_than_two_lines():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_FakeClient("only one line"), "original question"))
+    assert out == ["original question"]
+
+
+def test_decompose_falls_back_on_error():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_BoomClient(), "original question"))
+    assert out == ["original question"]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -v`
+Expected: FAIL with `AttributeError: module 'lme_runner' has no attribute 'decompose_query'`.
+
+- [ ] **Step 3: Add the config flags**
+
+In `benchmarks/longmemeval_runner.py`, after the rerank config block (after line 54, the `RERANK_TOP_K = ...` line), add:
+
+```python
+# E-012 lever 2: query decomposition with iterative retrieval. Split the
+# question into 2-3 sub-queries, retrieve for each, union deduplicated. Ported
+# from locomo_runner._decompose_query. Default off.
+DECOMPOSE = os.environ.get("TAOSMD_DECOMPOSE", "0") == "1"
+DECOMPOSE_MODEL = os.environ.get("TAOSMD_DECOMPOSE_MODEL", "gemma4:e2b")
+```
+
+- [ ] **Step 4: Add the MULTIHOP_PROMPT and decompose_query helper**
+
+After the `llm_answer` function (after line 143), add:
+
+```python
+MULTIHOP_PROMPT = """Split this question into 2 or 3 shorter, focused sub-queries that together cover everything needed to answer it. Respond with one sub-query per line. No numbering, no explanation.
+
+Question: {question}"""
+
+
+async def decompose_query(client, question: str) -> list:
+    """Split a question into 2-3 sub-queries via a small utility model.
+
+    Returns a list of >=2 stripped lines, or [question] on failure or if fewer
+    than two lines come back (so callers can iterate uniformly).
+    """
+    try:
+        resp = await client.post(
+            f"{REMOTE_LLM_URL}/api/chat",
+            json={
+                "model": DECOMPOSE_MODEL,
+                "messages": [{"role": "user", "content": MULTIHOP_PROMPT.format(question=question) + " /no_think"}],
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0, "num_predict": 80},
+            },
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            raw = resp.json().get("message", {}).get("content", "")
+            lines = [l.strip() for l in raw.splitlines() if l.strip()]
+            if len(lines) >= 2:
+                return lines
+    except Exception:
+        pass
+    return [question]
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -v`
+Expected: the three decompose tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add benchmarks/longmemeval_runner.py tests/test_e012_levers.py
+git commit -m "bench(e012): add query-decomposition helper (lever 2)"
+```
+
+---
+
+## Task 2: Wire decomposition into retrieval
+
+**Files:**
+- Modify: `benchmarks/longmemeval_runner.py:261` (the `vector_results = await vmem.search(...)` line)
+
+- [ ] **Step 1: Replace the single vector search with the decomposition fan-out**
+
+In `run_benchmark`, replace this exact line (currently line 261):
+
+```python
+        vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
+```
+
+with:
+
+```python
+        if DECOMPOSE and llm_client is not None:
+            sub_queries = await decompose_query(llm_client, question)
+            seen_texts = set()
+            vector_results = []
+            for sq in sub_queries:
+                for r in await vmem.search(sq, limit=RETRIEVE_LIMIT):
+                    t = r.get("text", "")
+                    if t and t not in seen_texts:
+                        seen_texts.add(t)
+                        vector_results.append(r)
+            vector_results = vector_results[:RETRIEVE_LIMIT]
+        else:
+            vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
+```
+
+The following `rr = _get_reranker()` block is unchanged: rerank still runs over the (now possibly unioned) `vector_results`.
+
+- [ ] **Step 2: Verify the harness still imports and runs offline (no LLM, decompose off = baseline unchanged)**
+
+Run: `.venv/bin/python benchmarks/longmemeval_runner.py --limit 1`
+Expected: it runs one question in substring mode and prints a RESULTS block (no crash). Note: this requires `benchmarks/data/longmemeval_oracle.json` present; on a machine without it, skip this step and rely on the bench-host run in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/longmemeval_runner.py
+git commit -m "bench(e012): wire decomposition fan-out into retrieval (lever 2)"
+```
+
+---
+
+## Task 3: Answer self-verification helper (TAOSMD_SELF_VERIFY)
+
+**Files:**
+- Modify: `benchmarks/longmemeval_runner.py` (config block; new helper after `decompose_query`)
+- Test: `tests/test_e012_levers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_e012_levers.py`:
+
+```python
+def test_self_verify_returns_revised_when_nonempty():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("corrected answer"), "ctx", "Q", "draft answer"))
+    assert out == "corrected answer"
+
+
+def test_self_verify_keeps_draft_on_error():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_BoomClient(), "ctx", "Q", "draft answer"))
+    assert out == "draft answer"
+
+
+def test_self_verify_keeps_draft_when_revision_empty():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("   "), "ctx", "Q", "draft answer"))
+    assert out == "draft answer"
+
+
+def test_self_verify_noops_on_empty_draft():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("anything"), "ctx", "Q", ""))
+    assert out == ""
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -k self_verify -v`
+Expected: FAIL with `AttributeError: module 'lme_runner' has no attribute 'self_verify_answer'`.
+
+- [ ] **Step 3: Add the config flag**
+
+After the `DECOMPOSE_MODEL = ...` line added in Task 1, add:
+
+```python
+# E-012 lever 3: CoVe-style answer self-verification. After the first answer,
+# one extra generator pass keeps the draft if it is fully supported by the
+# context, else rewrites it from the context. Default off.
+SELF_VERIFY = os.environ.get("TAOSMD_SELF_VERIFY", "0") == "1"
+```
+
+- [ ] **Step 4: Add the VERIFY_PROMPT and self_verify_answer helper**
+
+After the `decompose_query` function, add:
+
+```python
+VERIFY_PROMPT = """You are checking a draft answer against the context.
+If every part of the draft answer is supported by the context, repeat the draft answer exactly.
+If any part is unsupported or contradicted by the context, write a corrected answer using ONLY the context.
+Answer concisely in 1-2 sentences, no explanation. /no_think
+
+Context:
+{context}
+
+Question: {question}
+
+Draft answer: {answer}
+
+Final answer:"""
+
+
+async def self_verify_answer(client, context: str, question: str, answer: str) -> str:
+    """One CoVe-style verification pass.
+
+    Keeps the draft if it is supported by the context, otherwise returns a
+    corrected answer. Falls back to the original draft on empty draft, empty
+    revision, or any failure, so it can never make an answer worse by erroring.
+    """
+    if not answer:
+        return answer
+    try:
+        resp = await client.post(
+            f"{REMOTE_LLM_URL}/api/chat",
+            json={
+                "model": REMOTE_LLM_MODEL,
+                "messages": [{"role": "user", "content": VERIFY_PROMPT.format(context=context[:CONTEXT_CHARS], question=question, answer=answer)}],
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0, "num_predict": 100},
+            },
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            revised = resp.json().get("message", {}).get("content", "").strip()
+            if revised:
+                return revised
+    except Exception:
+        pass
+    return answer
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -v`
+Expected: all seven tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add benchmarks/longmemeval_runner.py tests/test_e012_levers.py
+git commit -m "bench(e012): add CoVe-style answer self-verification (lever 3)"
+```
+
+---
+
+## Task 4: Wire self-verification after generation
+
+**Files:**
+- Modify: `benchmarks/longmemeval_runner.py` (the answer-generation block, currently ~line 275)
+
+- [ ] **Step 1: Add the verification pass after the first answer**
+
+In `run_benchmark`, find this exact line (currently line 275):
+
+```python
+            answer = await llm_answer(llm_client, full_context, question)
+```
+
+and add immediately after it:
+
+```python
+            if SELF_VERIFY:
+                answer = await self_verify_answer(llm_client, full_context, question, answer)
+```
+
+- [ ] **Step 2: Verify the full test suite for the new helpers still passes**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -v`
+Expected: all seven tests PASS (the wiring change does not affect the unit tests, which call the helpers directly; this confirms no syntax error was introduced).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/longmemeval_runner.py
+git commit -m "bench(e012): run self-verification pass when enabled (lever 3)"
+```
+
+---
+
+## Task 5: Ablation matrix runner
+
+**Files:**
+- Create: `benchmarks/e012_ablation.sh`
+
+- [ ] **Step 1: Write the matrix runner**
+
+Create `benchmarks/e012_ablation.sh`:
+
+```bash
+#!/usr/bin/env bash
+# E-012 score-up ablation. Sweeps the lever arms SEQUENTIALLY (one Ollama job
+# at a time per the GPU-contention rule) and records each arm's overall and
+# per-type Judge accuracy.
+#
+# Usage: benchmarks/e012_ablation.sh [LIMIT]
+#   LIMIT defaults to 100 (screening pass). Use 500 for the full oracle set.
+#
+# Required env (export before running):
+#   TAOSMD_OLLAMA_MODEL   generator (e.g. qwen3.5:9b)
+#   TAOSMD_JUDGE_MODEL    external judge (e.g. qwen3:4b-instruct-2507)
+#   TAOSMD_OLLAMA_URL     Ollama base URL (default http://localhost:11434)
+# Fixed substrate (depth + rerank context-release = lever 1) is set per arm.
+set -u
+LIMIT="${1:-100}"
+PY=".venv/bin/python"
+OUT="benchmarks/results/e012_ablation_$(date -u +%Y%m%d_%H%M%S).log"
+RUNNER="benchmarks/longmemeval_runner.py"
+
+run_arm () {
+  local name="$1"; shift
+  echo "==================== ARM: $name (limit=$LIMIT) ====================" | tee -a "$OUT"
+  # Reset all levers off, then apply this arm's env (passed as VAR=VAL args).
+  env -u TAOSMD_DECOMPOSE -u TAOSMD_SELF_VERIFY -u TAOSMD_RERANK \
+      TAOSMD_ASSEMBLE_TOKENS="${TAOSMD_ASSEMBLE_TOKENS:-4000}" \
+      TAOSMD_RETRIEVE_LIMIT="${TAOSMD_RETRIEVE_LIMIT:-12}" \
+      TAOSMD_FTS_LIMIT="${TAOSMD_FTS_LIMIT:-5}" \
+      TAOSMD_CONTEXT_CHARS="${TAOSMD_CONTEXT_CHARS:-16000}" \
+      "$@" \
+      "$PY" "$RUNNER" --llm --limit "$LIMIT" 2>&1 | tee -a "$OUT"
+  echo "" | tee -a "$OUT"
+}
+
+# Arms. Lever 1 = TAOSMD_RERANK=1, lever 2 = TAOSMD_DECOMPOSE=1, lever 3 = TAOSMD_SELF_VERIFY=1.
+run_arm "baseline"
+run_arm "L1_context_release"  TAOSMD_RERANK=1
+run_arm "L2_decompose"        TAOSMD_DECOMPOSE=1
+run_arm "L3_self_verify"      TAOSMD_SELF_VERIFY=1
+run_arm "L1+L2"               TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1
+run_arm "L1+L3"               TAOSMD_RERANK=1 TAOSMD_SELF_VERIFY=1
+run_arm "L2+L3"               TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
+run_arm "L1+L2+L3"            TAOSMD_RERANK=1 TAOSMD_DECOMPOSE=1 TAOSMD_SELF_VERIFY=1
+
+echo "Ablation complete. Full log: $OUT" | tee -a "$OUT"
+echo "Per-arm overall accuracy:" | tee -a "$OUT"
+grep -E "ARM:|Overall:" "$OUT" | tee -a "$OUT"
+```
+
+- [ ] **Step 2: Make it executable and syntax-check it**
+
+```bash
+chmod +x benchmarks/e012_ablation.sh
+bash -n benchmarks/e012_ablation.sh && echo "syntax OK"
+```
+Expected: `syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/e012_ablation.sh
+git commit -m "bench(e012): ablation matrix runner (8 lever arms, sequential)"
+```
+
+---
+
+## Task 6: Final review and run handoff
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full new-helper test suite once more**
+
+Run: `.venv/bin/python -m pytest tests/test_e012_levers.py -v`
+Expected: 7 passed.
+
+- [ ] **Step 2: Confirm the baseline arm is unchanged behavior**
+
+Verify by inspection that with all three flags unset, `run_benchmark` takes the exact original path: `decompose_query` is skipped (the `else` branch), `self_verify_answer` is skipped, rerank is gated by `RERANK`. The baseline arm therefore reproduces the 47.2% control.
+
+- [ ] **Step 3: Hand off to the run**
+
+The build is done and GPU-free. The matrix run is a separate, GPU-gated step (coordinate with @taOS via the lease protocol): screen all arms at `--limit` 100 first to find which levers move the number, then full-500 on the baseline plus the winning arm(s), then the bigger-generator arm (`TAOSMD_OLLAMA_MODEL=qwen3.6:35b-a3b-q4_K_M`) on the winner, then the tri-judge firm-up. Record the result as an F or N finding in the research report with provenance, either way.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Lever 1 (context release) is the existing rerank/depth, exercised as arms in Task 5 (no build needed, per spec). Lever 2 (decomposition) = Tasks 1, 2. Lever 3 (self-verify) = Tasks 3, 4. The bigger-generator arm = Task 6 Step 3 handoff (env only, no code). Ablation matrix = Task 5. Judge protocol and tri-judge firm-up = Task 6 Step 3. All spec sections map to a task.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; the only "skip" is the optionally-absent dataset in Task 2 Step 2, which has an explicit fallback.
+
+**Type consistency:** `decompose_query(client, question) -> list` and `self_verify_answer(client, context, question, answer) -> str` are used with matching signatures in the wiring (Tasks 2, 4) and the tests. Env flag names (`TAOSMD_DECOMPOSE`, `TAOSMD_DECOMPOSE_MODEL`, `TAOSMD_SELF_VERIFY`) match between the runner, the helpers, and the ablation script.

--- a/docs/superpowers/specs/2026-06-14-e012-score-up-ablation-design.md
+++ b/docs/superpowers/specs/2026-06-14-e012-score-up-ablation-design.md
@@ -1,0 +1,117 @@
+# E-012 score-up ablation design
+
+**Status:** approved (Jay, 2026-06-14). Build now, run the matrix when the GPU is claimed.
+
+**Goal:** lift the honest end-to-end Judge score on LongMemEval-S above the F-012
+baseline of 47.2% (236/500), and attribute any gain to a specific lever via a
+clean ablation, not a single tangled config.
+
+## Background
+
+F-012 established the real Judge number: 47.2% on the 500-question oracle set,
+with a qwen3.5:9b generator, a strict external Qwen3-4B-Instruct judge, MiniLM
+embeddings, and the depth-tuned evidence pipeline. The diagnosis was that
+retrieval is solved (97.0% Recall@5) but reasoning is the bottleneck: temporal
+17.3% and multi-session 28.6%, against single-session and knowledge 71 to 89%.
+The generator was also evidence-starved at the original depth.
+
+The levers below target the reasoning bottleneck and the evidence quality, in
+the order Jay chose: reasoning scaffolds and context-release first (levers 1 to
+3), the bigger generator as a separate arm afterwards.
+
+## The levers
+
+Each lever is an independent toggle on `benchmarks/longmemeval_runner.py`
+(branch `bench/e012-judge-harness`), gated by an environment variable, default
+off so the baseline is unchanged.
+
+**Lever 1 - context release (already built).** Retrieve more, then rerank and
+keep a clean subset before generation. Implemented: depth knobs
+(`TAOSMD_ASSEMBLE_TOKENS`, `TAOSMD_RETRIEVE_LIMIT`, `TAOSMD_FTS_LIMIT`,
+`TAOSMD_CONTEXT_CHARS`) and the `TAOSMD_RERANK` cross-encoder toggle
+(bge-reranker-v2-m3 ONNX, `TAOSMD_RERANK_TOP_K`). No new code; it is an arm in
+the matrix.
+
+**Lever 2 - query decomposition with iterative retrieval (port).** Split the
+question into 2 to 3 focused sub-queries, retrieve for each, union the hits
+deduplicated by text, cap at the retrieve limit. Port `_decompose_query` and
+`MULTIHOP_PROMPT` from `benchmarks/locomo_runner.py` (a small gemma4:e2b
+utility call, temperature 0, falls back to the original question on failure or
+fewer than two lines). New env toggle `TAOSMD_DECOMPOSE=1`. Targets
+multi-session questions that need facts from more than one place.
+
+**Lever 3 - answer self-verification, CoVe-style (fresh build).** After the
+first answer, run one verification pass: given the context and the draft
+answer, ask the generator to flag any part not supported by the context and
+return a corrected answer, or the draft unchanged if fully supported. This is a
+lightweight Chain-of-Verification adapted to QA; there is no existing
+implementation to port, so it is built fresh. New env toggle
+`TAOSMD_SELF_VERIFY=1`. Uses the same generator and the `/no_think` discipline
+already in the runner. Targets answers that drift from the evidence.
+
+**Separate arm - bigger generator.** qwen3.6:35b-a3b in place of qwen3.5:9b, via
+the existing `TAOSMD_OLLAMA_MODEL` env. No code change. Run after levers 1 to 3
+so we know what the scaffolds buy on the smaller, faster generator first.
+
+## Ablation matrix
+
+Same fixed substrate for every arm: oracle 500-question set, MiniLM embeddings,
+the hybrid plus query-expansion retrieval, the strict external
+Qwen3-4B-Instruct judge, `/no_think`, temperature 0. Only the lever under test
+changes.
+
+1. baseline (no levers) - reproduce 47.2% as the control in this run
+2. lever 1 alone (context release)
+3. lever 2 alone (decomposition)
+4. lever 3 alone (self-verification)
+5. levers 1 + 2
+6. levers 1 + 3
+7. levers 2 + 3
+8. levers 1 + 2 + 3 (all scaffolds)
+9. best-of-1-to-8 with the bigger generator
+
+Each arm reports overall Judge accuracy and the per-category breakdown, so a
+lever that helps temporal or multi-session but not overall is still visible.
+Read each arm against the baseline control, not against the prior 47.2% (judge
+and sampling noise differ across runs; the control absorbs that).
+
+## Judge protocol
+
+The ablation deltas use the single strict Qwen3-4B-Instruct judge for
+comparability and cost. The winning arm gets a tri-judge firm-up (gemma4:e2b
+lenient, llama3.1:8b strict, qwen3:4b-instruct-2507 strict) so the reported
+gain is not judge-specific, the same discipline E-009 uses before a default
+flip. A lever only counts as a win if it clears the baseline by more than
+plausible run-to-run noise and survives the firm-up.
+
+## GPU and run protocol
+
+The matrix needs the 3060 (9B and 35B generators plus the judge). Coordinate
+with @taOS over the lease protocol: CHECK plus nvidia-smi, post [GPU CLAIM]
+before running, [GPU RELEASE] when done, their demo has priority. Size models so
+co-resident generator plus judge stay under 12 GB to avoid the swap deadlock
+that hung E-009 (qwen3.5:9b plus Qwen3-4B-Instruct judge fits; the 35B arm runs
+with the judge pass sequenced, not co-resident, if it would exceed the budget).
+Build is GPU-free and happens first; the GPU is claimed only when an arm is
+ready to run.
+
+## Success criteria
+
+- A per-lever attribution table: each lever's overall and per-category delta
+  versus the baseline control.
+- At least the all-scaffolds arm and the bigger-generator arm measured.
+- The winning configuration confirmed under the tri-judge firm-up.
+- A recorded research-report finding (F or N) with provenance, whichever way it
+  lands. A null result (scaffolds do not move the Judge number) is a publishable
+  outcome and gets recorded as such.
+
+## Out of scope (YAGNI)
+
+- No new embedder work (E-010 settled arctic as the dense default; this run
+  holds the embedder fixed for comparability).
+- No full Provence-style learned pruner; the cross-encoder rerank is the
+  context-release mechanism for this round.
+- No distractor-set run in this matrix; the oracle set is the headline-
+  comparable surface. A distractor run is a later, separate arm.
+- No changes to shipped defaults from this harness; any win flows to defaults
+  through the normal branch, full-scale confirm, and Jay sign-off.

--- a/tests/test_e012_levers.py
+++ b/tests/test_e012_levers.py
@@ -76,3 +76,20 @@ def test_self_verify_noops_on_empty_draft():
     mod = _load_runner()
     out = asyncio.run(mod.self_verify_answer(_FakeClient("anything"), "ctx", "Q", ""))
     assert out == ""
+
+
+def test_sample_dataset_no_seed_is_head_slice():
+    mod = _load_runner()
+    data = [{"id": i} for i in range(100)]
+    assert mod.sample_dataset(data, 5, seed=None) == data[:5]
+
+
+def test_sample_dataset_seed_is_deterministic_and_representative():
+    mod = _load_runner()
+    # Type-ordered like the oracle set: first 50 one type, next 50 another.
+    data = [{"id": i, "t": "temporal" if i < 50 else "multi"} for i in range(100)]
+    a = mod.sample_dataset(data, 20, seed=42)
+    b = mod.sample_dataset(data, 20, seed=42)
+    assert a == b  # same seed -> same sample, comparable across arms
+    assert {d["t"] for d in a} == {"temporal", "multi"}  # not a single-type head slice
+    assert mod.sample_dataset(data, 20, seed=7) != a  # different seed -> different sample

--- a/tests/test_e012_levers.py
+++ b/tests/test_e012_levers.py
@@ -1,0 +1,54 @@
+import importlib.util
+import pathlib
+import asyncio
+
+_RUNNER = pathlib.Path(__file__).resolve().parent.parent / "benchmarks" / "longmemeval_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("lme_runner", _RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeResp:
+    def __init__(self, content, status=200):
+        self.status_code = status
+        self._content = content
+
+    def json(self):
+        return {"message": {"content": self._content}}
+
+
+class _FakeClient:
+    """Returns a fixed Ollama chat response for any .post()."""
+    def __init__(self, content, status=200):
+        self._content = content
+        self._status = status
+
+    async def post(self, *args, **kwargs):
+        return _FakeResp(self._content, self._status)
+
+
+class _BoomClient:
+    async def post(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_decompose_returns_lines_when_two_or_more():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_FakeClient("who did she marry\nwhen did they meet"), "Q"))
+    assert out == ["who did she marry", "when did they meet"]
+
+
+def test_decompose_falls_back_when_fewer_than_two_lines():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_FakeClient("only one line"), "original question"))
+    assert out == ["original question"]
+
+
+def test_decompose_falls_back_on_error():
+    mod = _load_runner()
+    out = asyncio.run(mod.decompose_query(_BoomClient(), "original question"))
+    assert out == ["original question"]

--- a/tests/test_e012_levers.py
+++ b/tests/test_e012_levers.py
@@ -52,3 +52,27 @@ def test_decompose_falls_back_on_error():
     mod = _load_runner()
     out = asyncio.run(mod.decompose_query(_BoomClient(), "original question"))
     assert out == ["original question"]
+
+
+def test_self_verify_returns_revised_when_nonempty():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("corrected answer"), "ctx", "Q", "draft answer"))
+    assert out == "corrected answer"
+
+
+def test_self_verify_keeps_draft_on_error():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_BoomClient(), "ctx", "Q", "draft answer"))
+    assert out == "draft answer"
+
+
+def test_self_verify_keeps_draft_when_revision_empty():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("   "), "ctx", "Q", "draft answer"))
+    assert out == "draft answer"
+
+
+def test_self_verify_noops_on_empty_draft():
+    mod = _load_runner()
+    out = asyncio.run(mod.self_verify_answer(_FakeClient("anything"), "ctx", "Q", ""))
+    assert out == ""


### PR DESCRIPTION
Fixes the LongMemEval Judge harness (the F-012 baseline = 47.2% honest end-to-end Judge) and adds the score-up levers. Harness fixes: external judge via TAOSMD_JUDGE_MODEL (was same-model, which emitted CoT and zeroed real generators), /no_think on generator + judge, context cap lifted. Score-up levers: evidence-depth knobs (TAOSMD_ASSEMBLE_TOKENS / RETRIEVE_LIMIT / FTS_LIMIT / CONTEXT_CHARS) and bge-v2-m3 reranking (TAOSMD_RERANK) for intelligent context release. Diagnosis recorded in docs/research-report.md F-012: retrieval solved, reasoning is the bottleneck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LongMemEval benchmark runner with configurable retrieval and answer verification capabilities.
  * Added ablation sweep benchmark script for systematic experimentation.

* **Documentation**
  * Added experimental design specification and implementation plan for LongMemEval enhancements.

* **Tests**
  * Added comprehensive test suite validating new benchmark runner functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->