### PR TITLE
test(profiles): negative-path coverage for generator-profile setters

### DIFF
--- a/tests/test_generator_profile_agent.py
+++ b/tests/test_generator_profile_agent.py
@@ -1,3 +1,5 @@
+import pytest
+
 from taosmd import agents
 
 
@@ -10,3 +12,22 @@ def test_agent_generator_profile_roundtrip(tmp_path):
     assert agents.get_agent_generator_profile("alice", data_dir=tmp_path) == "factual-recall"
     agents.set_agent_generator_profile("alice", None, data_dir=tmp_path)
     assert agents.get_agent_generator_profile("alice", data_dir=tmp_path) is None
+
+
+def test_set_agent_generator_profile_unknown_agent_raises(tmp_path):
+    agents.AgentRegistry(tmp_path).register_agent("real")
+    with pytest.raises(agents.AgentNotFoundError):
+        agents.set_agent_generator_profile("ghost", "factual-recall", data_dir=tmp_path)
+
+
+def test_get_agent_generator_profile_unknown_agent_raises(tmp_path):
+    agents.AgentRegistry(tmp_path).register_agent("real")
+    with pytest.raises(agents.AgentNotFoundError):
+        agents.get_agent_generator_profile("ghost", data_dir=tmp_path)
+
+
+def test_set_agent_generator_profile_empty_string_clears(tmp_path):
+    agents.AgentRegistry(tmp_path).register_agent("bob")
+    agents.set_agent_generator_profile("bob", "factual-recall", data_dir=tmp_path)
+    agents.set_agent_generator_profile("bob", "", data_dir=tmp_path)
+    assert agents.get_agent_generator_profile("bob", data_dir=tmp_path) is None

--- a/tests/test_generator_profile_config.py
+++ b/tests/test_generator_profile_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from taosmd import config
 
 
@@ -6,4 +8,12 @@ def test_generator_profile_roundtrip(tmp_path):
     config.set_generator_profile("factual-recall", data_dir=tmp_path)
     assert config.get_generator_profile(data_dir=tmp_path) == "factual-recall"
     config.set_generator_profile("", clear=True, data_dir=tmp_path)
+    assert config.get_generator_profile(data_dir=tmp_path) is None
+
+
+def test_set_generator_profile_rejects_blank_and_nonstr(tmp_path):
+    # clear=False with a blank or non-string id must raise and persist nothing.
+    for bad in ("", "   ", 123, None):
+        with pytest.raises(ValueError):
+            config.set_generator_profile(bad, data_dir=tmp_path)
     assert config.get_generator_profile(data_dir=tmp_path) is None


### PR DESCRIPTION
Closes deferred test minors flagged in the #177/#178 reviews. Pure test additions, no production change:
- config.set_generator_profile rejects blank/whitespace/non-string ids (ValueError) and persists nothing.
- agents.set/get_agent_generator_profile raise AgentNotFoundError for an unregistered agent.
- agents.set_agent_generator_profile clears on empty string (not just None).

Targeted run: 6 passed.