### PR TITLE
chore(bench): pin LongMemEval-S Recall@5 recipe + provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ __pycache__/
 dist/
 build/
 data/
+# dataset files stay ignored for size, but keep the tracked pointer/checksum
+!benchmarks/data/
+benchmarks/data/*
+!benchmarks/data/README.md
 *.rknn
 *.rkllm
 models/minilm-onnx/model.onnx

--- a/benchmarks/REPRODUCE-longmemeval.md
+++ b/benchmarks/REPRODUCE-longmemeval.md
@@ -96,5 +96,10 @@ of the host it runs on.
 - 2026-04-13: original run, `enhanced_20260413_133215.json` (query_expand
   485/500 = 97.0%). This file is the committed provenance above.
 - 2026-06-14: independent re-run from the pinned recipe on the project bench
-  host (CPU, MiniLM ONNX) to verify the repo reproduces its own headline.
-  Result recorded below once the run completes.
+  host (CPU, MiniLM ONNX), file `enhanced_20260614_175453.json`. It reproduces
+  the committed proof exactly: `query_expand` = 485/500 = 97.0% Recall@5, with
+  the same five-config table (baseline 96.6, query_expand 97.0, temporal_boost
+  96.6, combined_v2 97.0, wider_retrieval 96.2) and the same per-category counts
+  (knowledge-update 78/78, multi-session 131/133, temporal-reasoning 127/133,
+  single-session-user 68/70, single-session-assistant 54/56,
+  single-session-preference 27/30). The repo now reproduces its own headline.

--- a/benchmarks/REPRODUCE-longmemeval.md
+++ b/benchmarks/REPRODUCE-longmemeval.md
@@ -1,0 +1,100 @@
+# Reproducing the LongMemEval-S 97.0% Recall@5 headline
+
+This is the pinned recipe for the headline number taOSmd publishes on
+LongMemEval-S. Anyone with the repo, the dataset, and the ONNX model can
+re-run it and get the same result. It exists because the repo previously could
+not reproduce its own headline: the dataset lived as an untracked file and the
+exact recipe was never written down, which is how the number came to be
+mislabelled for a while (see "What this number is" below).
+
+## What this number is (and is not)
+
+The headline is **97.0% Recall@5**, a *retrieval* metric: for each question,
+does at least one gold answer session appear in the top 5 retrieved sessions.
+It is the `query_expand` configuration of `longmemeval_enhanced.py`, scoring
+485 of 500 questions.
+
+It is **not** end-to-end QA accuracy and **not** an LLM-as-judge score. A
+separate harness measures the genuine end-to-end Judge number (retrieve, then
+generate an answer, then grade it); that is tracked as E-012 and is a much
+lower number, because retrieval being solved does not mean the small local
+generator answers correctly. Do not describe this Recall@5 figure as Judge
+accuracy.
+
+The comparison point is MemPalace, which reports 96.6% Recall@5 on the same set
+with the same metric, so the head-to-head is like for like.
+
+## Prerequisites
+
+- Dataset: `benchmarks/data/longmemeval_s_full.json` (500 questions). It is
+  gitignored for size; see `benchmarks/data/README.md` for the identity, the
+  sha256 pin, and how to obtain it.
+- Embedding model: `models/minilm-onnx/` (all-MiniLM-L6-v2 exported to ONNX,
+  384 dim). This is the same model family MemPalace uses, chosen so the
+  comparison is fair.
+- A Python env with the repo installed (`pip install -e .`) plus
+  `onnxruntime`, `httpx`, `bm25s`, and `spacy`. No GPU and no Ollama are
+  needed: this is pure CPU ONNX retrieval.
+
+## The command
+
+```bash
+python benchmarks/longmemeval_enhanced.py --limit 500 --top-k 5
+```
+
+The runner sweeps five retrieval configurations and writes a timestamped JSON
+to `benchmarks/results/enhanced_<YYYYMMDD_HHMMSS>.json`. The published headline
+is the `query_expand` row.
+
+## What the recipe does
+
+For each question, fresh per question:
+
+1. Ingest the haystack. Each session is reduced to its user turns, joined, and
+   truncated to 512 characters, then embedded as one vector tagged with its
+   `session_id`. (User-turns-only ingestion was the best strategy in prior
+   ablations.)
+2. Build the query. For `query_expand`, the question is extended with up to
+   three entity keywords from `expand_query_fast`, plus preference terms from
+   `extract_preferences` when the question is a preference question. Other
+   configs differ here (temporal rerank, wider retrieve-then-trim, etc.).
+3. Retrieve with `vmem.search(query, limit=5, hybrid=True)` (dense + BM25
+   hybrid).
+4. Score Recall@5: a hit if any `answer_session_id` is among the retrieved
+   sessions' ids.
+
+## Expected output (committed provenance)
+
+The committed proof file is
+`benchmarks/results/enhanced_20260413_133215.json`. Its five configurations:
+
+| config           | Recall@5 | hits    |
+|------------------|----------|---------|
+| hybrid_baseline  | 96.6%    | 483/500 |
+| query_expand     | 97.0%    | 485/500 |
+| temporal_boost   | 96.6%    | 483/500 |
+| combined_v2      | 97.0%    | 485/500 |
+| wider_retrieval  | 96.2%    | 481/500 |
+
+The published `query_expand` per-category breakdown:
+
+| question type             | Recall@5 |
+|---------------------------|----------|
+| single-session-user       | 68/70    |
+| multi-session             | 131/133  |
+| single-session-preference | 27/30    |
+| temporal-reasoning        | 127/133  |
+| knowledge-update          | 78/78    |
+| single-session-assistant  | 54/56    |
+
+A fresh run reproduces these counts because retrieval here is deterministic
+(fixed dataset, fixed ONNX weights, no sampling), so the result is independent
+of the host it runs on.
+
+## Reproduction log
+
+- 2026-04-13: original run, `enhanced_20260413_133215.json` (query_expand
+  485/500 = 97.0%). This file is the committed provenance above.
+- 2026-06-14: independent re-run from the pinned recipe on the project bench
+  host (CPU, MiniLM ONNX) to verify the repo reproduces its own headline.
+  Result recorded below once the run completes.

--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -1,0 +1,33 @@
+# Benchmark datasets
+
+This directory holds benchmark datasets. The datasets themselves are gitignored
+because they are large, but their identities are pinned here so a missing file
+never means a lost or ambiguous dataset. Verify any copy against the checksum
+before trusting a published number.
+
+## longmemeval_s_full.json
+
+- What it is: LongMemEval-S, the oracle variant of the LongMemEval long-term
+  memory benchmark, 500 questions, each with a haystack of conversation
+  sessions and the gold answer session ids.
+- Used by: `benchmarks/longmemeval_enhanced.py` and the other
+  `longmemeval_*` runners. It is the source of the published 97.0% Recall@5
+  headline (see `benchmarks/REPRODUCE-longmemeval.md`).
+- Size: 277383467 bytes (about 265 MiB).
+- Question count: 500.
+- sha256: `d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442`
+
+To verify a copy:
+
+```bash
+shasum -a 256 benchmarks/data/longmemeval_s_full.json
+# expect: d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442
+```
+
+### How to obtain it
+
+Get LongMemEval-S from the upstream LongMemEval project (the `longmemeval_s`
+oracle set). Place the 500-question file at
+`benchmarks/data/longmemeval_s_full.json` and confirm the checksum above. A
+canonical pinned copy is also kept on the project bench host under the repo's
+`benchmarks/data/` directory.

--- a/benchmarks/longmemeval_recall.py
+++ b/benchmarks/longmemeval_recall.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""LongMemEval Recall@k Benchmark — Same metric as MemPalace.
+"""LongMemEval Recall@k Benchmark (DEPRECATED).
+
+DEPRECATED: superseded by longmemeval_enhanced.py, the canonical Recall@k
+runner for the published 97.0% number (see benchmarks/REPRODUCE-longmemeval.md).
+This file predates the taosmd package rename: it still imports the old
+`tinyagentos` package and targets a qmd server, so it will not import as-is.
+Kept for history only. Do not use it.
 
 Measures: Does at least one correct answer session appear in top-k
 retrieved results? This is a RETRIEVAL metric, not QA accuracy.

--- a/benchmarks/results/enhanced_20260413_133215.json
+++ b/benchmarks/results/enhanced_20260413_133215.json
@@ -1,0 +1,167 @@
+{
+  "benchmark": "enhanced",
+  "top_k": 5,
+  "results": {
+    "hybrid_baseline": {
+      "overall": 96.6,
+      "total": 483,
+      "questions": 500,
+      "time": 283.9552540779114,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 125,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "query_expand": {
+      "overall": 97.0,
+      "total": 485,
+      "questions": 500,
+      "time": 221.55716013908386,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 127,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "temporal_boost": {
+      "overall": 96.6,
+      "total": 483,
+      "questions": 500,
+      "time": 220.72949123382568,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 125,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "combined_v2": {
+      "overall": 97.0,
+      "total": 485,
+      "questions": 500,
+      "time": 220.74136090278625,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 127,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "wider_retrieval": {
+      "overall": 96.2,
+      "total": 481,
+      "questions": 500,
+      "time": 220.75352692604065,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 130,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 124,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    }
+  },
+  "timestamp": "2026-04-13 13:32:15"
+}

--- a/benchmarks/results/enhanced_20260614_175453.json
+++ b/benchmarks/results/enhanced_20260614_175453.json
@@ -1,0 +1,167 @@
+{
+  "benchmark": "enhanced",
+  "top_k": 5,
+  "results": {
+    "hybrid_baseline": {
+      "overall": 96.6,
+      "total": 483,
+      "questions": 500,
+      "time": 216.27127718925476,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 125,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "query_expand": {
+      "overall": 97.0,
+      "total": 485,
+      "questions": 500,
+      "time": 217.47671508789062,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 127,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "temporal_boost": {
+      "overall": 96.6,
+      "total": 483,
+      "questions": 500,
+      "time": 220.1477472782135,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 125,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "combined_v2": {
+      "overall": 97.0,
+      "total": 485,
+      "questions": 500,
+      "time": 218.23385667800903,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 131,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 127,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    },
+    "wider_retrieval": {
+      "overall": 96.2,
+      "total": 481,
+      "questions": 500,
+      "time": 217.95791816711426,
+      "by_type": {
+        "single-session-user": {
+          "hits": 68,
+          "total": 70
+        },
+        "multi-session": {
+          "hits": 130,
+          "total": 133
+        },
+        "single-session-preference": {
+          "hits": 27,
+          "total": 30
+        },
+        "temporal-reasoning": {
+          "hits": 124,
+          "total": 133
+        },
+        "knowledge-update": {
+          "hits": 78,
+          "total": 78
+        },
+        "single-session-assistant": {
+          "hits": 54,
+          "total": 56
+        }
+      }
+    }
+  },
+  "timestamp": "2026-06-14 17:54:53"
+}


### PR DESCRIPTION
## Why

The F-001 integrity episode had a root cause: the repo could not reproduce its own headline. The LongMemEval-S dataset lived as an untracked file, the proof file was never committed, and the exact recipe was undocumented. That is how the 97.0% figure drifted into being labelled "end-to-end Judge accuracy" when it is actually Recall@5. This PR makes the number re-runnable from the repo so it cannot drift again.

## What

- **Commit the proof file** `benchmarks/results/enhanced_20260413_133215.json` (previously untracked). It is the provenance the research report cites: `query_expand` = 485/500 = **97.0% Recall@5**, with the published per-category table.
- **Pin the recipe** in `benchmarks/REPRODUCE-longmemeval.md`: exact runner (`longmemeval_enhanced.py`), command (`--limit 500 --top-k 5`), config (`query_expand`), embedder (MiniLM ONNX), dataset, and expected output. It states plainly that this is a retrieval metric, not Judge accuracy.
- **Pin the dataset** by sha256 (`d6f21ea9...`) via a tracked `benchmarks/data/README.md`, kept trackable with a gitignore negation while the 265 MiB dataset stays ignored.
- **Deprecate** `longmemeval_recall.py` (predates the package rename, imports the old `tinyagentos` package, will not import); `longmemeval_enhanced.py` is canonical.

## Verification

Recall@5 here is deterministic (fixed dataset, fixed ONNX weights, no sampling), so a fresh run reproduces the committed counts independent of host. An independent CPU re-run from the pinned recipe is in progress on the bench host; its confirmation line will be appended to the reproduction log in the doc before merge.

No GPU or Ollama is involved; this is pure CPU ONNX retrieval.