### PR TITLE
Ship: verified-memory gate on by default; preset ladder (Quality gate on, Integrity strict)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,20 @@
   BM25 index reuses the fusion-path cache). Uses `bm25s` when installed and
   falls back to a dependency-free Okapi BM25 (same k1/b) when not.
 
+### Changed
+- **Verified-memory recall gate on by default, and a clearer preset ladder.** The
+  `prefer_verified` recall gate now ships on at the global default (the runtime falls
+  back to it when nothing is persisted), the flip backed by the E-018 tri-judge confirm
+  (served-hallucination 0.040 to 0.000 under all three judge families at no measured
+  accuracy or recall cost) and signed off. The three presets are now a clean ladder:
+  **Minimal** turns the gate off (the lean opt-out), **Quality** carries the gate on
+  alongside reranking (the recommended accuracy tier), and **Integrity** steps up to the
+  `strict` variant, which drops unverified claims for maximum purity and accepts a small
+  measured recall trade-off. The cross-encoder reranker stays on in the recommended
+  retrieve recipe, and answer self-verification (the dominant F-013 lever) stays an
+  opt-in consumer-side recommendation enabled in the Quality and Integrity install
+  profiles, since taOSmd serves memory and does not generate answers.
+
 ### Fixed
 - The live serve path now builds the vector store in the storage mode its
   recipe asks for. `late_interaction`/`colbert_model` lived only in

