### PR TITLE
bench(longmemeval): route the runner through retrieve() so the real retrieval path is measured (unblocks E-030)

### DIFF
--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -12,6 +12,7 @@ Usage: .venv/bin/python benchmarks/longmemeval_runner.py [--limit N] [--type TYP
 
 import argparse
 import asyncio
+import inspect
 import json
 import os
 import sys
@@ -24,6 +25,7 @@ from taosmd.knowledge_graph import TemporalKnowledgeGraph
 from taosmd.archive import ArchiveStore
 from taosmd.memory_extractor import extract_facts_from_text, process_conversation_turn
 from taosmd.context_assembler import ContextAssembler
+from taosmd.retrieval import retrieve as _retrieve
 from taosmd.vector_memory import VectorMemory
 
 
@@ -66,7 +68,23 @@ SELF_VERIFY = os.environ.get("TAOSMD_SELF_VERIFY", "0") == "1"
 # temporal). Set TAOSMD_SAMPLE_SEED to shuffle deterministically before slicing
 # so a screen at limit<500 covers all six types. Unset = head slice (back-compat).
 SAMPLE_SEED = os.environ.get("TAOSMD_SAMPLE_SEED")
+# Ollama context window for generation. 0 (the default) means "do not send
+# num_ctx", which leaves Ollama on its own default and keeps every historical
+# LongMemEval number reproducible byte for byte. It is recorded in the result
+# JSON so a run's window is never guessed after the fact. Note that a 16000-char
+# context is roughly 4500-5000 tokens, so Ollama's 4096 default already
+# truncates some prompts; raising this changes what is measured, which is why it
+# is opt-in rather than silently bumped here.
+NUM_CTX = int(os.environ.get("TAOSMD_LME_NUM_CTX", "0"))
 _reranker = None
+
+
+def _gen_options(**extra):
+    """Ollama options dict, carrying num_ctx only when it was explicitly set."""
+    opts = dict(extra)
+    if NUM_CTX:
+        opts["num_ctx"] = NUM_CTX
+    return opts
 
 
 def sample_dataset(dataset, limit, seed=None):
@@ -175,7 +193,7 @@ async def llm_answer(client, context: str, question: str) -> str:
                 "messages": [{"role": "user", "content": ANSWER_PROMPT.format(context=context[:CONTEXT_CHARS], question=question)}],
                 "stream": False,
                 "think": False,
-                "options": {"temperature": 0, "num_predict": 100},
+                "options": _gen_options(temperature=0, num_predict=100),
             },
             timeout=30,
         )
@@ -251,7 +269,7 @@ async def self_verify_answer(client, context: str, question: str, answer: str) -
                 "messages": [{"role": "user", "content": VERIFY_PROMPT.format(context=context[:CONTEXT_CHARS], question=question, answer=answer)}],
                 "stream": False,
                 "think": False,
-                "options": {"temperature": 0, "num_predict": 100},
+                "options": _gen_options(temperature=0, num_predict=100),
             },
             timeout=30,
         )
@@ -264,14 +282,267 @@ async def self_verify_answer(client, context: str, question: str, answer: str) -
     return answer
 
 
