### PR TITLE
Add taosmd reindex command for per-agent embedder cutover

### DIFF
--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -943,6 +943,112 @@ async def reconcile(*, agent: str, data_dir=None, repair: bool = True) -> dict:
     }
 
 
+async def reindex(*, agent: str, data_dir=None, check: bool = False) -> dict:
+    """Re-embed an agent's vector store from the zero-loss archive.
+
+    Switching embedders (e.g. MiniLM -> arctic-embed-s) produces an incompatible
+    vector space: a store embedded under the old model cannot be queried with the
+    new model. The append-only archive is the source of truth, so the safe,
+    re-runnable fix is to clear the agent's vector rows and re-add every archive
+    turn, which re-embeds each one under the *currently configured* embedder.
+
+    This is per-agent so live agents can be cut over one at a time. The archive
+    is never modified, so a reindex can always be re-run.
+
+    Args:
+        agent: Agent name whose vector store is rebuilt from its archive.
+        data_dir: Optional taosmd data dir. Defaults to ``$TAOSMD_DATA_DIR`` or
+            ``~/.taosmd``.
+        check: When True, a dry-run: report counts without modifying anything
+            (``cleared`` and ``readded`` are 0).
+
+    Returns:
+        ``{
+            "agent": str,
+            "archive_turns": int,   # non-empty conversation turns in the archive
+            "vector_before": int,   # agent's vector entries before reindex (incl. superseded)
+            "cleared": int,         # rows deleted (0 when check=True)
+            "readded": int,         # rows re-embedded and re-added (0 when check=True)
+            "reindexed_ok": bool,   # True when post-reindex active entries == archive turns
+        }``
+    """
+    import json as _json
+
+    if not agent:
+        raise ValueError("agent name is required")
+
+    stores = await _ensure_stores(data_dir)
+    archive = stores["archive"]
+    vmem = stores["vector"]
+
+    from taosmd.archive import EVENT_CONVERSATION
+
+    # --- Collect the agent's archive turns (source of truth) ------------
+    rows = await archive.query(
+        event_type=EVENT_CONVERSATION,
+        agent_name=agent,
+        limit=1_000_000,
+    )
+    archive_turns: list[dict] = []
+    for row in rows:
+        try:
+            data = _json.loads(row.get("data_json", "{}"))
+        except (_json.JSONDecodeError, TypeError):
+            data = {}
+        text = str(data.get("content", "")).strip()
+        if not text:
+            continue
+        archive_turns.append(data)
+
+    archive_count = len(archive_turns)
+
+    # --- Count the agent's current vector entries (incl. superseded) ----
+    vector_before = 0
+    async for _text, _meta in vmem.iter_entries(agent=agent, include_superseded=True):
+        vector_before += 1
+
+    if check:
+        return {
+            "agent": agent,
+            "archive_turns": archive_count,
+            "vector_before": vector_before,
+            "cleared": 0,
+            "readded": 0,
+            "reindexed_ok": vector_before == archive_count,
+        }
+
+    # --- Clear the agent's vector rows, then rebuild from the archive ---
+    cleared = await vmem.clear(agent=agent)
+
+    readded = 0
+    for data in archive_turns:
+        text = str(data.get("content", "")).strip()
+        meta: dict = {"agent": agent}
+        # Propagate role and timestamp from the archive entry where available,
+        # mirroring the metadata reconstruction used by reconcile().
+        if "role" in data:
+            meta["role"] = data["role"]
+        if "timestamp" in data:
+            meta["timestamp"] = data["timestamp"]
+        added_id = await vmem.add(text, metadata=meta)
+        if added_id != -1:
+            readded += 1
+
+    # --- Verify: active entries for the agent now match archive turns ---
+    active_after = 0
+    async for _text, _meta in vmem.iter_entries(agent=agent, include_superseded=False):
+        active_after += 1
+
+    return {
+        "agent": agent,
+        "archive_turns": archive_count,
+        "vector_before": vector_before,
+        "cleared": cleared,
+        "readded": readded,
+        "reindexed_ok": active_after == archive_count,
+    }
+
+
 async def supersede_vectors(match: str, *, data_dir=None) -> int:
     """Soft-supersede vector chunk(s) whose stored text contains ``match``.
 

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -973,6 +973,61 @@ def _reconcile_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
+def _reindex_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd reindex``: rebuild an agent's vector store from the archive.
+
+    Clears the agent's vector rows and re-adds every archive turn, which
+    re-embeds each under the CURRENTLY configured embedder. Used to cut an agent
+    over to a new embedder (e.g. arctic-embed-s); the zero-loss archive is the
+    source of truth so reindex is safe to re-run.
+    """
+    import asyncio  # noqa: PLC0415
+
+    from . import service  # noqa: PLC0415
+    from .agents import AgentRegistry  # noqa: PLC0415
+
+    check = args.check
+    data_dir = args.data_dir
+
+    print(
+        "note: reindex clears the agent's vector rows and rebuilds them from the "
+        "zero-loss archive under the CURRENTLY configured embedder. Set "
+        "vector_memory.embed_model to the target embedder (e.g. arctic-embed-s) "
+        "BEFORE running."
+    )
+
+    agent_names: list[str]
+    if args.agent:
+        agent_names = [args.agent]
+    else:
+        # Reindex all registered agents.
+        registry = AgentRegistry(data_dir)
+        agent_names = [a["name"] for a in registry.list_agents()]
+        if not agent_names:
+            print("No registered agents found.")
+            return 0
+
+    any_mismatch = False
+    for agent in agent_names:
+        result = asyncio.run(service.reindex(agent=agent, data_dir=data_dir, check=check))
+        mode = "check" if check else "reindex"
+        status = "ok" if result["reindexed_ok"] else "MISMATCH"
+        print(
+            f"[{mode}] {result['agent']:<24} "
+            f"archive={result['archive_turns']}  "
+            f"vector={result['vector_before']}  "
+            f"cleared={result['cleared']}  "
+            f"re-added={result['readded']}  "
+            f"{status}"
+        )
+        if not result["reindexed_ok"]:
+            any_mismatch = True
+
+    if check:
+        print("\nhint: run without --check to clear and rebuild the vector store.")
+    return 1 if any_mismatch and not check else 0
+
+
 def _claims_cmd(args: argparse.Namespace) -> int:
     """Handle ``taosmd claims`` subcommand group."""
     import asyncio  # noqa: PLC0415