--- a/README.md
+++ b/README.md
@@ -424,13 +424,13 @@ You can set the live controls three ways: the dashboard Settings panel (presets 
 
 ### Presets
 
-One-tap bundles of the live controls. The recall gate is on globally by default, so Minimal is the preset that turns it off.
+One-tap bundles of the live controls. The recall gate is on globally by default; Minimal turns it off, Quality keeps it on, and Integrity steps up to the strict variant.
 
 | Preset | `reranker` | `prefer_verified` | `fusion` | `adjacent_turns` | For |
 | --- | --- | --- | --- | --- | --- |
 | Minimal | `off` | `off` | `rrf` | 1 | Fastest and lightest: plain retrieval, weak hardware or speed-first. |
-| Quality | `bge-v2-m3` | `off` | `rrf` | 2 | Best accuracy where hardware affords (pair with `self_verify` in your answer-gen). |
-| Integrity | `bge-v2-m3` | `prefer_verified` | `rrf` | 2 | Quality plus the verified-memory gate: auditable, zero-served-hallucination recall. |
+| Quality | `bge-v2-m3` | `prefer_verified` | `rrf` | 2 | Best accuracy with the verified gate on (pair with `self_verify` in your answer-gen). |
+| Integrity | `bge-v2-m3` | `strict` | `rrf` | 2 | Maximum purity: the strict gate drops unverified claims for auditable, zero-served-hallucination recall. |
 
 The numbers above are cross-linked to their measurements in [docs/benchmarks.md](docs/benchmarks.md), and the full method and provenance for each lever are in the [research report](docs/research-report.md) (F-010 embedder, F-011 recall gate, F-013 reranking and self-verification, E-018 the tri-judge gate confirm).
 

--- a/docs/INTEGRATION-memory-config.md
+++ b/docs/INTEGRATION-memory-config.md
@@ -30,10 +30,10 @@ The cost, pros, and cons for each are in the schema and mirrored in the README C
 | Preset | `reranker` | `prefer_verified` | `fusion` | `adjacent_turns` | For |
 |---|---|---|---|---|---|
 | Minimal | `off` | `off` | `rrf` | 1 | Fastest and lightest; weak hardware or speed-first. |
-| Quality | `bge-v2-m3` | `off` | `rrf` | 2 | Best accuracy where hardware affords (pair with `self_verify` in answer-gen). |
-| Integrity | `bge-v2-m3` | `prefer_verified` | `rrf` | 2 | Auditable, zero-served-hallucination recall. |
+| Quality | `bge-v2-m3` | `prefer_verified` | `rrf` | 2 | Best accuracy with the verified gate on (pair with `self_verify` in answer-gen). |
+| Integrity | `bge-v2-m3` | `strict` | `rrf` | 2 | Maximum purity: strict gate, auditable, zero-served-hallucination recall. |
 
-The recall gate is on globally by default, so Minimal is the preset that turns it off.
+The recall gate is on globally by default; Minimal turns it off, Quality keeps it on, and Integrity uses the strict variant.
 
 ## Install-time profiles vs runtime controls
 

--- a/taosmd/controls.py
+++ b/taosmd/controls.py
@@ -134,7 +134,8 @@ CONTROLS: dict[str, Control] = {
 
 
 # Named bundles. Values are {control_id: value}. prefer_verified is on globally
-# by default, so Minimal is the preset that turns it off.
+# by default; Minimal turns it off, Quality keeps it on, and Integrity uses the
+# stricter variant (drops unverified claims for maximum purity).
 PRESETS: dict[str, dict] = {
     "minimal": {
         "label": "Minimal",
@@ -144,15 +145,15 @@ PRESETS: dict[str, dict] = {
     },
     "quality": {
         "label": "Quality",
-        "description": "Best accuracy where hardware affords: reranking on (pair with self-verify in your answer-gen).",
+        "description": "Best accuracy plus the verified-memory gate: reranking on and the recall gate on (pair with self-verify in your answer-gen).",
         "values": {"reranker": "bge-v2-m3",
-                   "prefer_verified": "off", "fusion": "rrf", "adjacent_turns": 2},
+                   "prefer_verified": "prefer_verified", "fusion": "rrf", "adjacent_turns": 2},
     },
     "integrity": {
         "label": "Integrity",
-        "description": "Quality plus the verified-memory gate: auditable, zero-served-hallucination recall.",
+        "description": "Maximum purity: the strict recall gate drops unverified claims (a small recall trade-off) for auditable, zero-served-hallucination recall.",
         "values": {"reranker": "bge-v2-m3",
-                   "prefer_verified": "prefer_verified", "fusion": "rrf", "adjacent_turns": 2},
+                   "prefer_verified": "strict", "fusion": "rrf", "adjacent_turns": 2},
     },
 }
 

--- a/taosmd/profiles.py
+++ b/taosmd/profiles.py
@@ -71,7 +71,7 @@ SWITCHES = {
         help="Demotes (never deletes) claims verified as unsupported out of default recall. "
              "Eliminates served-hallucination (0.040 -> 0.000) at no measured accuracy cost, "
              "tri-judge confirmed (E-018). Ships on by default because it is a safe no-op until "
-             "the verify-pass is populated; Minimal and Quality turn it off, Integrity keeps it on. "
+             "the verify-pass is populated; Minimal turns it off, Quality keeps it on, and Integrity uses the stricter variant. "
              "Writes the same controls.prefer_verified the runtime recall gate reads.",
     ),
 }
@@ -87,16 +87,18 @@ PROFILES = {
     "quality": Profile(
         id="quality", label="Quality",
         description="Best accuracy on capable hardware: arctic-embed + rerank + "
-                    "self-verify. This is the F-013 configuration.",
+                    "self-verify, plus the verified-memory recall gate on. The F-013 "
+                    "accuracy configuration with the F-011 integrity gate.",
         overrides={"arctic_embed": True, "rerank": True, "self_verify": True,
-                   "prefer_verified": False},
+                   "prefer_verified": True},
     ),
     "integrity": Profile(
         id="integrity", label="Integrity",
-        description="Quality plus the verified-memory recall gate, with provenance and "
-                    "the audit surface. For auditable, zero-served-hallucination memory.",
+        description="Maximum purity: Quality plus the strict recall gate, which drops "
+                    "unverified claims (accepts a small measured recall trade-off) for "
+                    "auditable, zero-served-hallucination memory.",
         overrides={"arctic_embed": True, "rerank": True, "self_verify": True,
-                   "prefer_verified": True},
+                   "prefer_verified": "strict"},
     ),
 }
 
@@ -152,6 +154,15 @@ def resolve_config(profile_id: str, consented_switches: list[str] | None = None)
     out: dict = {}
     for sid, sw in SWITCHES.items():
         wants = prof.overrides.get(sid, sw.default)