-async def run_benchmark(limit: int = 50, question_type: str | None = None, use_llm: bool = False):
+def retrieve_supports_graph_expansion() -> bool:
+    """True when the installed ``taosmd.retrieval.retrieve`` accepts graph_expansion.
+
+    The control is added by the bi-temporal fact-readback work (PR #191). On a
+    checkout without it the runner still works, but the E-030 arms cannot be
+    distinguished, so ``--graph-expansion N>0`` is rejected up front rather
+    than silently producing two identical arms (the exact failure mode this
+    wiring exists to remove).
+    """
+    return "graph_expansion" in inspect.signature(_retrieve).parameters
+
+
+async def retrieve_vector_hits(
+    question: str,
+    kg,
+    vmem,
+    graph_expansion: int = 0,
+    reranker=None,
+    limit: int | None = None,
+) -> list[dict]:
+    """Fetch the vector-layer hits through the real retrieval path.
+
+    Goes through ``taosmd.retrieval.retrieve`` rather than calling
+    ``vmem.search`` directly, so runtime retrieval controls -- notably
+    ``graph_expansion`` -- actually take effect on this benchmark.
+
+    Anchor preservation: the call is deliberately parameterised to reproduce
+    the hand-rolled vector stage it replaces.
+
+    * ``strategy="custom"`` with ``memory_layers=["vector"]`` queries the
+      vector source only. ``kg`` is still passed in ``sources`` because
+      ``_append_graph_expansion`` reads ``sources["kg"]`` regardless of which
+      layers were searched, so the fact-readback block can fire without the KG
+      competing for the ``limit`` slots.
+    * ``candidate_top_k=RETRIEVE_LIMIT`` pins the vector fetch to exactly the
+      ``limit`` the old code used (retrieve() would otherwise fetch limit * 3).
+    * ``limit`` is ``RERANK_TOP_K`` when reranking is on and ``RETRIEVE_LIMIT``
+      otherwise, matching the old narrow-after-rerank behaviour.
+    * ``verify`` is left at its default False: the old stage never gated on
+      claims, so turning verification on here would quietly change what the
+      benchmark measures.
+
+    The one residual difference from the old code is retrieve()'s near-duplicate
+    filter (Jaccard >= 0.8 over the hit texts) where the old path deduplicated
+    on exact string equality only. LongMemEval chunks are ~100-word windows with
+    a 20-word overlap, so unlike EventQA this filter CAN fire; that is exactly
+    what ``--report-retrieval-delta`` measures rather than assumes.
+
+    Returns the raw normalised hit dicts (each with a ``text`` field). When
+    ``graph_expansion`` > 0 a trailing derived block (``source ==
+    "kg_expansion"``) is present.
+    """
+    if limit is None:
+        limit = RERANK_TOP_K if reranker is not None else RETRIEVE_LIMIT
+
+    kwargs = dict(
+        strategy="custom",
+        memory_layers=["vector"],
+        sources={"vector": vmem, "kg": kg},
+        limit=limit,
+        candidate_top_k=RETRIEVE_LIMIT,
+        reranker=reranker,
+        agent_name="longmemeval_eval",
+    )
+    if graph_expansion:
+        kwargs["graph_expansion"] = graph_expansion
+    return await _retrieve(question, **kwargs)
+
+
+async def retrieve_vector_results(
+    question: str,
+    kg,
+    vmem,
+    llm_client=None,
+    graph_expansion: int = 0,
+    retrieval_path: str = "retrieve",
+) -> list[dict]:
+    """The runner's vector stage, on either the wired or the legacy path.
+
+    Reproduces the pre-wiring shape in both modes: optional query decomposition
+    with a deduplicated union capped at ``RETRIEVE_LIMIT``, then an optional
+    cross-encoder rerank down to ``RERANK_TOP_K``.
+    """
+    rr = _get_reranker()
+    reranker = rr if (rr is not None and getattr(rr, "available", False)) else None
+    decomposing = DECOMPOSE and llm_client is not None
+
+    if graph_expansion and retrieval_path == "legacy":
+        raise ValueError(
+            "graph_expansion requires --retrieval-path retrieve; the legacy "
+            "path assembles context by hand and cannot honour the control."
+        )
+    if graph_expansion and decomposing:
+        raise ValueError(
+            "graph_expansion cannot be combined with TAOSMD_DECOMPOSE=1: the "
+            "sub-query union is truncated to RETRIEVE_LIMIT, which can discard "
+            "the derived fact-readback block and make the arm unmeasurable."
+        )
+
+    async def _search(query: str, want_rerank: bool) -> list[dict]:
+        """One query's hits. want_rerank folds the rerank into retrieve()."""
+        if retrieval_path == "legacy":
+            return await vmem.search(query, limit=RETRIEVE_LIMIT)
+        return await retrieve_vector_hits(
+            question=query,
+            kg=kg,
+            vmem=vmem,
+            graph_expansion=graph_expansion,
+            reranker=reranker if want_rerank else None,
+            limit=None if want_rerank else RETRIEVE_LIMIT,
+        )
+
+    if decomposing:
+        # The union is reranked once at the end, so the per-sub-query fetch must
+        # NOT rerank; otherwise the union would be assembled from pre-narrowed
+        # pools and would not match the pre-wiring behaviour.
+        sub_queries = await decompose_query(llm_client, question)
+        seen_texts = set()
+        vector_results = []
+        for sq in sub_queries:
+            for r in await _search(sq, want_rerank=False):
+                t = r.get("text", "")
+                if t and t not in seen_texts:
+                    seen_texts.add(t)
+                    vector_results.append(r)
+        vector_results = vector_results[:RETRIEVE_LIMIT]
+        if reranker is not None and vector_results:
+            vector_results = reranker.rerank(question, vector_results, RERANK_TOP_K)
+        return vector_results
+
+    vector_results = await _search(question, want_rerank=retrieval_path != "legacy")
+    if retrieval_path == "legacy" and reranker is not None and vector_results:
+        vector_results = reranker.rerank(question, vector_results, RERANK_TOP_K)
+    return vector_results
+
+
+async def retrieve_context(
+    question: str,
+    kg,
+    archive,
+    vmem,
+    llm_client=None,
+    graph_expansion: int = 0,
+    retrieval_path: str = "retrieve",
+) -> str:
+    """Assemble the generator context for one question.
+
+    Combines the three retrieval methods the runner has always combined:
+    ContextAssembler, archive FTS over the question's leading terms, and the
+    vector stage. Only the vector stage moved onto ``retrieve()``; the other
+    two are untouched.
+
+    Args:
+        graph_expansion: Token budget for the bi-temporal fact-readback block
+            (0 = off). Requires ``retrieval_path="retrieve"``; the manual
+            legacy path cannot honour it, which is what blocked E-030.
+        retrieval_path: ``"retrieve"`` (default) routes the vector stage
+            through ``taosmd.retrieval.retrieve`` so runtime controls apply.
+            ``"legacy"`` reproduces the pre-wiring hand-rolled stage so the
+            published anchors can be re-measured side by side.
+    """
+    assembler = ContextAssembler(kg=kg, archive=archive)
+    ctx = await assembler.assemble(
+        query=question,
+        depth="auto",
+        max_total_tokens=ASSEMBLE_TOKENS,
+    )
+
+    # FTS search over raw archive (the MemPalace approach -- verbatim recall).
+    # Search for key words from the question.
+    archive_text = ""
+    for term in question.split()[:5]:
+        if len(term) > 3:  # Skip short words
+            try:
+                fts_results = await archive.search_fts(term, limit=FTS_LIMIT)
+                for r in fts_results:
+                    archive_text += " " + r.get("data_json", "") + " " + r.get("summary", "")
+            except Exception:
+                pass
+
+    vector_results = await retrieve_vector_results(
+        question, kg, vmem,
+        llm_client=llm_client,
+        graph_expansion=graph_expansion,
+        retrieval_path=retrieval_path,
+    )
+    vector_text = " ".join(r["text"] for r in vector_results if r.get("text"))
+
+    return ctx["context"] + " " + archive_text + " " + vector_text
+
+
+def summarize_retrieval_delta(results: list[dict]) -> dict | None:
+    """Summarise the wired-vs-legacy context comparison, or None if not measured.
+
+    Only populated when the runner is given ``--report-retrieval-delta``. This
+    is the evidence for whether routing through retrieve() preserved the
+    published LongMemEval anchors: 100% byte-identical means they carry over
+    untouched, and anything less quantifies exactly how much has to be
+    re-anchored before the arms can be trusted.
+    """
+    deltas = [r["retrieval_delta"] for r in results if r.get("retrieval_delta")]
+    if not deltas:
+        return None
+    n = len(deltas)
+    identical = sum(1 for d in deltas if d["identical"])
+    return {
+        "n": n,
+        "identical": identical,
+        "identical_pct": round(identical / n * 100, 2),
+        "mean_legacy_chars": round(sum(d["legacy_chars"] for d in deltas) / n, 1),
+        "mean_wired_chars": round(sum(d["wired_chars"] for d in deltas) / n, 1),
+    }
+
+
+def load_dataset() -> list:
+    """Load the LongMemEval oracle set from disk."""
+    with open(DATA_PATH) as f:
+        return json.load(f)
+
+
+async def run_benchmark(
+    limit: int = 50,
+    question_type: str | None = None,
+    use_llm: bool = False,
+    args: argparse.Namespace | None = None,
+):
+    graph_expansion = 0
+    retrieval_path = "retrieve"
+    report_retrieval_delta = False
+    out_path = ""
+    if args is not None:
+        limit = args.limit
+        question_type = args.type
+        use_llm = args.llm
+        graph_expansion = args.graph_expansion
+        retrieval_path = args.retrieval_path
+        report_retrieval_delta = args.report_retrieval_delta
+        out_path = args.out
+
     print("=" * 70)
     print("LongMemEval Benchmark — taOSmd")
     print("=" * 70)