@@ -1420,6 +1475,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Dry-run: report missing counts without modifying the vector store.",
     )
 
+    # ----- reindex subcommand ------------------------------------------
+    reindex_p = sub.add_parser(
+        "reindex",
+        help="Re-embed an agent's vector store from the zero-loss archive under "
+             "the CURRENTLY configured embedder. Used to cut an agent over to a "
+             "new embedder (e.g. arctic-embed-s): clears the agent's vector rows "
+             "and re-adds every archive turn. The archive is never touched, so "
+             "reindex is per-agent and safe to re-run.",
+    )
+    reindex_p.add_argument(
+        "--agent", default=None,
+        help="Agent name to reindex. When omitted, all registered agents are reindexed.",
+    )
+    reindex_p.add_argument(
+        "--check", action="store_true",
+        help="Dry-run: report archive/vector counts without modifying the vector store.",
+    )
+
     # ----- project discovery subcommands --------------------------------
     sub.add_parser(
         "projects",
@@ -1592,6 +1665,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "reconcile":
         return _reconcile_cmd(args)
+
+    if args.cmd == "reindex":
+        return _reindex_cmd(args)
 
     if args.cmd in ("projects", "shelves"):
         return _projects_cmd(args)

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -260,6 +260,24 @@ async def reconcile(*, agent: str, data_dir=None, repair: bool = True) -> dict:
     return await _api.reconcile(agent=agent, data_dir=data_dir, repair=repair)
 
 
+async def reindex(*, agent: str, data_dir=None, check: bool = False) -> dict:
+    """Re-embed an agent's vector store from the zero-loss archive.
+
+    Thin wrapper over :func:`taosmd.api.reindex`. The append-only archive is the
+    source of truth; the vector store is a derived index. Switching embedders
+    (e.g. MiniLM -> arctic-embed-s) leaves the old vectors in an incompatible
+    space, so reindex clears the agent's vector rows and rebuilds them by
+    re-adding every archive turn, which re-embeds each one under the *currently
+    configured* embedder. The archive is never touched, so reindex is safe to
+    re-run and is applied per-agent (live agents cut over one at a time).
+
+    Returns ``{"agent", "archive_turns", "vector_before", "cleared", "readded",
+    "reindexed_ok"}``. When ``check=True`` this is a dry-run: ``cleared`` and
+    ``readded`` are 0 and nothing is modified.
+    """
+    return await _api.reindex(agent=agent, data_dir=data_dir, check=check)
+
+
 async def supersede(match: str, *, agent: str | None = None, data_dir=None) -> dict:
     """Soft-supersede vector chunk(s) whose stored text contains ``match``.
 

--- a/taosmd/vector_memory.py
+++ b/taosmd/vector_memory.py
@@ -1307,7 +1307,27 @@ class VectorMemory:
                 continue
             yield row["text"], meta
 
-    async def clear(self) -> int:
-        cursor = self._conn.execute("DELETE FROM vector_memory")
+    async def clear(self, agent: str | None = None) -> int:
+        """Delete vector rows. With no ``agent`` this wipes the whole store.
+
+        When ``agent`` is given, only rows whose stored metadata ``agent`` field
+        equals it are deleted, matching the per-agent scope used by :meth:`add`
+        (which writes ``{"agent": ...}`` at ingest time) and by
+        :meth:`iter_entries`. The append-only archive is never touched, so the
+        deleted rows can always be rebuilt by re-adding the archive turns (this
+        is what :func:`taosmd.api.reindex` does when an embedder changes).
+
+        Returns the number of rows deleted. Invalidates the BM25 cache when the
+        corpus changed so the next query rebuilds it.
+        """
+        if agent is None:
+            cursor = self._conn.execute("DELETE FROM vector_memory")
+        else:
+            cursor = self._conn.execute(
+                "DELETE FROM vector_memory WHERE json_extract(metadata_json, '$.agent') = ?",
+                (agent,),
+            )
         self._conn.commit()
+        if cursor.rowcount > 0:
+            self._bm25_dirty = True  # corpus changed; invalidate BM25 cache
         return cursor.rowcount

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -1,0 +1,275 @@
+"""Tests for the archive->vector reindex path (taOS embedder cutover).
+
+taOS is migrating live agents from MiniLM to arctic-embed-s. A MiniLM-embedded
+vector store and an arctic query are incompatible vector spaces, so switching
+embedders requires RE-EMBEDDING the store. The zero-loss archive is the source
+of truth, so the safe procedure is: clear the agent's vector rows, then re-add
+every archive turn (which re-embeds under the currently configured embedder).
+
+These tests cover:
+- VectorMemory.clear(agent=...) is agent-scoped; clear() with no arg clears all.
+- api.reindex(check=True) reports counts and modifies nothing.
+- api.reindex(check=False) ends with vector entries == archive turns, ok=True.
+- CLI smoke: ``taosmd reindex --check`` runs and prints without error.
+
+All tests are hermetic: each uses its own tmp_path data dir and a deterministic
+fake embedder so ONNX/QMD are never required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import taosmd
+from taosmd import api as taosmd_api
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    """Replace embed() with a stable hash-based 8-dim vector (no ONNX/QMD)."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """Isolated data dir + clean stores cache; embedder patched after first init."""
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    # Release SQLite handles before pytest removes tmp_path.
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+async def _active_count(vmem, agent: str) -> int:
+    """Count active (non-superseded) vector rows for an agent via iter_entries."""
+    n = 0
+    async for _text, _meta in vmem.iter_entries(agent=agent, include_superseded=False):
+        n += 1
+    return n
+
+
+# ---------------------------------------------------------------------------
+# VectorMemory.clear agent scoping
+# ---------------------------------------------------------------------------
+
+def test_clear_agent_scoped_leaves_other_agents(isolated):
+    """clear(agent='agent-a') deletes only agent A's rows; agent B's rows remain."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+
+    asyncio.run(taosmd.ingest("alpha one", agent="agent-a", data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("alpha two", agent="agent-a", data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("beta one", agent="agent-b", data_dir=str(data_dir)))
+
+    total_before = asyncio.run(vmem.count())
+    assert total_before == 3
+
+    deleted = asyncio.run(vmem.clear(agent="agent-a"))
+    assert deleted == 2, "should delete exactly agent A's two rows"
+
+    # Agent A gone, agent B intact.
+    assert asyncio.run(_active_count(vmem, "agent-a")) == 0
+    assert asyncio.run(_active_count(vmem, "agent-b")) == 1
+    assert asyncio.run(vmem.count()) == 1
+
+
+def test_clear_no_arg_deletes_all(isolated):
+    """clear() with no arg still deletes every row (back-compat)."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+
+    asyncio.run(taosmd.ingest("alpha one", agent="agent-a", data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("beta one", agent="agent-b", data_dir=str(data_dir)))
+    assert asyncio.run(vmem.count()) == 2
+
+    deleted = asyncio.run(vmem.clear())
+    assert deleted == 2
+    assert asyncio.run(vmem.count()) == 0
+
+
+# ---------------------------------------------------------------------------
+# api.reindex check (dry-run)
+# ---------------------------------------------------------------------------
+
+def test_reindex_check_reports_and_does_not_modify(isolated):
+    """reindex(check=True) reports archive_turns and changes nothing."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+    agent = "check-agent"
+
+    for t in ("one fish", "two fish", "red fish"):
+        asyncio.run(taosmd.ingest(t, agent=agent, data_dir=str(data_dir)))
+
+    count_before = asyncio.run(vmem.count())
+    assert count_before == 3
+
+    result = asyncio.run(
+        taosmd_api.reindex(agent=agent, data_dir=str(data_dir), check=True)
+    )
+    assert result["agent"] == agent
+    assert result["archive_turns"] == 3
+    assert result["vector_before"] == 3
+    assert result["cleared"] == 0
+    assert result["readded"] == 0
+
+    # Nothing modified.
+    assert asyncio.run(vmem.count()) == 3
+
+
+# ---------------------------------------------------------------------------
+# api.reindex full run
+# ---------------------------------------------------------------------------
+
+def test_reindex_rebuilds_to_archive_count(isolated):
+    """reindex(check=False) clears and rebuilds; vector entries == archive turns."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+    agent = "reindex-agent"
+
+    turns = ["the librarian keeps every word", "even if the power goes out", "that is the point"]
+    for t in turns:
+        asyncio.run(taosmd.ingest(t, agent=agent, data_dir=str(data_dir)))
+
+    result = asyncio.run(
+        taosmd_api.reindex(agent=agent, data_dir=str(data_dir), check=False)
+    )
+    assert result["agent"] == agent
+    assert result["archive_turns"] == 3
+    assert result["vector_before"] == 3
+    assert result["cleared"] == 3
+    assert result["readded"] == 3
+    assert result["reindexed_ok"] is True
+
+    # Active vector entries for the agent now equal the archive turn count.
+    assert asyncio.run(_active_count(vmem, agent)) == 3
+
+    # Re-embedded entries are still findable.
+    hits = asyncio.run(taosmd.search(turns[0], agent=agent, data_dir=str(data_dir), limit=5))
+    assert turns[0] in {h["text"] for h in hits}
+
+
+def test_reindex_repairs_partially_stale_store(isolated):
+    """A partially-stale store (some vector rows missing) is fully rebuilt."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+    agent = "stale-agent"
+
+    turns = ["first turn here", "second turn here", "third turn here"]
+    for t in turns:
+        asyncio.run(taosmd.ingest(t, agent=agent, data_dir=str(data_dir)))
+
+    # Simulate a partially-stale vector store: drop one row directly.
+    vmem._conn.execute("DELETE FROM vector_memory WHERE text = ?", (turns[1],))
+    vmem._conn.commit()
+    assert asyncio.run(_active_count(vmem, agent)) == 2
+
+    result = asyncio.run(
+        taosmd_api.reindex(agent=agent, data_dir=str(data_dir), check=False)
+    )
+    assert result["archive_turns"] == 3
+    assert result["vector_before"] == 2
+    assert result["cleared"] == 2
+    assert result["readded"] == 3
+    assert result["reindexed_ok"] is True
+    assert asyncio.run(_active_count(vmem, agent)) == 3
+
+
+def test_reindex_does_not_touch_other_agents(isolated):
+    """Reindexing agent A leaves agent B's vector rows untouched."""
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+
+    asyncio.run(taosmd.ingest("alpha one", agent="agent-a", data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("beta one", agent="agent-b", data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("beta two", agent="agent-b", data_dir=str(data_dir)))
+
+    result = asyncio.run(taosmd_api.reindex(agent="agent-a", data_dir=str(data_dir), check=False))
+    assert result["reindexed_ok"] is True
+    assert asyncio.run(_active_count(vmem, "agent-a")) == 1
+    assert asyncio.run(_active_count(vmem, "agent-b")) == 2
+
+
+def test_reindex_empty_agent_is_consistent(isolated):
+    """An agent with no archive turns reindexes to a consistent empty state."""
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "empty-agent"
+
+    result = asyncio.run(taosmd_api.reindex(agent=agent, data_dir=str(data_dir), check=False))
+    assert result["archive_turns"] == 0
+    assert result["vector_before"] == 0
+    assert result["cleared"] == 0
+    assert result["readded"] == 0
+    assert result["reindexed_ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# service wrapper
+# ---------------------------------------------------------------------------
+
+def test_service_reindex_wrapper(isolated):
+    """service.reindex forwards to api.reindex and returns the same shape."""
+    from taosmd import service
+
+    data_dir = isolated
+    stores = _setup(data_dir)
+    vmem = stores["vector"]
+    agent = "svc-agent"
+
+    asyncio.run(taosmd.ingest("svc turn one", agent=agent, data_dir=str(data_dir)))
+    asyncio.run(taosmd.ingest("svc turn two", agent=agent, data_dir=str(data_dir)))
+
+    result = asyncio.run(service.reindex(agent=agent, data_dir=str(data_dir), check=False))
+    assert result["archive_turns"] == 2
+    assert result["reindexed_ok"] is True
+    assert asyncio.run(_active_count(vmem, agent)) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+def test_cli_reindex_check_runs(isolated, monkeypatch, capsys):
+    """`taosmd reindex --check` runs and prints without error."""
+    from taosmd import cli
+
+    data_dir = isolated
+    _setup(data_dir)
+    agent = "cli-agent"
+    asyncio.run(taosmd.ingest("cli turn one", agent=agent, data_dir=str(data_dir)))
+
+    rc = cli.main(["--data-dir", str(data_dir), "reindex", "--agent", agent, "--check"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert agent in out
+    assert "archive=" in out


### PR DESCRIPTION
## What

Adds a single-shot, per-agent `taosmd reindex` command that rebuilds an agent's vector store from the zero-loss archive, re-embedding every turn under the currently configured embedder.

- `VectorMemory.clear(agent=None)`: optional agent filter. With no `agent` the behaviour is unchanged (`DELETE` all rows, back-compat). With an `agent`, deletes only that agent's rows via `json_extract(metadata_json, '$.agent')` (json1 is already used elsewhere in this module).
- `api.reindex(*, agent, data_dir=None, check=False)`: resolves the per-data-dir vector store + archive exactly as `api.reconcile` does, counts the agent's archive turns, and either reports (`check=True`, nothing modified) or clears the agent's vector rows and re-adds every archive turn through the same re-add path reconcile uses (so they re-embed). Returns `{agent, archive_turns, vector_before, cleared, readded, reindexed_ok}` where `reindexed_ok` is `True` when post-reindex active entries for the agent equal the archive turn count.
- `service.reindex`: thin wrapper mirroring `service.reconcile`.
- `taosmd reindex [--agent AGENT] [--check]`: mirrors the `reconcile` CLI. All registered agents when `--agent` is omitted; `--check` dry-run; one line per agent (archive/vector/cleared/re-added + ok/MISMATCH). Prints an upfront note that the rebuild re-embeds under the currently configured embedder, so set `vector_memory.embed_model` to the target embedder before running.

`reconcile` is CLI-only (not present in `remote.py` or `http_server.py`), so `reindex` is kept CLI-only for parity (no new HTTP endpoint invented).

## Why

taOS-dev is migrating live agents from the MiniLM embedder to arctic-embed-s. A MiniLM-embedded vector store and an arctic query are incompatible vector spaces, so switching embedders requires re-embedding the store. The zero-loss archive is the source of truth, so the safe, re-runnable procedure is: clear the agent's vector rows, then re-add every archive turn (which re-embeds under the currently configured embedder).

taOS-dev explicitly requested a single-shot `taosmd reindex` command to make this atomic and per-agent (they cut over live agents one at a time). Because the archive is never touched, a reindex can always be re-run.

## Tests

TDD, `tests/test_reindex.py` (9 tests):
- `clear(agent=...)` deletes only that agent's rows; `clear()` with no arg still deletes all.
- `reindex(check=True)` reports `archive_turns` / `vector_before` and modifies nothing (`cleared==0`, `readded==0`).
- `reindex(check=False)` rebuilds to the archive count and ends `reindexed_ok==True`, including a partially-stale store.
- Reindexing one agent leaves other agents' vector rows untouched; empty-agent stays consistent.
- `service.reindex` wrapper forwards correctly.
- CLI smoke: `taosmd reindex --check` runs and prints without error.

New tests plus the existing `reconcile` + `vector_memory` tests pass; full suite green (983 passed). `python3 -c "import taosmd"` import check passes.