### PR TITLE
Preflight the dense embedder so a missing model is loud, not silent

### DIFF
--- a/taosmd/auto_setup.py
+++ b/taosmd/auto_setup.py
@@ -135,6 +135,12 @@ async def setup(data_dir: str = DEFAULT_DATA_DIR, interactive: bool = True):
     # 9. Pre-flight: enricher-model availability
     _preflight_enricher_model(interactive=interactive)
 
+    # 9b. Pre-flight: dense embedder availability. The recipe wrote embed_model
+    # into config above, but the ONNX files are fetched by scripts/setup.sh; warn
+    # loudly if they are missing so the store does not silently degrade to a
+    # different embedder at serve time (which corrupts the vector space).
+    _preflight_embedder_model(_mode["embed_model"], interactive=interactive)
+
     # 10. Daily nightly librarian cron
     setup_cron = True
     if interactive:
@@ -356,6 +362,89 @@ def _preflight_enricher_model(
         if resp == "n":
             print("    Aborting setup. Re-run `python -m taosmd.auto_setup` after pulling a model.")
             sys.exit(0)
+
+
+# Exact fetch command per dense-embedder dir name, mirroring scripts/setup.sh.
+# A store's vectors are tied to one embedder (a stored arctic vector is
+# meaningless to a MiniLM query), so a missing model that silently degrades to a
+# different embedder corrupts retrieval. These let the preflight tell the user
+# exactly how to fetch the model the recipe selected.
+_EMBEDDER_DOWNLOAD = {
+    "minilm-onnx": (
+        "hf download onnx-models/all-MiniLM-L6-v2-onnx --local-dir models/minilm-onnx"
+    ),
+    "arctic-embed-s": (
+        "hf download Snowflake/snowflake-arctic-embed-s "
+        '--include "onnx/model.onnx" "*.json" "tokenizer*" "vocab*" "special_tokens*" '
+        "--local-dir models/arctic-embed-s"
+    ),
+}
+
+
+def _embedder_model_present(model_dir: str) -> bool:
+    """True if an ONNX model.onnx exists at the dir root or under onnx/.
+
+    Matches VectorMemory's own resolution order so the preflight checks the
+    exact files the loader will look for at serve time.
+    """
+    return (
+        Path(f"{model_dir}/model.onnx").exists()
+        or Path(f"{model_dir}/onnx/model.onnx").exists()
+    )
+
+
+def _preflight_embedder_model(
+    embed_model: str,
+    models_root: str = "models",
+    interactive: bool = True,
+) -> bool:
+    """Check the recommended dense ONNX embedder is present on disk.
+
+    The recipe writes ``embed_model`` into config, but the ONNX files are
+    fetched separately by scripts/setup.sh. If a provisioning path skips that
+    script the model is absent, and at serve time the store falls back to a
+    different embedder, which silently corrupts the vector space: a stored
+    vector is meaningless to a query embedded by a different model, so retrieval
+    returns wrong results with no error. This preflight catches that gap loudly
+    at setup, mirroring the enricher-model preflight.
+
+    Returns True when the model files are found, False when missing or when no
+    dense embedder is configured. Never raises. Does not block setup unless the
+    user declines interactively.
+    """
+    print("  Checking embedder model availability...", end="", flush=True)
+
+    if not embed_model:
+        print(" (no dense embedder configured)")
+        return False
+
+    model_dir = os.path.join(models_root, embed_model)
+    if _embedder_model_present(model_dir):
+        print(f" ✓ {embed_model} found at {model_dir}")
+        return True
+
+    print()  # break from the "..." line
+    print(f"  ⚠ Recommended embedder '{embed_model}' is NOT on disk (looked in {model_dir}/).")
+    print("     The recipe selected it, but the model files are fetched separately.")
+    print("     Without them the store falls back to a different embedder at serve")
+    print("     time. A store's vectors are tied to one embedder, so a stored vector")
+    print("     is meaningless to a query embedded by a different model: retrieval")
+    print("     silently returns wrong results. Fetch the model now:")
+    cmd = _EMBEDDER_DOWNLOAD.get(embed_model)
+    if cmd:
+        print(f"       {cmd}")
+    else:
+        print(f"     (see scripts/setup.sh for the {embed_model} download command)")
+    print("     Or re-run scripts/setup.sh, which fetches every recommended embedder.")
+    print()
+
+    if interactive:
+        resp = input("    Continue setup without the embedder? [Y/n]: ").strip().lower()
+        if resp == "n":
+            print("    Aborting setup. Fetch the embedder above, then re-run "
+                  "`python -m taosmd.auto_setup`.")
+            sys.exit(0)
+    return False
 
 
 if __name__ == "__main__":

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -306,10 +306,11 @@ class VectorMemory:
                     logger.warning("sentence-transformers not installed, falling back to QMD")
                     self._embed_mode = "qmd"
         elif self._embed_mode == "onnx":
+            # Resolved before the try so the failure path can name it.
+            model_dir = self._onnx_path or "models/minilm-onnx"
             try:
                 import onnxruntime as ort
                 from transformers import AutoTokenizer
-                model_dir = self._onnx_path or "models/minilm-onnx"
                 # Find model.onnx at the dir root or under an onnx/ subdir
                 # (the layout arctic-embed and most HF ONNX exports ship).
                 model_file = f"{model_dir}/model.onnx"
@@ -322,7 +323,19 @@ class VectorMemory:
                 self._onnx_tokenizer = AutoTokenizer.from_pretrained(model_dir)
                 logger.info("Loaded ONNX embedding model from %s", model_file)
             except Exception as e:
-                logger.warning("ONNX model failed to load: %s, falling back to QMD", e)
+                # Loud and actionable: a silent embedder swap corrupts retrieval.
+                # The store's vectors are tied to the embedder that wrote them, so
+                # falling back to a different embedder than the store was built
+                # with returns meaningless results. Name the dir and the fix.
+                logger.warning(
+                    "ONNX embedder failed to load from %s (%s). Falling back to QMD "
+                    "remote embeddings. If a local embedder was expected, its ONNX "
+                    "files are missing or unreadable; run scripts/setup.sh to fetch "
+                    "them. NOTE: a store's vectors are tied to the embedder that "
+                    "wrote them, so serving a different embedder than the store was "
+                    "built with returns meaningless retrieval.",
+                    model_dir, e,
+                )
                 self._embed_mode = "qmd"
 
     def _migrate(self) -> None:

--- a/tests/test_embedder_preflight.py
+++ b/tests/test_embedder_preflight.py
@@ -1,0 +1,67 @@
+# tests/test_embedder_preflight.py
+"""Setup-time preflight for the dense ONNX embedder.
+
+The recipe writes ``embed_model`` (e.g. arctic-embed-s) into config, but the
+model files are fetched separately by scripts/setup.sh. If a provisioning path
+skips that script the embedder is absent, and at serve time the store silently
+degrades to a different embedder, which corrupts the vector space. The preflight
+catches that gap loudly at setup, mirroring the enricher-model preflight.
+"""
+
+from taosmd import auto_setup
+
+
+def _make_onnx(root, name, layout):
+    """Create a fake model dir; layout is 'root' or 'onnx_subdir'."""
+    d = root / "models" / name
+    if layout == "root":
+        d.mkdir(parents=True)
+        (d / "model.onnx").write_bytes(b"\x00")
+    elif layout == "onnx_subdir":
+        (d / "onnx").mkdir(parents=True)
+        (d / "onnx" / "model.onnx").write_bytes(b"\x00")
+    return d
+
+
+def test_present_at_root_returns_true(tmp_path):
+    _make_onnx(tmp_path, "minilm-onnx", "root")
+    ok = auto_setup._preflight_embedder_model(
+        "minilm-onnx", models_root=str(tmp_path / "models"), interactive=False
+    )
+    assert ok is True
+
+
+def test_present_under_onnx_subdir_returns_true(tmp_path):
+    # arctic-embed-s ships model.onnx under an onnx/ subdir
+    _make_onnx(tmp_path, "arctic-embed-s", "onnx_subdir")
+    ok = auto_setup._preflight_embedder_model(
+        "arctic-embed-s", models_root=str(tmp_path / "models"), interactive=False
+    )
+    assert ok is True
+
+
+def test_missing_returns_false_without_raising(tmp_path):
+    ok = auto_setup._preflight_embedder_model(
+        "arctic-embed-s", models_root=str(tmp_path / "models"), interactive=False
+    )
+    assert ok is False
+
+
+def test_missing_prints_download_command(tmp_path, capsys):
+    auto_setup._preflight_embedder_model(
+        "arctic-embed-s", models_root=str(tmp_path / "models"), interactive=False
+    )
+    out = capsys.readouterr().out
+    # names the missing model and the exact fetch command for it
+    assert "arctic-embed-s" in out
+    assert "snowflake-arctic-embed-s" in out
+    # warns that a silent embedder swap is the failure mode
+    assert "vector" in out.lower()
+
+
+def test_empty_embed_model_does_not_crash(tmp_path):
+    # defensive: a blank embed_model should be treated as nothing to check
+    ok = auto_setup._preflight_embedder_model(
+        "", models_root=str(tmp_path / "models"), interactive=False
+    )
+    assert ok is False


### PR DESCRIPTION
## Why

A taOS-provisioned agent downloaded MiniLM instead of the recommended arctic-embed-s. Root cause: the recipe writes `embed_model` into config, but the ONNX files are fetched separately by `scripts/setup.sh`. A provisioning path that skips that script leaves the model absent, and at serve time the store falls back to a different embedder.

A store's vectors are tied to the embedder that wrote them. A stored arctic vector is meaningless to a MiniLM query, so retrieval silently returns wrong results with no error. The enricher LLM already gets a loud setup preflight; the embedder had none. This closes that asymmetry.

## What

- `auto_setup._preflight_embedder_model()`: mirrors the enricher-model preflight. Checks the recommended embedder's ONNX files are on disk (root or `onnx/` subdir, the exact resolution `VectorMemory` uses) and, when missing, warns loudly with the precise `hf download` command for that model and names the vector-space-corruption risk. Wired into `setup()` as step 9b. Does not block setup unless declined interactively.
- `VectorMemory.init()`: the ONNX load-failure warning now names the model dir, points at `scripts/setup.sh`, and flags that serving a different embedder than the store was built with returns meaningless retrieval. Control flow unchanged (still falls back to QMD).

## Tests

`tests/test_embedder_preflight.py` (5 cases: present at root, present under `onnx/`, missing returns False without raising, missing prints the download command, blank embed_model is safe). Full embedder/setup/vector suites pass with no regression.

## Not in this PR

The CWD-relative `models/` path resolution and the actual download-on-setup are deliberately out of scope; this PR makes the failure loud and actionable first. Auto-fetch on setup can be a follow-up if wanted.