### PR TITLE
feat(embed): env-configurable onnx pooling/prefix + E-010 embedding bake-off (N-012)

### DIFF
--- a/.claude/a2a-session-setup.md
+++ b/.claude/a2a-session-setup.md
@@ -7,8 +7,15 @@ resolves it from the local taosmd config (server_url in the user config file)
 or TAOSMD_SERVER_URL.
 
 1. LIVE WATCHER (in-session): run `taosmd a2a-watch --exclude @taOSmd` as a
-   persistent background monitor so every new bus message wakes the session.
-   It streams all channels over SSE and reconnects on drops.
+   MANAGED background task so every new bus message wakes the session. It
+   streams all channels over SSE and reconnects on drops. CRITICAL: launch it
+   with the harness's background-task mechanism (Claude Code: the Bash tool's
+   `run_in_background: true`, which returns a task ID and delivers
+   `<task-notification>` events). Do NOT launch it as a plain shell `&`
+   background process: that runs and streams to a log file but is NOT tracked
+   by the harness, so it delivers NO notifications and you silently fall back
+   to polling. On resume, re-arm it this way (the wind-down step that silences
+   it stops the managed task, so a fresh managed task is needed on wake).
 2. DURABLE FLOOR (machine-level, verify it exists rather than re-adding):
    hourly `taosmd a2a-poll` crontab lines per channel appending to the
    inbox log under the taosmd user config dir. These survive sessions and

--- a/benchmarks/e010_bakeoff.sh
+++ b/benchmarks/e010_bakeoff.sh
@@ -65,7 +65,7 @@ for entry in "${CANDIDATES[@]}"; do
         --embed-mode onnx --onnx-path "$dir" --reranker off \
         --out "$out" 2>>"$OUTDIR/e010_${name}_${STAMP}.err" \
       | grep -E "^Overall|R@K" | head -1)
-  rk=$("$PY" -c "import json,sys; d=json.load(open('$out')); print(d.get('r_at_k', d.get('overall',{}).get('r_at_k','?')))" 2>/dev/null || echo "?")
+  rk=$("$PY" -c "import json; d=json.load(open('$out')); print((d.get('summary') or {}).get('r_at_k','?'))" 2>/dev/null || echo "?")
   echo "$(printf '%-20s' "$name") $(printf '%-7s' "$rk")" | tee -a "$SUMMARY"
 done
 

--- a/benchmarks/e010_bakeoff.sh
+++ b/benchmarks/e010_bakeoff.sh
@@ -28,7 +28,7 @@ import sys
 from huggingface_hub import snapshot_download
 repo, dir = sys.argv[1], sys.argv[2]
 snapshot_download(repo, local_dir=dir, allow_patterns=[
-    "onnx/model.onnx", "model.onnx", "*.json", "tokenizer*", "vocab*", "1_Pooling/*"])
+    "onnx/model.onnx", "onnx/model.onnx_data", "onnx/*.onnx_data", "model.onnx", "model.onnx_data", "*.json", "tokenizer*", "vocab*", "1_Pooling/*"])
 print("fetched", repo)
 PYEOF
 }

