### PR TITLE
Add task edge read endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ benchmarks/data/*
 models/minilm-onnx/model.onnx
 models/cross-encoder-onnx/
 .env
+.venv/
 *.log
 eval/reports/
 .superpowers/

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -88,6 +88,7 @@ Endpoints
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 ``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
 ``GET  /tasks``            ``?status=&project=&assignee=&limit=``  -> ``{"tasks": [...]}``
+``GET  /tasks/edges``      ``?from_id=&to_id=&type=&limit=``       -> ``{"edges": [...]}``
 ``GET  /tasks/ready``      ``?project=&assignee=&limit=``  -> ``{"tasks": [...]}``
 ``GET  /tasks/prime``      ``?project=&assignee=``         -> ``{"text": ..., "tasks": [...]}``
 ``POST /tasks/{id}``       ``{"status"?, "assignee"?, "priority"?, "body"?}`` -> updated task object
@@ -826,6 +827,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_task_create()
                 elif method == "GET" and path == "/tasks":
                     self._handle_task_list(query)
+                elif method == "GET" and path == "/tasks/edges":
+                    self._handle_task_list_edges(query)
                 elif method == "GET" and path == "/tasks/ready":
                     self._handle_task_ready(query)
                 elif method == "GET" and path == "/tasks/prime":
@@ -1382,6 +1385,29 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, {"tasks": tasks})
 
+        def _handle_task_list_edges(self, qs: dict) -> None:
+            from_id = (qs.get("from_id") or [None])[0]
+            to_id = (qs.get("to_id") or [None])[0]
+            edge_type = (qs.get("type") or [None])[0]
+            limit_raw = (qs.get("limit") or [500])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            try:
+                edges = runner.run(
+                    service.task_list_edges(
+                        from_id=from_id,
+                        to_id=to_id,
+                        edge_type=edge_type,
+                        limit=limit_i,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, {"edges": edges})
+
         def _handle_task_ready(self, qs: dict) -> None:
             project = (qs.get("project") or [None])[0]
             assignee = (qs.get("assignee") or [None])[0]
@@ -1651,7 +1677,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "GET /pending, POST /pending/resolve, "
           "POST /a2a/send, GET /a2a/messages, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
-          "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
+          "POST /tasks, GET /tasks, GET /tasks/edges, GET /tasks/ready, GET /tasks/prime, "
           "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove")
     print("Admin (token required): POST /shelves, POST /shelves/{id}/archive, "
           "POST /shelves/{id}/unarchive, "

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -323,6 +323,26 @@ class RemoteClient:
         resp = await self._run("GET", "/tasks/ready", params=params)
         return resp.get("tasks", [])
 
+    async def task_list_edges(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+        limit: int = 500,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks/edges: list active task edges from the remote server."""
+        params: dict = {"limit": limit}
+        if from_id is not None:
+            params["from_id"] = from_id
+        if to_id is not None:
+            params["to_id"] = to_id
+        if edge_type is not None:
+            params["type"] = edge_type
+        resp = await self._run("GET", "/tasks/edges", params=params)
+        return resp.get("edges", [])
+
     async def task_prime(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -645,6 +645,30 @@ async def task_list(
     )
 
 
+async def task_list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    data_dir=None,
+) -> list[dict]:
+    """Return active task edges matching the given filters.
+
+    Thin wrapper over :func:`taosmd.tasks.list_edges`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_list_edges(
+            from_id=from_id, to_id=to_id, edge_type=edge_type, limit=limit
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.list_edges(
+        from_id=from_id, to_id=to_id, edge_type=edge_type,
+        limit=limit, data_dir=data_dir,
+    )
+
+
 async def task_ready(
     *,
     project: str | None = None,
@@ -837,7 +861,7 @@ async def admin_a2a_supersede_message(msg_id: int, *, data_dir=None) -> dict:
 
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
            "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
-           "task_create", "task_list", "task_ready", "task_prime",
+           "task_create", "task_list", "task_list_edges", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -16,6 +16,7 @@ Public API
 create_task(title, *, body, project, assignee, priority, depends_on,
             created_by, data_dir) -> dict
 list_tasks(*, status, project, assignee, limit, data_dir) -> list[dict]
+list_edges(*, from_id, to_id, edge_type, limit, data_dir) -> list[dict]
 ready_tasks(*, project, assignee, limit, data_dir) -> list[dict]
 prime(*, project, assignee, data_dir) -> {"text": str, "tasks": list[dict]}
 update_task(task_id, *, status, assignee, priority, body, data_dir) -> dict
@@ -289,6 +290,42 @@ async def list_tasks(
         params,
     ).fetchall()
     return [_row_to_dict(r) for r in rows]
+
+
+async def list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return active task edges matching the given filters, newest first."""
+    if edge_type is not None and edge_type not in VALID_EDGE_TYPES:
+        raise ValueError(f"edge_type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    conditions: list[str] = ["removed_ts IS NULL"]
+    params: list[Any] = []
+
+    if from_id is not None:
+        conditions.append("from_id = ?")
+        params.append(from_id)
+    if to_id is not None:
+        conditions.append("to_id = ?")
+        params.append(to_id)
+    if edge_type is not None:
+        conditions.append("type = ?")
+        params.append(edge_type)
+
+    params.append(limit)
+    rows = conn.execute(
+        "SELECT from_id, to_id, type, created_ts, created_by, removed_ts "
+        f"FROM task_edges WHERE {' AND '.join(conditions)} "
+        "ORDER BY created_ts DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
 
 
 async def ready_tasks(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -578,6 +578,39 @@ def test_task_add_edge(live_server):
     assert body["removed_ts"] is None
 
 
+def test_task_list_edges_filters_active_edges(live_server):
+    """GET /tasks/edges lists active task edges and supports query filters."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "Parent", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "Child", "created_by": "a"})
+    _, t3 = _post(f"{live_server}/tasks", {"title": "Related", "created_by": "a"})
+    _post(
+        f"{live_server}/tasks/{t1['id']}/edges",
+        {"to_id": t2["id"], "type": "parent", "created_by": "a"},
+    )
+    _post(
+        f"{live_server}/tasks/{t2['id']}/edges",
+        {"to_id": t3["id"], "type": "relates", "created_by": "a"},
+    )
+    _post(
+        f"{live_server}/tasks/{t2['id']}/edges/remove",
+        {"to_id": t3["id"], "type": "relates"},
+    )
+
+    status, body = _get(f"{live_server}/tasks/edges?from_id={t1['id']}&type=parent")
+
+    assert status == 200
+    assert body["edges"] == [
+        {
+            "from_id": t1["id"],
+            "to_id": t2["id"],
+            "type": "parent",
+            "created_ts": body["edges"][0]["created_ts"],
+            "created_by": "a",
+            "removed_ts": None,
+        }
+    ]
+
+
 def test_task_add_edge_bad_type(live_server):
     _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
     _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -285,6 +285,43 @@ def test_remove_edge_already_removed(data_dir):
         run(tasks_mod.remove_edge(a["id"], b["id"], "blocks", data_dir=data_dir))
 
 
+def test_list_edges_returns_only_active_edges_by_default(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    c = run(tasks_mod.create_task("C", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(b["id"], c["id"], "parent", "x", data_dir=data_dir))
+    run(tasks_mod.remove_edge(b["id"], c["id"], "parent", data_dir=data_dir))
+
+    edges = run(tasks_mod.list_edges(data_dir=data_dir))
+
+    assert edges == [
+        {
+            "from_id": a["id"],
+            "to_id": b["id"],
+            "type": "blocks",
+            "created_ts": edges[0]["created_ts"],
+            "created_by": "x",
+            "removed_ts": None,
+        }
+    ]
+
+
+def test_list_edges_filters_active_edges(data_dir):
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    c = run(tasks_mod.create_task("C", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], c["id"], "parent", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(b["id"], c["id"], "relates", "x", data_dir=data_dir))
+
+    edges = run(tasks_mod.list_edges(from_id=a["id"], edge_type="parent", data_dir=data_dir))
+
+    assert [(e["from_id"], e["to_id"], e["type"]) for e in edges] == [
+        (a["id"], c["id"], "parent")
+    ]
+
+
 # ---------------------------------------------------------------------------
 # depends_on in create_task
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add GET /tasks/edges for active task edge reads
- support from_id, to_id, type, and limit filters
- add service/remote wrappers and focused task/http tests

## Tests
- .venv/bin/python -m pytest tests/test_tasks.py tests/test_http_server.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing task-graph edges through a new `GET /tasks/edges` endpoint.
  * Edge queries now support filtering by source, destination, edge type, and result limit.

* **Bug Fixes**
  * Active edges are returned consistently, excluding removed entries from results.

* **Chores**
  * Updated ignore rules to exclude the Python virtual environment directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->