+        if isinstance(wants, str):
+            # A profile may pin an explicit value (e.g. prefer_verified="strict")
+            # instead of a bool. Consent-required switches still need consent;
+            # non-consent switches write the pinned value directly.
+            if not sw.requires_consent or sid in consented:
+                out[sw.config_key] = wants
+            elif sw.off_value is not None:
+                out[sw.config_key] = sw.off_value
+            continue
         if sw.requires_consent:
             enabled = sid in consented and wants
         else:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -667,7 +667,7 @@ def test_controls_post_preset_applies_bundle(live_server):
     assert status == 200, body
     assert body["errors"] == {}
     s = body["settings"]
-    assert s["prefer_verified"] == "prefer_verified"
+    assert s["prefer_verified"] == "strict"  # Integrity is the strict/max-purity tier
     assert s["reranker"] == "bge-v2-m3"
     assert s["adjacent_turns"] == 2
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -59,9 +59,17 @@ def test_resolve_config_minimal_enables_no_consent_switch():
     assert "claims.prefer_verified" not in cfg  # the old dead key is gone
 
 
-def test_resolve_config_integrity_enables_recall_gate():
+def test_resolve_config_integrity_uses_strict_gate():
     cfg = profiles.resolve_config("integrity", consented_switches=["rerank", "self_verify"])
-    # Integrity turns the gate on with the value the runtime recall gate reads.
+    # Integrity is the maximum-purity tier: it pins the strict gate variant.
+    assert cfg["controls.prefer_verified"] == "strict"
+
+
+def test_resolve_config_quality_enables_recall_gate():
+    # Quality now carries the verified gate on (a no-op until the verify-pass
+    # runs, no measured accuracy cost). prefer_verified is a non-consent switch,
+    # so it is written regardless of which quality switches were consented.
+    cfg = profiles.resolve_config("quality", consented_switches=[])
     assert cfg["controls.prefer_verified"] == "prefer_verified"
 
 


### PR DESCRIPTION
Finalizes the two ship decisions you signed off on.

**The flip was already live at the bare default.** `config.get_controls` falls back to `prefer_verified` (on) when nothing is persisted, and `get_runtime_overrides` excludes unset controls so the recommended recipe's reranker stays on. So this PR makes the *presets* honour 'on across tiers' and records the decision; it does not change the out-of-the-box default (which was already on).

**Decision 1 (prefer_verified flip on).** Backed by E-018: served-hallucination 0.040 to 0.000 under all three judge families (llama / qwen-instruct / gemma) at n=250, at no measured accuracy or recall cost. The preset ladder is now three clear rungs:

| Preset | gate | meaning |
|---|---|---|
| Minimal | `off` | lean opt-out, no rerank |
| Quality | `prefer_verified` | recommended accuracy tier, gate on |
| Integrity | `strict` | maximum purity: drops unverified claims, accepts a small measured recall trade-off |

This resolves the prior inconsistency where Quality (the common accuracy pick) silently turned the gate off. `profiles.resolve_config` now accepts an explicit pinned value in a profile override (so Integrity can write `strict`), in addition to the existing bool switches.

**Decision 2 (E-012 ship: rerank default + self-verify opt-in).** No code change was needed: reranking is already on in the recommended retrieve recipe and in the Quality/Integrity presets, and answer self-verification stays an opt-in consumer-side recommendation enabled in the Quality and Integrity install profiles (taOSmd serves memory; answer generation is the consumer's path). Documented as such.

Updated `controls.py`, `profiles.py`, the README and INTEGRATION preset tables, the CHANGELOG, and the profile/controls/http tests. Full suite **970 pass**. The research-report status flip (F-011/E-018 pending-Jay to signed-off) will follow on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated changelog, README, and integration documentation to reflect default behavior of the verification recall gate
  * Quality tier preset now enables the verification gate by default (previously disabled)
  * Integrity tier preset uses a stricter verification variant
  * Minimal tier preset disables the verification gate
  * Cross-encoder reranker remains enabled in the recommended configuration

* **Tests**
  * Updated tests to validate new preset configurations and gate behavior across tiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->