+    print(
+        f"  retrieval_path={retrieval_path}  graph_expansion={graph_expansion}  "
+        f"num_ctx={NUM_CTX or 'ollama-default'}"
+    )
+
+    # Refuse rather than silently run two identical arms. Exits non-zero on
+    # purpose so an automated chain checking $? reads a refusal as a failure.
+    if graph_expansion and not retrieve_supports_graph_expansion():
+        print(
+            "  ERROR: the installed taosmd.retrieval.retrieve() has no "
+            "graph_expansion parameter, so both E-030 arms would be identical. "
+            "Run this on a checkout that includes the bi-temporal fact-readback "
+            "work (PR #191).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Load dataset
-    with open(DATA_PATH) as f:
-        dataset = json.load(f)
+    dataset = load_dataset()
 
     if question_type:
         dataset = [q for q in dataset if q["question_type"] == question_type]
@@ -281,6 +552,7 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
     print(f"Running {len(dataset)} questions" + (f" (sampled, seed={SAMPLE_SEED})" if SAMPLE_SEED else ""))
 
     results_by_type = {}
+    all_results: list[dict] = []
     total_correct = 0
     total_questions = 0
     total_time = 0
@@ -354,53 +626,36 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
 
         ingest_time = time.time() - t0
 
-        # Query taOSmd — both assembled context AND raw archive search
-        assembler = ContextAssembler(kg=kg, archive=archive)
+        # Query taOSmd: assembled context + raw archive FTS + the vector stage,
+        # the last of which now runs through taosmd.retrieval.retrieve().
         t1 = time.time()
-        ctx = await assembler.assemble(
-            query=question,
-            depth="auto",
-            max_total_tokens=ASSEMBLE_TOKENS,
+        full_context = await retrieve_context(
+            question, kg, archive, vmem,
+            llm_client=llm_client,
+            graph_expansion=graph_expansion,
+            retrieval_path=retrieval_path,
         )
-
-        # Also do FTS search over raw archive (the MemPalace approach — verbatim recall)
-        # Search for key words from the question AND the answer
-        search_terms = question.split()[:5]  # First 5 words of question
-        archive_text = ""
-        for term in search_terms:
-            if len(term) > 3:  # Skip short words
-                try:
-                    fts_results = await archive.search_fts(term, limit=FTS_LIMIT)
-                    for r in fts_results:
-                        archive_text += " " + r.get("data_json", "") + " " + r.get("summary", "")
-                except Exception:
-                    pass
-
-        # Also do semantic vector search (the MemPalace approach). Retrieve a
-        # wider pool, then rerank/prune to the clean top-K (intelligent context
-        # release) so the generator is not buried in redundant chunks.
-        if DECOMPOSE and llm_client is not None:
-            sub_queries = await decompose_query(llm_client, question)
-            seen_texts = set()
-            vector_results = []
-            for sq in sub_queries:
-                for r in await vmem.search(sq, limit=RETRIEVE_LIMIT):
-                    t = r.get("text", "")
-                    if t and t not in seen_texts:
-                        seen_texts.add(t)
-                        vector_results.append(r)
-            vector_results = vector_results[:RETRIEVE_LIMIT]
-        else:
-            vector_results = await vmem.search(question, limit=RETRIEVE_LIMIT)
-        rr = _get_reranker()
-        if rr is not None and getattr(rr, "available", False) and vector_results:
-            vector_results = rr.rerank(question, vector_results, RERANK_TOP_K)
-        vector_text = " ".join(r["text"] for r in vector_results)
-
         query_time = time.time() - t1
 
-        # Score — combine ALL retrieval methods
-        full_context = ctx["context"] + " " + archive_text + " " + vector_text
+        # Anchor evidence: with the flag on, also build the pre-wiring context
+        # and record how far the two diverge, so "does the default path still
+        # reproduce the published numbers?" is answered with a measurement.
+        delta = None
+        if report_retrieval_delta:
+            legacy_ctx = await retrieve_context(
+                question, kg, archive, vmem,
+                llm_client=llm_client,
+                retrieval_path="legacy",
+            )
+            delta = {
+                "legacy_chars": len(legacy_ctx),
+                "wired_chars": len(full_context),
+                "identical": legacy_ctx == full_context,
+            }
+            print(
+                f"    [DELTA] q={i} legacy={delta['legacy_chars']} "
+                f"wired={delta['wired_chars']} identical={delta['identical']}"
+            )
 
         if use_llm and llm_client is not None:
             t_llm = time.time()
@@ -432,6 +687,14 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
 
         elapsed = ingest_time + query_time
         total_time += elapsed
+        all_results.append({
+            "idx": i,
+            "question_type": qtype,
+            "question": question,
+            "correct": bool(correct),
+            "retrieved_chars": len(full_context),
+            "retrieval_delta": delta,
+        })
 
         status = "✓" if correct else "✗"
         print(f"  [{i+1:3d}/{len(dataset)}] {status} {qtype:25s} | ingest:{ingest_time:.1f}s query:{query_time:.3f}s | {question[:50]}")
@@ -443,12 +706,23 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
 
     # Results
     overall = total_correct / total_questions * 100 if total_questions > 0 else 0
+    per_q = total_time / total_questions if total_questions > 0 else 0.0
+
+    delta_summary = summarize_retrieval_delta(all_results)
+    if delta_summary:
+        print(f"\n{'='*70}")
+        print("RETRIEVAL DELTA (wired retrieve() path vs pre-wiring legacy path)")
+        print(f"  questions compared:      {delta_summary['n']}")
+        print(f"  byte-identical contexts: {delta_summary['identical']}"
+              f" ({delta_summary['identical_pct']:.1f}%)")
+        print(f"  mean chars legacy/wired: {delta_summary['mean_legacy_chars']:.0f}"
+              f" / {delta_summary['mean_wired_chars']:.0f}")
 
     print(f"\n{'='*70}")
     print("RESULTS")
     print(f"{'='*70}")
     print(f"\n  Overall: {total_correct}/{total_questions} ({overall:.1f}%)")
-    print(f"  Total time: {total_time:.1f}s ({total_time/total_questions:.1f}s per question)")
+    print(f"  Total time: {total_time:.1f}s ({per_q:.1f}s per question)")
 
     print(f"\n  By question type:")
     for qtype, data in sorted(results_by_type.items()):
@@ -465,14 +739,78 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
     if llm_client:
         await llm_client.aclose()
 
+    if total_questions:
+        if not out_path:
+            out_dir = os.path.join(os.path.dirname(__file__), "results")
+            os.makedirs(out_dir, exist_ok=True)
+            out_path = os.path.join(out_dir, f"longmemeval_{int(time.time())}.json")
+        result_doc = {
+            "question_type": question_type,
+            "limit": limit,
+            "generator": REMOTE_LLM_MODEL,
+            "judge": JUDGE_MODEL,
+            "rerank": RERANK,
+            "decompose": DECOMPOSE,
+            "self_verify": SELF_VERIFY,
+            "assemble_tokens": ASSEMBLE_TOKENS,
+            "retrieve_limit": RETRIEVE_LIMIT,
+            "fts_limit": FTS_LIMIT,
+            "context_chars": CONTEXT_CHARS,
+            "num_ctx": NUM_CTX,
+            "retrieval_path": retrieval_path,
+            "graph_expansion": graph_expansion,
+            "retrieval_delta": delta_summary,
+            "metrics": {
+                "n": total_questions,
+                "correct": total_correct,
+                "accuracy": overall,
+                "by_type": results_by_type,
+            },
+            "results": all_results,
+        }
+        with open(out_path, "w") as f:
+            json.dump(result_doc, f, indent=2)
+        print(f"  results -> {out_path}")
+
     return overall
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate taOSmd on LongMemEval")
     parser.add_argument("--limit", type=int, default=50, help="Number of questions to run")
     parser.add_argument("--type", type=str, default=None, help="Filter by question type")
     parser.add_argument("--llm", action="store_true", help="Use remote LLM for answer generation")
+    parser.add_argument(
+        "--graph-expansion",
+        type=int,
+        default=int(os.environ.get("TAOSMD_GRAPH_EXPANSION", "0")),
+        metavar="N",
+        help="Bi-temporal fact-readback token budget (0 = off, the default). "
+             "This is the E-030 lever; needs --retrieval-path retrieve.",
+    )
+    parser.add_argument(
+        "--retrieval-path",
+        default="retrieve",
+        choices=("retrieve", "legacy"),
+        help="'retrieve' (default) routes the vector stage through "
+             "taosmd.retrieval.retrieve() so runtime controls apply. 'legacy' "
+             "reproduces the pre-wiring hand-rolled stage, for re-anchoring only.",
+    )
+    parser.add_argument(
+        "--report-retrieval-delta",
+        action="store_true",
+        help="Also build the legacy context per question and report how far the "
+             "wired path diverges (anchor evidence). Doubles retrieval cost.",
+    )
+    parser.add_argument(
+        "--out",
+        default="",
+        help="Result JSON path (default: benchmarks/results/longmemeval_<ts>.json)",
+    )
     args = parser.parse_args()
 
-    asyncio.run(run_benchmark(limit=args.limit, question_type=args.type, use_llm=args.llm))
+    asyncio.run(run_benchmark(args=args))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -75,7 +75,28 @@ SAMPLE_SEED = os.environ.get("TAOSMD_SAMPLE_SEED")
 # context is roughly 4500-5000 tokens, so Ollama's 4096 default already
 # truncates some prompts; raising this changes what is measured, which is why it
 # is opt-in rather than silently bumped here.
-NUM_CTX = int(os.environ.get("TAOSMD_LME_NUM_CTX", "0"))
+def _num_ctx_from_env(raw: str | None) -> int:
+    """Parse TAOSMD_LME_NUM_CTX, falling back to the default on a bad value.
+
+    A malformed or empty value used to raise ValueError at module import, which
+    killed the runner before it could say what was wrong. Falling back keeps the
+    historical default (num_ctx unset), and the warning names the offending
+    value so a mis-set window is never mistaken for a deliberate one.
+    """
+    if not raw:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"  WARNING: TAOSMD_LME_NUM_CTX={raw!r} is not an integer; falling "
+            "back to the Ollama default (num_ctx unset).",
+            file=sys.stderr,
+        )
+        return 0
+
+
+NUM_CTX = _num_ctx_from_env(os.environ.get("TAOSMD_LME_NUM_CTX"))
 _reranker = None
 
 
@@ -496,6 +517,36 @@ def summarize_retrieval_delta(results: list[dict]) -> dict | None:
     }
 
 