--- a/benchmarks/e010_bakeoff.sh
+++ b/benchmarks/e010_bakeoff.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# E-010 embedding bake-off (judge-free R@K screen). CPU-only, no GPU, no servers,
+# no Docker, no system changes -> safe to run on the VPS alongside Coolify.
+# For each candidate embedder: fetch its ONNX, set the correct pooling + prefix
+# via the env-configurable loader (TAOSMD_ONNX_POOLING / _QUERY_PREFIX / _DOC_PREFIX),
+# run the retrieval R@K probe on a LoCoMo subset, collect R@K. Compares against
+# the shipped arctic-embed-s default.
+#
+# Usage: bash benchmarks/e010_bakeoff.sh [conversations]   (default 10)
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+PY="${PY:-/root/bench-venv/bin/python}"
+[ -x "$PY" ] || PY="$(command -v python3)"
+CONV="${1:-10}"
+DATASET="${LOCOMO_DATASET:-data/locomo/data/locomo10.json}"
+OUTDIR="benchmarks/results"; mkdir -p "$OUTDIR"
+STAMP="$(date +%Y%m%d_%H%M%S)"
+SUMMARY="$OUTDIR/e010_bakeoff_${STAMP}.txt"
+ARCTIC_PREFIX="Represent this sentence for searching relevant passages: "
+
+# Ensure huggingface_hub CLI is available in the venv (isolated, no system touch).
+"$PY" -c "import huggingface_hub" 2>/dev/null || "$PY" -m pip install -q huggingface_hub 2>/dev/null
+HF="$PY -m huggingface_hub.commands.huggingface_cli"
+
+# name | hf_repo | pooling | query_prefix | doc_prefix
+CANDIDATES=(
+  "arctic-s|Snowflake/snowflake-arctic-embed-s|cls|${ARCTIC_PREFIX}|"
+  "bge-small|BAAI/bge-small-en-v1.5|cls|${ARCTIC_PREFIX}|"
+  "gte-small|thenlper/gte-small|mean||"
+  "e5-small-v2|intfloat/e5-small-v2|mean|query: |passage: "
+  "granite-small-r2|onnx-community/granite-embedding-small-english-r2-ONNX|cls||"
+)
+
+echo "E-010 embedding bake-off  $(date -u)  conv=$CONV dataset=$DATASET" | tee "$SUMMARY"
+echo "model                R@K     n_evid" | tee -a "$SUMMARY"
+
+for entry in "${CANDIDATES[@]}"; do
+  IFS='|' read -r name repo pooling qpref dpref <<< "$entry"
+  dir="models/e010-$name"
+  if [ ! -f "$dir/onnx/model.onnx" ] && [ ! -f "$dir/model.onnx" ]; then
+    echo "[fetch] $name <- $repo" | tee -a "$SUMMARY"
+    $HF download "$repo" --include "onnx/model.onnx" "model.onnx" "*.json" "tokenizer*" "vocab*" "1_Pooling/*" \
+      --local-dir "$dir" >/dev/null 2>&1
+  fi
+  if [ ! -f "$dir/onnx/model.onnx" ] && [ ! -f "$dir/model.onnx" ]; then
+    echo "$(printf '%-20s' "$name") FETCH_FAILED (no model.onnx)" | tee -a "$SUMMARY"; continue
+  fi
+  out="$OUTDIR/e010_${name}_${STAMP}.json"
+  # The loader env overrides take precedence over name detection.
+  R=$(TAOSMD_ONNX_POOLING="$pooling" \
+      TAOSMD_ONNX_QUERY_PREFIX="$qpref" \
+      TAOSMD_ONNX_DOC_PREFIX="$dpref" \
+      "$PY" benchmarks/retrieval_latency_probe.py \
+        --dataset "$DATASET" --conversations "$CONV" \
+        --embed-mode onnx --onnx-path "$dir" --reranker off \
+        --out "$out" 2>>"$OUTDIR/e010_${name}_${STAMP}.err" \
+      | grep -E "^Overall|R@K" | head -1)
+  rk=$("$PY" -c "import json,sys; d=json.load(open('$out')); print(d.get('r_at_k', d.get('overall',{}).get('r_at_k','?')))" 2>/dev/null || echo "?")
+  echo "$(printf '%-20s' "$name") $(printf '%-7s' "$rk")" | tee -a "$SUMMARY"
+done
+
+echo "" | tee -a "$SUMMARY"
+echo "done. summary: $SUMMARY" | tee -a "$SUMMARY"

--- a/benchmarks/e010_bakeoff.sh
+++ b/benchmarks/e010_bakeoff.sh
@@ -19,9 +19,19 @@ STAMP="$(date +%Y%m%d_%H%M%S)"
 SUMMARY="$OUTDIR/e010_bakeoff_${STAMP}.txt"
 ARCTIC_PREFIX="Represent this sentence for searching relevant passages: "
 
-# Ensure huggingface_hub CLI is available in the venv (isolated, no system touch).
+# Ensure huggingface_hub is available in the venv (isolated, no system touch).
 "$PY" -c "import huggingface_hub" 2>/dev/null || "$PY" -m pip install -q huggingface_hub 2>/dev/null
