### PR TITLE
Fix judge verdict parser that scored every INCORRECT reply as a pass

### DIFF
--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -109,6 +109,20 @@ def score_answer_substring(predicted: str, gold: str) -> bool:
     return gold.lower().strip() in predicted.lower()
 
 
+def _parse_verdict(content: str) -> bool:
+    """Parse a judge's one-word CORRECT / INCORRECT verdict into a pass/fail.
+
+    The negative verdict is checked FIRST on purpose: the string "INCORRECT"
+    contains the substring "CORRECT", so a naive ``"CORRECT" in judgment`` scores
+    every INCORRECT reply as a pass. An empty or unrecognised reply is treated as
+    incorrect (fail-closed).
+    """
+    j = (content or "").strip().upper()
+    if "INCORRECT" in j:
+        return False
+    return "CORRECT" in j
+
+
 async def score_answer_llm(client, predicted: str, gold: str, question: str) -> bool:
     """Score using LLM-as-judge (official LongMemEval approach)."""
     prompt = f"""You are a strict answer evaluator. Determine if the predicted answer contains the same factual information as the reference answer.
@@ -139,8 +153,8 @@ Verdict: /no_think"""
             timeout=30,
         )
         if resp.status_code == 200:
-            judgment = resp.json().get("message", {}).get("content", "").strip().upper()
-            return "CORRECT" in judgment
+            content = resp.json().get("message", {}).get("content", "")
+            return _parse_verdict(content)
     except Exception:
         pass
     return False

--- a/tests/test_judge_verdict_parser.py
+++ b/tests/test_judge_verdict_parser.py
@@ -1,0 +1,52 @@
+"""Regression test for the LongMemEval judge verdict parser.
+
+The runner scores an LLM judge's reply (prompted to be exactly one word,
+CORRECT or INCORRECT). A naive ``"CORRECT" in judgment`` mis-scores every
+INCORRECT reply as a pass, because "INCORRECT" contains the substring "CORRECT".
+That bug silently inflated every --llm "Judge" number from this runner. These
+tests pin the corrected behavior: INCORRECT is checked first, unrecognised
+replies fail closed.
+"""
+
+import importlib.util
+import pathlib
+
+_RUNNER = pathlib.Path(__file__).resolve().parent.parent / "benchmarks" / "longmemeval_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("lme_runner", _RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_incorrect_is_not_scored_correct():
+    # the core bug: "CORRECT" in "INCORRECT" is True, but the verdict is a FAIL
+    parse = _load_runner()._parse_verdict
+    assert parse("INCORRECT") is False
+
+
+def test_correct_is_scored_correct():
+    parse = _load_runner()._parse_verdict
+    assert parse("CORRECT") is True
+
+
+def test_case_insensitive():
+    parse = _load_runner()._parse_verdict
+    assert parse("incorrect") is False
+    assert parse("correct") is True
+
+
+def test_verdict_embedded_in_a_sentence():
+    parse = _load_runner()._parse_verdict
+    assert parse("The predicted answer is INCORRECT because the dates differ.") is False
+    assert parse("Verdict: CORRECT") is True
+
+
+def test_empty_or_unrecognised_fails_closed():
+    parse = _load_runner()._parse_verdict
+    assert parse("") is False
+    assert parse("   ") is False
+    assert parse("WRONG") is False
+    assert parse("NO") is False


### PR DESCRIPTION
## The bug

`benchmarks/longmemeval_runner.py` scored an LLM judge's reply with:

```python
judgment = resp.json()...content...strip().upper()   # "CORRECT" or "INCORRECT"
return "CORRECT" in judgment
```

The judge is prompted to reply with one word, CORRECT or INCORRECT. `"INCORRECT"` contains the substring `"CORRECT"`, so **every INCORRECT verdict was scored as a pass.** The only answers marked wrong were ones the abstain-guard caught first or where the judge did not use that token. So the `--llm` "Judge" score measured whether the model *attempted* an answer, not whether it was *right*, and better retrieval appeared to raise it. Present since the first commit (2026-04-13).

Empirical confirmation (n=100 dump, deterministic judge): stored 77/100, corrected 33/100 under the same Qwen judge, 25 (gemma4:e4b) / 37 (llama3.1:8b) cross-family. Roughly 40 points of inflation.

## The fix

Extract `_parse_verdict(content)` that checks `INCORRECT` first and fails closed on empty/unrecognised replies. Covered by `tests/test_judge_verdict_parser.py` (5 cases). The existing runner tests still pass.

## Scope / what is NOT affected

- The objective **Recall@K** path (`fusion_shootout.py`, `embedding_comparison.py`) uses no LLM judge (`any(answer_session_id in retrieved)`), so the **97% Recall@5 primary headline is unaffected.**
- The buggy pattern is isolated to this one file (grep-confirmed). BEAM and LoCoMo use different judges and should be audited separately.

## Follow-up (not in this PR)

Re-baseline the affected Judge numbers with the fixed parser, then correct the public references (README 74.6%, research report F-013/E-021/E-022 entries, benchmarks.md, the directory PRs, and the @taOS-dev thread). Held for owner direction.