+def _default_out_dir() -> str:
+    """Directory the runner writes results into when --out is not given."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "results")
+
+
+def _prepare_out_dir(out_path: str) -> str:
+    """Create the result directory and prove it is writable. Returns it.
+
+    Called before the question loop so an unusable --out costs nothing. The
+    probe is a real create-and-delete rather than an os.access() check, because
+    access() answers about permission bits and not about read-only mounts,
+    full filesystems or a parent component that is a regular file.
+    """
+    parent = os.path.dirname(os.path.abspath(out_path)) if out_path else _default_out_dir()
+    try:
+        os.makedirs(parent, exist_ok=True)
+        fd, probe = tempfile.mkstemp(dir=parent, prefix=".out-probe-")
+        os.close(fd)
+        os.unlink(probe)
+    except OSError as exc:
+        print(
+            f"  ERROR: results cannot be written to {parent}: {exc}. Fix --out "
+            "before starting the run, because a path that only fails at write "
+            "time discards every question the run has already answered.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return parent
+
+
 def load_dataset() -> list:
     """Load the LongMemEval oracle set from disk."""
     with open(DATA_PATH) as f:
@@ -540,6 +591,26 @@ async def run_benchmark(
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # The delta builds the legacy context and compares it against the context
+    # the run itself used. On the legacy path those are the same assembly, so
+    # the comparison is legacy-against-legacy: identical by construction, and
+    # a 100% figure that measures nothing. Refuse rather than report it.
+    if report_retrieval_delta and retrieval_path == "legacy":
+        print(
+            "  ERROR: --report-retrieval-delta compares the run's context "
+            "against the legacy context, so with --retrieval-path legacy it "
+            "compares legacy to legacy and is identical by construction. Drop "
+            "--retrieval-path legacy (the wired path is the default) to measure "
+            "the two paths against each other.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Prove the result path is writable now, not after the run. A --out into a
+    # directory that cannot be created used to fail at the final write, by which
+    # point every question had been answered and the results were unrecoverable.
+    _prepare_out_dir(out_path)
 
     # Load dataset
     dataset = load_dataset()
@@ -741,7 +812,7 @@ async def run_benchmark(
 
     if total_questions:
         if not out_path:
-            out_dir = os.path.join(os.path.dirname(__file__), "results")
+            out_dir = _default_out_dir()
             os.makedirs(out_dir, exist_ok=True)
             out_path = os.path.join(out_dir, f"longmemeval_{int(time.time())}.json")
         result_doc = {

--- a/tests/test_longmemeval_retrieve_wiring.py
+++ b/tests/test_longmemeval_retrieve_wiring.py
@@ -1,0 +1,344 @@
+"""Tests for the LongMemEval runner's retrieval wiring (unblocks E-030).
+
+The runner used to assemble its context by hand (ContextAssembler +
+archive.search_fts + vmem.search + reranker) and never called
+taosmd.retrieval.retrieve(), so setting the graph_expansion control had no
+effect and both E-030 arms would have been byte-identical. These tests pin
+the wiring:
+
+  1. The vector stage goes through retrieve().
+  2. graph_expansion is forwarded only when the flag is set (default 0 stays
+     off, and the kwarg is omitted entirely so the runner still imports on a
+     checkout predating PR #191).
+  3. The derived fact block reaches the assembled context.
+  4. The legacy path refuses graph_expansion instead of silently ignoring it.
+  5. At graph_expansion=0 the wired path is parameterised to match the legacy
+     stage (the anchor condition), including the candidate pool width.
+  6. The signature probe REFUSES the run, with a non-zero exit, on a checkout
+     whose retrieve() has no graph_expansion parameter. The EventQA sibling
+     test only asserted the probe returns a bool and never asserted the abort,
+     which left the safety-critical behaviour untested.
+  7. The CLI exposes --graph-expansion / --retrieval-path /
+     --report-retrieval-delta with the documented defaults.
+
+The LongMemEval-S / oracle dataset is gitignored and generally absent, so
+every test here uses synthetic fixtures and never touches benchmarks/data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER_PATH = REPO_ROOT / "benchmarks" / "longmemeval_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("longmemeval_runner", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeVectorMemory:
+    """Minimal vector source: returns fixed hits in retrieve()'s expected shape."""
+
+    def __init__(self, texts):
+        self.texts = texts
+        self.calls = []
+
+    async def search(self, query, limit=5, hybrid=True, fusion="boost",
+                     project=None, search_agents=None):
+        self.calls.append({"query": query, "limit": limit, "fusion": fusion})
+        return [
+            {"id": i, "text": t, "similarity": 1.0 - i * 0.01, "metadata": {}}
+            for i, t in enumerate(self.texts[:limit])
+        ]
+
+
+class _FakeArchive:
+    async def search_fts(self, term, limit=5):
+        return []
+
+
+class _FakeKG:
+    pass
+
+
+class _RecordingAssembler:
+    """Stands in for ContextAssembler; contributes nothing to the context."""
+
+    def __init__(self, kg=None, archive=None):
+        pass
+
+    async def assemble(self, query, depth="auto", max_total_tokens=4000):
+        return {"context": ""}
+
+
+@pytest.fixture()
+def runner(monkeypatch):
+    mod = _load_runner()
+    monkeypatch.setattr(mod, "ContextAssembler", _RecordingAssembler)
+    return mod
+
+
+def _context(mod, **kwargs):
+    vmem = kwargs.pop("vmem", None) or _FakeVectorMemory(["alpha chunk", "beta chunk"])
+    return asyncio.run(
+        mod.retrieve_context(
+            "who met the captain", _FakeKG(), _FakeArchive(), vmem, **kwargs
+        )
+    ), vmem
+
+
+# ---------------------------------------------------------------------------
+# 1-2. the vector stage goes through retrieve(), carrying graph_expansion
+# ---------------------------------------------------------------------------
+
+def test_default_path_calls_retrieve_without_graph_expansion(runner, monkeypatch):
+    seen = {}
+
+    async def fake_retrieve(query, **kwargs):
+        seen.update(kwargs)
+        seen["query"] = query
+        return [{"text": "alpha chunk"}]
+
+    monkeypatch.setattr(runner, "_retrieve", fake_retrieve)
+    ctx, _ = _context(runner)
+
+    assert seen["query"] == "who met the captain"
+    assert seen["memory_layers"] == ["vector"]
+    # The KG must be in sources even though only the vector layer is searched:
+    # _append_graph_expansion reads sources["kg"] regardless.
+    assert set(seen["sources"]) == {"vector", "kg"}
+    # Default arm must not pass the kwarg at all, so the runner still imports
+    # and runs on a checkout whose retrieve() predates the control.
+    assert "graph_expansion" not in seen
+    # Claims-gating must stay off: the legacy stage never verified, and turning
+    # it on here would silently change what the benchmark measures.
+    assert seen.get("verify", False) is False
+    assert "alpha chunk" in ctx
+
+
+def test_flag_forwards_graph_expansion_to_retrieve(runner, monkeypatch):
+    seen = {}
+
+    async def fake_retrieve(query, **kwargs):
+        seen.update(kwargs)
+        return [{"text": "alpha chunk"}]
+
+    monkeypatch.setattr(runner, "_retrieve", fake_retrieve)
+    _context(runner, graph_expansion=512)
+
+    assert seen["graph_expansion"] == 512
+
+
+# ---------------------------------------------------------------------------
+# 3. the derived fact block reaches the generator context
+# ---------------------------------------------------------------------------
+
+def test_graph_expansion_block_reaches_assembled_context(runner, monkeypatch):
+    async def fake_retrieve(query, **kwargs):
+        hits = [{"text": "alpha chunk", "source": "vector"}]
+        if kwargs.get("graph_expansion"):
+            hits.append({
+                "text": "captain commands ship",
+                "source": "kg_expansion",
+                "derived": True,
+            })
+        return hits
+
+    monkeypatch.setattr(runner, "_retrieve", fake_retrieve)
+
+    off, _ = _context(runner, graph_expansion=0)
+    on, _ = _context(runner, graph_expansion=512)
+
+    assert "captain commands ship" not in off
+    assert "captain commands ship" in on
+    assert off != on, "the two E-030 arms must not produce identical context"
+
+
+# ---------------------------------------------------------------------------
+# 4. the legacy path refuses the control rather than ignoring it
+# ---------------------------------------------------------------------------
+
+def test_legacy_path_rejects_graph_expansion(runner):
+    with pytest.raises(ValueError, match="graph_expansion"):
+        _context(runner, retrieval_path="legacy", graph_expansion=512)
+
+
+def test_decompose_rejects_graph_expansion(runner, monkeypatch):
+    """The sub-query union truncates, which can drop the derived block."""
+    monkeypatch.setattr(runner, "DECOMPOSE", True)
+    with pytest.raises(ValueError, match="graph_expansion"):
+        _context(runner, graph_expansion=512, llm_client=object())
+
+
+# ---------------------------------------------------------------------------
+# 5. anchor condition: the wired default is parameterised like the legacy stage
+# ---------------------------------------------------------------------------
+
+def test_wired_default_matches_legacy_context(runner):
+    """With no reranker and distinct chunks, wired and legacy contexts agree."""
+    texts = ["alpha chunk one", "beta chunk two", "gamma chunk three"]
+    wired, vmem_wired = _context(runner, vmem=_FakeVectorMemory(texts))
+    legacy, vmem_legacy = _context(
+        runner, vmem=_FakeVectorMemory(texts), retrieval_path="legacy"
+    )
+
+    assert wired == legacy
+    # Both stages must fetch the same candidate pool: retrieve() would default
+    # to limit * 3, so candidate_top_k has to pin it to RETRIEVE_LIMIT.
+    assert vmem_wired.calls[0]["limit"] == vmem_legacy.calls[0]["limit"]
+    assert vmem_wired.calls[0]["limit"] == runner.RETRIEVE_LIMIT
+
+
+def test_wired_decompose_matches_legacy_decompose(runner, monkeypatch):
+    """Decomposed retrieval must union/dedup/truncate identically either way."""
+    texts = ["alpha chunk one", "beta chunk two", "gamma chunk three"]
+
+    async def fake_decompose(client, question):
+        return ["sub one", "sub two"]
+
+    monkeypatch.setattr(runner, "DECOMPOSE", True)
+    monkeypatch.setattr(runner, "decompose_query", fake_decompose)
+
+    wired, vmem_wired = _context(
+        runner, vmem=_FakeVectorMemory(texts), llm_client=object()
+    )
+    legacy, vmem_legacy = _context(
+        runner, vmem=_FakeVectorMemory(texts), llm_client=object(),
+        retrieval_path="legacy",
+    )
+
+    assert wired == legacy
+    assert [c["query"] for c in vmem_wired.calls] == [
+        c["query"] for c in vmem_legacy.calls
+    ]
+    assert all(c["limit"] == runner.RETRIEVE_LIMIT for c in vmem_wired.calls)
+
+
+def test_retrieve_supports_graph_expansion_reports_installed_signature(runner):
+    # Never raises; the answer depends on whether PR #191 is in the checkout.
+    assert isinstance(runner.retrieve_supports_graph_expansion(), bool)
+
+
+# ---------------------------------------------------------------------------
+# 6. the probe must ABORT the run, with a non-zero exit
+# ---------------------------------------------------------------------------
+
+def _args(**overrides):
+    base = dict(
+        limit=1,
+        type=None,
+        llm=False,
+        graph_expansion=512,
+        retrieval_path="retrieve",
+        report_retrieval_delta=False,
+        out="",
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_unsupported_graph_expansion_aborts_the_run(runner, monkeypatch):
+    """The safety-critical case: refuse rather than run two identical arms."""
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", lambda: False)
+
+    opened = []
+    monkeypatch.setattr(
+        runner, "load_dataset",
+        lambda: opened.append("loaded") or [],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        asyncio.run(runner.run_benchmark(args=_args()))
+
+    # Non-zero exit: a chain that checks $? must read a refusal as a failure.
+    # (The EventQA sibling uses a bare `return`, so it exits 0 and a refusal
+    # reads as success; see the PR body.)
+    assert exc.value.code != 0
+    assert opened == [], "the dataset must not even be loaded after a refusal"
+
+
+def test_supported_graph_expansion_does_not_abort(runner, monkeypatch):
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", lambda: True)
+    monkeypatch.setattr(runner, "load_dataset", lambda: [])
+
+    # Empty dataset short-circuits before any store is created; the point is
+    # only that the probe did not raise SystemExit.
+    asyncio.run(runner.run_benchmark(args=_args()))
+
+
+def test_zero_graph_expansion_never_probes(runner, monkeypatch):
+    """graph_expansion=0 must run on any checkout, probe or no probe."""
+    def _boom():
+        raise AssertionError("probe must not gate the default arm")
+
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", _boom)
+    monkeypatch.setattr(runner, "load_dataset", lambda: [])
+
+    asyncio.run(runner.run_benchmark(args=_args(graph_expansion=0)))
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI surface
+# ---------------------------------------------------------------------------
+
+def test_cli_exposes_the_e030_arms(runner, monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(runner.asyncio, "run", lambda coro: None)
+    monkeypatch.setattr(
+        runner, "run_benchmark", lambda args: captured.update(vars(args))
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["longmemeval_runner.py", "--graph-expansion", "512", "--limit", "2"],
+    )
+    runner.main()
+
+    assert captured["graph_expansion"] == 512
+    assert captured["retrieval_path"] == "retrieve"
+    assert captured["limit"] == 2
+
+
+def test_cli_defaults(runner, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(runner.asyncio, "run", lambda coro: None)
+    monkeypatch.setattr(
+        runner, "run_benchmark", lambda args: captured.update(vars(args))
+    )
+    monkeypatch.setattr(sys, "argv", ["longmemeval_runner.py"])
+    runner.main()
+
+    assert captured["graph_expansion"] == 0
+    assert captured["retrieval_path"] == "retrieve"
+    assert captured["report_retrieval_delta"] is False
+
+
+def test_cli_rejects_unknown_retrieval_path(runner, monkeypatch):
+    monkeypatch.setattr(runner.asyncio, "run", lambda coro: None)
+    monkeypatch.setattr(sys, "argv", ["longmemeval_runner.py", "--retrieval-path", "hand"])
+    with pytest.raises(SystemExit):
+        runner.main()
+
+
+def test_summarize_retrieval_delta_reports_identity(runner):
+    results = [
+        {"retrieval_delta": {"legacy_chars": 10, "wired_chars": 10, "identical": True}},
+        {"retrieval_delta": {"legacy_chars": 10, "wired_chars": 12, "identical": False}},
+        {"retrieval_delta": None},
+    ]
+    summary = runner.summarize_retrieval_delta(results)
+    assert summary["n"] == 2
+    assert summary["identical"] == 1
+    assert summary["identical_pct"] == 50.0
+    assert runner.summarize_retrieval_delta([{"correct": True}]) is None

--- a/tests/test_longmemeval_retrieve_wiring.py
+++ b/tests/test_longmemeval_retrieve_wiring.py
@@ -342,3 +342,113 @@ def test_summarize_retrieval_delta_reports_identity(runner):
     assert summary["identical"] == 1
     assert summary["identical_pct"] == 50.0
     assert runner.summarize_retrieval_delta([{"correct": True}]) is None
+
+
+# ---------------------------------------------------------------------------
+# 8. Operator-error handling: a bad input must fail loudly and early, never
+#    at import time and never after a full run has already been spent.
+# ---------------------------------------------------------------------------
+
+def test_malformed_num_ctx_does_not_kill_the_import(monkeypatch, capsys):
+    """A junk TAOSMD_LME_NUM_CTX must degrade to the default, not raise.
+
+    The value is read at module scope, so a bare int() turned a typo into an
+    ImportError with no mention of the variable that caused it.
+    """
+    monkeypatch.setenv("TAOSMD_LME_NUM_CTX", "banana")
+
+    mod = _load_runner()
+
+    assert mod.NUM_CTX == 0
+    # The warning has to name the offending value, or the operator is left
+    # guessing which of the environment's settings was ignored.
+    assert "banana" in capsys.readouterr().err
+
+
+def test_empty_num_ctx_is_treated_as_unset_and_stays_quiet(monkeypatch, capsys):
+    """`export VAR=` means unset, not malformed, so it must not warn.
+
+    Both are worth separating: a warning on every empty value is noise an
+    operator learns to ignore, which is how the one that matters gets missed.
+    """
+    monkeypatch.setenv("TAOSMD_LME_NUM_CTX", "")
+
+    assert _load_runner().NUM_CTX == 0
+    assert "TAOSMD_LME_NUM_CTX" not in capsys.readouterr().err
+
+
+def test_well_formed_num_ctx_is_still_honoured(monkeypatch):
+    """Positive control: the fallback must not swallow a legitimate value."""
+    monkeypatch.setenv("TAOSMD_LME_NUM_CTX", "8192")
+
+    assert _load_runner().NUM_CTX == 8192
+
+
+def test_delta_on_the_legacy_path_is_refused(runner, monkeypatch):
+    """legacy + --report-retrieval-delta compares legacy against legacy.
+
+    That is identical by construction, so it would report a 100% anchor match
+    while measuring nothing at all. Refusing is the only honest answer.
+    """
+    opened = []
+    monkeypatch.setattr(
+        runner, "load_dataset",
+        lambda: opened.append("loaded") or [],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        asyncio.run(runner.run_benchmark(args=_args(
+            graph_expansion=0,
+            retrieval_path="legacy",
+            report_retrieval_delta=True,
+        )))
+
+    assert exc.value.code != 0
+    assert opened == [], "the refusal must land before any work is done"
+
+
+def test_delta_on_the_wired_path_is_not_refused(runner, monkeypatch, tmp_path):
+    """Positive control: the refusal is specific to the legacy combination."""
+    monkeypatch.setattr(runner, "load_dataset", lambda: [])
+
+    asyncio.run(runner.run_benchmark(args=_args(
+        graph_expansion=0,
+        report_retrieval_delta=True,
+        out=str(tmp_path / "results.json"),
+    )))
+
+
+def test_missing_out_directory_is_created_before_the_run(runner, monkeypatch, tmp_path):
+    """--out into a directory that does not exist yet must be made to work."""
+    target = tmp_path / "deep" / "nested" / "results.json"
+    monkeypatch.setattr(runner, "load_dataset", lambda: [])
+
+    asyncio.run(runner.run_benchmark(args=_args(graph_expansion=0, out=str(target))))
+
+    # Created up front, so it is already there even though this run answered
+    # no questions and therefore never reached the write.
+    assert target.parent.is_dir()
+
+
+def test_unwritable_out_path_is_refused_before_the_run(runner, monkeypatch, tmp_path):
+    """An --out that can never be written must cost zero questions.
+
+    The parent component is a regular file, so the directory cannot be created
+    at all. That shape is deterministic and, unlike a chmod, it still fails
+    when the suite happens to run as root.
+    """
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("regular file")
+    target = blocker / "results.json"
+
+    opened = []
+    monkeypatch.setattr(
+        runner, "load_dataset",
+        lambda: opened.append("loaded") or [],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        asyncio.run(runner.run_benchmark(args=_args(graph_expansion=0, out=str(target))))
+
+    assert exc.value.code != 0
+    assert opened == [], "the run must not answer a single question first"


### PR DESCRIPTION
**HELD FOR REVIEW. Do not merge. No benchmark was run.**

## The defect

`benchmarks/longmemeval_runner.py` never called `taosmd.retrieval.retrieve()`. It hand-assembled its context:

```python
full_context = ctx["context"] + " " + archive_text + " " + vector_text
```

where `vector_text` came from a direct `vmem.search()` plus an optional reranker pass. Two consequences.

1. **The runner was not measuring the shipped path.** Every LongMemEval number it produced described a pipeline users do not have. Anything `retrieve()` does that the hand-rolled stage does not (near-duplicate filtering, fusion, the layer plumbing) was absent from the measurement.
2. **`graph_expansion` (PR #191) was unreachable from it**, which blocks the pre-registered E-030. Setting the control would have had no effect and both arms would have been byte-identical, so the experiment would have silently measured nothing and reported a null.

This is the same defect PR #196 (`ea882a2`) fixed for the EventQA runner. This change follows that wiring closely so the two runners stay consistent.

## What moved

Only the vector stage. `ContextAssembler` and the archive-FTS pass are untouched and still contribute to the context exactly as before.

## Reconstruction choices

`retrieve()` has different defaults from the code it replaces, so the call is deliberately parameterised to reproduce the old stage rather than to be idiomatic:

- `strategy="custom"`, `memory_layers=["vector"]` so only the vector source is searched, as before. `kg` is still passed in `sources` because `_append_graph_expansion` reads `sources["kg"]` regardless of which layers were searched, so the readback block can fire without the KG competing for `limit` slots.
- `candidate_top_k=RETRIEVE_LIMIT` pins the vector fetch to exactly the width the old code used. Left unset, `retrieve()` fetches `limit * 3` and would have silently widened the instrument.
- `limit` narrows to `RERANK_TOP_K` only when a reranker is actually available, matching the old narrow-after-rerank behaviour. With no reranker it stays at `RETRIEVE_LIMIT`.
- `verify` is left at its default `False`. The old stage never gated on claims; enabling verification here would change what the benchmark measures.
- Decomposition (`TAOSMD_DECOMPOSE=1`) keeps its shape: per-sub-query fetches with **no** per-query rerank, deduplicated union truncated to `RETRIEVE_LIMIT`, then one rerank at the end. Reranking inside each sub-query fetch would have built the union out of pre-narrowed pools.

**Residual difference, measured not assumed.** `retrieve()` applies a near-duplicate filter (Jaccard >= 0.8) where the old path deduplicated on exact string equality. Unlike EventQA's distinct 4096-token passages, LongMemEval chunks are ~100-word windows with a 20-word overlap, so this filter **can** fire here. `--report-retrieval-delta` quantifies it per question instead of hand-waving it.

`graph_expansion` is refused, not ignored, on `--retrieval-path legacy` (the hand-rolled path cannot honour it) and under `TAOSMD_DECOMPOSE=1` (the union is truncated to `RETRIEVE_LIMIT`, which can discard the derived block and make the arm unmeasurable).

## Non-zero exit: an improvement over the EventQA probe

`retrieve_supports_graph_expansion()` is ported from EventQA, with one fix. The EventQA refusal path uses a bare `return`, so the process exits **0** and an automated chain checking `$?` reads a refusal as a success. This version calls `sys.exit(1)`. **The EventQA runner should be brought into line** in a follow-up.

This is not hypothetical. On `origin/master` the probe returns **False**: `graph_expansion` lives on `origin/feat/bitemporal-readback` (`9286e47`) and is not an ancestor of master. E-030 therefore cannot run on master today, and on this branch it fails loudly instead of quietly producing two identical arms.

## Tests

`tests/test_longmemeval_retrieve_wiring.py`, 15 tests, synthetic fixtures only (the LongMemEval-S / oracle data is gitignored and absent on most boxes, so nothing here touches `benchmarks/data`).

Closes a real gap in the EventQA test file: it asserted the probe *returns a bool* but never asserted the run *aborts*, leaving the safety-critical behaviour untested. Covered here:

- the run aborts with a **non-zero** `SystemExit` when the probe is False, and the dataset is not even opened;
- a supported checkout does not abort, and `graph_expansion=0` never consults the probe at all (so the default arm runs anywhere);
- flag forwarding, including that the kwarg is *omitted* at 0 so the runner still imports on a pre-#191 checkout;
- `verify` stays off;
- wired-vs-legacy equivalence on identical inputs, single-query and decomposed, plus an assertion that both fetch the same candidate-pool width;
- the derived block reaches the generator context and the two arms differ;
- legacy and decompose both refuse `graph_expansion`;
- CLI defaults and rejection of an unknown `--retrieval-path`.

## Result JSON

The runner now writes `benchmarks/results/longmemeval_<ts>.json` (or `--out`) recording `retrieval_path`, `graph_expansion`, `num_ctx`, the lever env, per-type metrics and the delta summary.

`num_ctx` is a new `TAOSMD_LME_NUM_CTX` knob defaulting to **0 = do not send**, which leaves Ollama on its own default and keeps historical numbers reproducible byte for byte. Worth flagging separately: a 16000-char context is roughly 4500-5000 tokens, so Ollama's 4096 default is likely already truncating some LongMemEval prompts. Raising it changes what is measured, so it is opt-in here rather than silently bumped.

## What an operator should run before trusting the arms

Establish the delta before reading any E-030 result:

```bash
TAOSMD_OLLAMA_MODEL=... TAOSMD_JUDGE_MODEL=... \
  .venv/bin/python benchmarks/longmemeval_runner.py \
    --llm --limit 50 --report-retrieval-delta
```

Read `identical_pct` in the `RETRIEVAL DELTA` block. 100% means the published anchors carry over untouched. Anything less is the exact amount that has to be re-anchored, and given the overlapping chunks it is unlikely to be 100% here. If it is low, re-anchor with `--retrieval-path legacy` on the same slice before comparing arms.

## Suite

Same environment, same box. Pre-existing failures are environmental (torch/CUDA: GTX 1050 Ti `sm_61` against a torch build wanting `sm_75+`, plus a missing ONNX model) and were not chased.

| | result |
|---|---|
| `origin/master` baseline | 9 failed, 1124 passed, 5 skipped |
| this branch | 9 failed, **1139** passed, 5 skipped |

Identical failure set. +15 passing, all new.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retrieval modes for benchmark runs, including wired and legacy paths.
  * Added optional graph expansion, query decomposition, cross-encoder reranking, and retrieval-delta reporting.
  * Added command-line options for retrieval configuration and JSON result output.
  * Benchmark results now include structured per-question retrieval details.

* **Bug Fixes**
  * Prevented unsupported graph expansion configurations from running and producing invalid results.

* **Tests**
  * Added comprehensive coverage for retrieval behavior, CLI validation, graph expansion, and result comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->