-HF="$PY -m huggingface_hub.commands.huggingface_cli"
+
+fetch_model() {  # $1=repo  $2=dir
+  "$PY" - "$1" "$2" <<'PYEOF'
+import sys
+from huggingface_hub import snapshot_download
+repo, dir = sys.argv[1], sys.argv[2]
+snapshot_download(repo, local_dir=dir, allow_patterns=[
+    "onnx/model.onnx", "model.onnx", "*.json", "tokenizer*", "vocab*", "1_Pooling/*"])
+print("fetched", repo)
+PYEOF
+}
 
 # name | hf_repo | pooling | query_prefix | doc_prefix
 CANDIDATES=(
@@ -40,8 +50,7 @@ for entry in "${CANDIDATES[@]}"; do
   dir="models/e010-$name"
   if [ ! -f "$dir/onnx/model.onnx" ] && [ ! -f "$dir/model.onnx" ]; then
     echo "[fetch] $name <- $repo" | tee -a "$SUMMARY"
-    $HF download "$repo" --include "onnx/model.onnx" "model.onnx" "*.json" "tokenizer*" "vocab*" "1_Pooling/*" \
-      --local-dir "$dir" >/dev/null 2>&1
+    fetch_model "$repo" "$dir" >>"$OUTDIR/e010_${name}_fetch.err" 2>&1
   fi
   if [ ! -f "$dir/onnx/model.onnx" ] && [ ! -f "$dir/model.onnx" ]; then
     echo "$(printf '%-20s' "$name") FETCH_FAILED (no model.onnx)" | tee -a "$SUMMARY"; continue

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -11,6 +11,7 @@ import base64
 import json
 import logging
 import math
+import os
 import sqlite3
 import time
 from pathlib import Path
@@ -126,6 +127,13 @@ def _onnx_apply_prefix(onnx_path, text: str, task: str) -> str:
     task name; arctic-embed prefixes only the query. MiniLM and anything
     else gets no prefix. Detection is by model directory name.
     """
+    # Env override (E-010 bake-off: let any model set its prefixes explicitly,
+    # independent of pooling and of directory-name detection). Active when
+    # either var is present; empty string means "no prefix on that side".
+    if "TAOSMD_ONNX_QUERY_PREFIX" in os.environ or "TAOSMD_ONNX_DOC_PREFIX" in os.environ:
+        if task == "search_query":
+            return f"{os.environ.get('TAOSMD_ONNX_QUERY_PREFIX', '')}{text}"
+        return f"{os.environ.get('TAOSMD_ONNX_DOC_PREFIX', '')}{text}"
     path = str(onnx_path).lower() if onnx_path else ""
     if "nomic" in path:
         return f"{task}: {text}"
@@ -141,6 +149,9 @@ def _onnx_pooling_mode(onnx_path) -> str:
     pooling_mode_cls_token true, mean false); the MiniLM default and
     everything else mean-pool over the attention mask.
     """
+    pm = os.environ.get("TAOSMD_ONNX_POOLING")
+    if pm in ("cls", "mean"):
+        return pm
     path = str(onnx_path).lower() if onnx_path else ""
     if "arctic" in path:
         return "cls"


### PR DESCRIPTION
Ships the env-configurable ONNX loader (the reusable part) and the E-010 bake-off that produced N-012 (no small embedder beats arctic-embed-s; arctic retained, F-010 reaffirmed).

**Loader (package feature):** `TAOSMD_ONNX_POOLING` (cls|mean), `TAOSMD_ONNX_QUERY_PREFIX`, `TAOSMD_ONNX_DOC_PREFIX` env overrides make pooling and prefix independent and explicit, instead of directory-name detection. Lets any ONNX embedder run with its correct config. Back-compat preserved (overrides only when set); 13 onnx/store tests green.

**Bake-off:** `benchmarks/e010_bakeoff.sh` runs a judge-free R@K probe per candidate on the VPS (CPU). Result (LoCoMo R@K): arctic-s 0.823, e5-small 0.808, bge-small 0.773, granite-r2 0.742, gte-small 0.727. None clears the +0.02 kill margin. Recorded docs/research-report.md N-012.