### PR TITLE
docs(agent-jobs): refresh the pack for the weekly dark window

### DIFF
--- a/docs/agent-jobs/README.md
+++ b/docs/agent-jobs/README.md
@@ -22,8 +22,9 @@ Do not improvise.
    on the PR instead of guessing.
 6. No new dependencies. Never edit pyproject.toml, requirements, or CI.
 7. The full test suite must pass before you push:
-   `python3 -m pytest -q -m "not slow"` (expect roughly 850 tests, all green).
-   Lint the files you changed: `python3 -m ruff check <files>`.
+   `python3 -m pytest -q -m "not slow"` (well over a thousand tests, all
+   green; record the exact number in your PR body). Lint the files you
+   changed: `python3 -m ruff check <files>`.
 8. Never commit IP addresses, hostnames, tokens, or credentials.
 9. STOP on any surprise: a failing test you did not cause, a merge conflict,
    a file that does not look like the job describes. Open the PR with what
@@ -48,8 +49,37 @@ Do not improvise.
 
 ## Job index
 
-| Job | File | Risk | Scope |
-|---|---|---|---|
-| JOB-001 | job-001-benchmarks-em-dash-sweep.md | minimal | punctuation only, one doc |
-| JOB-002 | job-002-cross-encoder-path-fix.md | low | one small class, one test file |
-| JOB-003 | job-003-http-server-dead-import.md | minimal | delete dead code, one function |
+Every job carries a Status line at the top of its file. Check it before you
+start. Only take a job whose status is OPEN. The pack was last verified
+against master on 2026-07-21.
+
+| Job | File | Status | Risk | Scope |
+|---|---|---|---|---|
+| JOB-001 | job-001-benchmarks-em-dash-sweep.md | OPEN | minimal | punctuation only, one doc |
+| JOB-002 | job-002-cross-encoder-path-fix.md | ON HOLD, see #199 | n/a | do not start |
+| JOB-003 | job-003-http-server-dead-import.md | OPEN | minimal | delete dead code, one function |
+| JOB-004 | job-004-eventqa-runner-exit-code.md | OPEN | low | two returns in one runner, one test file |
+| JOB-005 | job-005-collections-db-connect.md | OPEN | low | one line plus an import, one test file |
+
+Take them in any order; no job depends on another. If two of you are working
+at once, do not both take the same job, and never touch a file another job
+lists under "Allowed files".
+
+## Work that is deliberately NOT in this pack
+
+Some open issues look like small jobs and are not. Do not pick these up even
+if you find the issue and it reads as mechanical:
+
+- **#199 (reranker model path).** Superseded JOB-002. The read path and the
+  download path have separate defaults, so fixing either one alone desyncs
+  them, and the right resolution mechanism is a design decision.
+- **#203 (unregistered databases in the migration REGISTRY).** Blocked on
+  PR #201, which is not merged. The issue calls each entry mechanical, but a
+  registry entry needs a `detect` probe written against each database's real
+  baseline schema, and a wrong probe stamps the wrong version against a live
+  store. That is the exact silent-corruption class the framework exists to
+  prevent. The `knowledge-graph.db` two-schema-owners half of the issue is
+  design work outright.
+- **#206 (CLI silently operating on a remote store).** The issue proposes two
+  fixes and one of them is a breaking change. Picking between them is the
+  work.

--- a/docs/agent-jobs/job-001-benchmarks-em-dash-sweep.md
+++ b/docs/agent-jobs/job-001-benchmarks-em-dash-sweep.md
@@ -1,5 +1,9 @@
 # JOB-001: Replace every em dash in docs/benchmarks.md
 
+**Status: OPEN (verified 2026-07-21).** `grep -c "—" docs/benchmarks.md`
+prints 120 on current master, so the sweep has not been done. The count below
+says "roughly 121"; 120 is the current number and is what you should expect.
+
 Read docs/agent-jobs/README.md first and follow its absolute rules.
 
 - Branch: `docs/benchmarks-em-dash-sweep` (from `origin/master`)

--- a/docs/agent-jobs/job-002-cross-encoder-path-fix.md
+++ b/docs/agent-jobs/job-002-cross-encoder-path-fix.md
@@ -1,5 +1,33 @@
 # JOB-002: Make CrossEncoderReranker's default model path cwd-independent
 
+**Status: ON HOLD (verified 2026-07-21). DO NOT START THIS JOB.**
+
+The bug this job describes is still real: `taosmd/cross_encoder.py` line 21
+still defaults `onnx_path` to the relative `"models/cross-encoder-onnx"`.
+The fix written below is what has gone stale, and applying it as written
+would make things worse. Issue #199 covers the same ground and supersedes
+this job.
+
+Two reasons this is no longer a self-contained job:
+
+1. The read path and the download path have SEPARATE defaults.
+   `taosmd/api.py` line 635 builds `CrossEncoderReranker()` with no argument,
+   and line 641 calls `_recipes.ensure_reranker_model(block=False)`, which
+   has its own default of `"models/cross-encoder-onnx"` at
+   `taosmd/recipes.py` line 457. The steps below change only the first one.
+   That would leave the downloader writing to `$CWD/models/` while the
+   reranker looks in the repo root, so `available` would never become true
+   and a fresh deployment would re-fire a roughly 600MB download on every
+   single search. That is a regression, not a fix.
+2. Resolving against the repo root is itself the wrong answer for a wheel
+   install, where the repo root is site-packages and is not writable. Issue
+   #199 asks for the reranker path to go through the same mechanism as the
+   embedder (`_resolve_onnx_path(data_dir, ...)` in `taosmd/api.py`) or an
+   env override, and separately asks whether a live search should be pulling
+   600MB at all. Choosing between those is a design decision.
+
+Leave this to the primary session. The file is kept for history.
+
 Read docs/agent-jobs/README.md first and follow its absolute rules.
 
 - Branch: `fix/cross-encoder-cwd-path` (from `origin/master`)

--- a/docs/agent-jobs/job-003-http-server-dead-import.md
+++ b/docs/agent-jobs/job-003-http-server-dead-import.md
@@ -1,5 +1,10 @@
 # JOB-003: Remove the dead importlib block in _webui_dir
 
+**Status: OPEN (verified 2026-07-21).** The dead try block is still in
+`taosmd/http_server.py`, now at `_webui_dir()` around line 165 rather than
+112. `_pkg_files` (imported at line 155) still has exactly one user, the dead
+block itself, so step 4 will tell you to remove that import too.
+
 Read docs/agent-jobs/README.md first and follow its absolute rules.
 
 - Branch: `chore/http-server-dead-import` (from `origin/master`)

--- a/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
+++ b/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
@@ -1,0 +1,193 @@
+# JOB-004: Make the EventQA runner exit non-zero when it refuses to run
+
+Read docs/agent-jobs/README.md first and follow its absolute rules.
+
+- Tracks issue #205.
+- Branch: `fix/eventqa-runner-exit-code` (from `origin/master`)
+- Commit message: `fix(bench): exit non-zero when the EventQA runner refuses to run`
+- PR title: `fix(bench): exit non-zero when the EventQA runner refuses to run`
+- Allowed files: `benchmarks/eventqa_runner.py`,
+  `tests/test_eventqa_retrieve_wiring.py` ONLY.
+
+## The bug
+
+`benchmarks/eventqa_runner.py`, in `async def run(args)` (around line 715),
+refuses to run when the checkout does not support the requested lever. The
+refusal itself is correct: without it the two E-025 arms would be
+byte-identical and the benchmark would report a null result that is really an
+instrument failure.
+
+The problem is how it refuses. It prints an error and then does a bare
+`return`, so the process exits **0**. An overnight chain that runs arms in
+sequence and checks `$?` reads "I refused to run" as "this arm succeeded",
+carries on, and the missing arm only shows up much later as an absent result
+file rather than as a failure at the point it happened.
+
+The sibling LongMemEval runner already has the correct shape. There is a
+worked reference implementation on branch `feat/longmemeval-retrieve-wiring`
+(PR #204): see `benchmarks/longmemeval_runner.py` around line 534, and its
+tests in `tests/test_longmemeval_retrieve_wiring.py` around line 251. Read
+both before you start. You are copying that pattern, not inventing one.
+
+Fetch the reference without checking it out:
+
+```
+git fetch origin feat/longmemeval-retrieve-wiring
+git show origin/feat/longmemeval-retrieve-wiring:benchmarks/longmemeval_runner.py | sed -n '525,545p'
+git show origin/feat/longmemeval-retrieve-wiring:tests/test_longmemeval_retrieve_wiring.py | sed -n '236,285p'
+```
+
+Do NOT branch from `feat/longmemeval-retrieve-wiring`, and do not merge it
+into your branch. Branch from `origin/master` as usual. The reference is for
+reading only.
+
+## Two refusals to fix, and one return you must NOT touch
+
+Inside `async def run(args)` there are exactly two error paths that print an
+`ERROR:` line and then `return`. Both must exit non-zero:
+
+1. around line 715: the `graph_expansion` support probe
+2. around line 726: `if not rows:` after `load_eventqa_rows(...)`
+
+There is a THIRD bare `return` further down (around line 765), at the end of
+the `if not args.llm:` dry-run summary block. That one is a SUCCESS path: a
+dry wiring check that completed normally. It must keep exiting 0. Do not
+touch it. If you find yourself editing anything near the words
+`DRY WIRING CHECK`, you have the wrong return.
+
+## Steps
+
+1. `git fetch origin && git checkout -b fix/eventqa-runner-exit-code origin/master`
+2. Read `benchmarks/eventqa_runner.py` from line 690 to line 790 before
+   editing, so you can see all three returns and tell them apart.
+3. Confirm `sys` is already imported (it is, around line 58). Do not add the
+   import again.
+4. Write the failing tests FIRST. Append them to the END of the existing file
+   `tests/test_eventqa_retrieve_wiring.py`. That file already has a `runner`
+   fixture and loads the runner module by path; reuse it, do not write a new
+   loader.
+
+   The file does NOT currently import `argparse`. Add `import argparse` to the
+   import block at the top of the file, in alphabetical order (it goes before
+   `import asyncio`).
+
+   Then append this block at the end of the file:
+
+```python
+# ---------------------------------------------------------------------------
+# 7. a refusal must abort with a non-zero exit
+# ---------------------------------------------------------------------------
+
+def _args(**overrides):
+    base = dict(
+        tier="eventqa_65536",
+        contexts=1,
+        limit=1,
+        llm=False,
+        graph_expansion=512,
+        retrieval_path="retrieve",
+        report_retrieval_delta=False,
+        out="",
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_unsupported_graph_expansion_aborts_the_run(runner, monkeypatch):
+    """The safety-critical case: refuse rather than run two identical arms."""
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", lambda: False)
+
+    opened = []
+    monkeypatch.setattr(
+        runner, "load_eventqa_rows",
+        lambda tier, contexts: opened.append("loaded") or [],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        asyncio.run(runner.run(_args()))
+
+    # Non-zero exit: a chain that checks $? must read a refusal as a failure.
+    assert exc.value.code != 0
+    assert opened == [], "the dataset must not even be loaded after a refusal"
+
+
+def test_empty_dataset_aborts_the_run(runner, monkeypatch):
+    """No rows loaded is an instrument failure, not an empty success."""
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", lambda: True)
+    monkeypatch.setattr(runner, "load_eventqa_rows", lambda tier, contexts: [])
+
+    with pytest.raises(SystemExit) as exc:
+        asyncio.run(runner.run(_args()))
+
+    assert exc.value.code != 0
+
+
+def test_zero_graph_expansion_never_probes(runner, monkeypatch):
+    """graph_expansion=0 must run on any checkout, probe or no probe."""
+    def _boom():
+        raise AssertionError("probe must not gate the default arm")
+
+    monkeypatch.setattr(runner, "retrieve_supports_graph_expansion", _boom)
+    monkeypatch.setattr(runner, "load_eventqa_rows", lambda tier, contexts: [])
+
+    # Still aborts, but on the empty dataset, not on the probe.
+    with pytest.raises(SystemExit):
+        asyncio.run(runner.run(_args(graph_expansion=0)))
+```
+
+5. Run just the new tests and watch them FAIL:
+   `python3 -m pytest tests/test_eventqa_retrieve_wiring.py -q`
+   The two abort tests must fail with "DID NOT RAISE SystemExit". If they
+   pass before you have changed the runner, something is different from what
+   this job describes: STOP per rule 9.
+6. Now fix `benchmarks/eventqa_runner.py`. Change ONLY the two `return`
+   statements named above to `sys.exit(1)`.
+
+   The probe refusal becomes:
+
+```python
+    # Refuse rather than silently run two identical arms. Exits non-zero on
+    # purpose so an automated chain checking $? reads a refusal as a failure.
+    if args.graph_expansion and not retrieve_supports_graph_expansion():
+        print(
+            "  ERROR: the installed taosmd.retrieval.retrieve() has no "
+            "graph_expansion parameter, so both E-025 arms would be identical. "
+            "Run this on a checkout that includes the bi-temporal fact-readback "
+            "work (PR #191).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+```
+
+   The empty-rows refusal becomes:
+
+```python
+    rows = load_eventqa_rows(args.tier, args.contexts)
+    if not rows:
+        print("  ERROR: no rows loaded for tier", args.tier, file=sys.stderr)
+        sys.exit(1)
+```
+
+   Do not change the wording of either message. Do not add any other
+   `sys.exit` call anywhere in the file.
+7. Re-run the file: `python3 -m pytest tests/test_eventqa_retrieve_wiring.py -q`
+   (all green), then the FULL suite
+   `python3 -m pytest -q -m "not slow"`, then
+   `python3 -m ruff check benchmarks/eventqa_runner.py tests/test_eventqa_retrieve_wiring.py`.
+8. One commit, push, open the PR. PR body: the bug (a refusal exited 0 so a
+   chain read it as success), the fix (`sys.exit(1)` on both refusal paths,
+   the dry-run success return untouched), the reference it copies
+   (PR #204 for the LongMemEval runner), and the test count. Reference
+   issue #205. Do not merge.
+
+## STOP conditions
+
+- If `run()` is not an `async def` taking `args`, or the two `ERROR:` returns
+  are not where this job says, STOP and describe what you found in the PR
+  body.
+- If the full suite has failures you did not cause, STOP, open the PR with
+  what you have, and say which tests failed.
+- Issue #205 also asks whether OTHER runners under `benchmarks/` refuse
+  without a non-zero exit. That is a survey, not this job. Do NOT go looking,
+  and do NOT edit any other runner. If you happen to notice one, write the
+  filename in the PR body as a note and leave it alone.

--- a/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
+++ b/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
@@ -131,8 +131,13 @@ def test_zero_graph_expansion_never_probes(runner, monkeypatch):
     monkeypatch.setattr(runner, "load_eventqa_rows", lambda tier, contexts: [])
 
     # Still aborts, but on the empty dataset, not on the probe.
-    with pytest.raises(SystemExit):
+    # Assert the CODE, not just that SystemExit was raised: this whole job
+    # exists because a refusal exited 0, and a bare pytest.raises(SystemExit)
+    # passes on sys.exit(0) too. A test that cannot fail on the original bug
+    # is not evidence.
+    with pytest.raises(SystemExit) as exc:
         asyncio.run(runner.run(_args(graph_expansion=0)))
+    assert exc.value.code != 0
 ```
 
 5. Run just the new tests and watch them FAIL:

--- a/docs/agent-jobs/job-005-collections-db-connect.md
+++ b/docs/agent-jobs/job-005-collections-db-connect.md
@@ -1,0 +1,122 @@
+# JOB-005: Open collections.db through the shared _db.connect helper
+
+Read docs/agent-jobs/README.md first and follow its absolute rules.
+
+- Tracks issue #202.
+- Branch: `fix/collections-db-connect` (from `origin/master`)
+- Commit message: `fix(collections): open collections.db through _db.connect for WAL and a busy timeout`
+- PR title: `fix(collections): open collections.db through _db.connect for WAL and a busy timeout`
+- Allowed files: `taosmd/collections.py`, `tests/test_collections_db_connect.py`
+  (new) ONLY.
+
+## The bug
+
+Every persistent store in the package opens its database through
+`taosmd/_db.py`'s `connect` helper, which enables WAL and sets a busy timeout
+so a contended writer waits and retries instead of failing immediately with
+`database is locked`. `CollectionStore` alone uses a bare `sqlite3.connect`.
+
+`taosmd/collections.py` line 116:
+
+```python
+        self._conn = sqlite3.connect(str(path / "collections.db"))
+```
+
+Collections indexing runs on the service loop and can overlap with search
+requests that read collection rows and grants, so this is a latent
+concurrency failure, not only an inconsistency.
+
+This has already been checked for you: nothing in `CollectionStore` reads or
+depends on the journal mode. There is no `PRAGMA journal_mode`, no `VACUUM`,
+no `ATTACH`, no `isolation_level` handling, and no test asserting the files
+present in the data directory. So this is a genuine one-line swap. If you
+find otherwise, that changes the job: STOP per the STOP conditions below.
+
+## Steps
+
+1. `git fetch origin && git checkout -b fix/collections-db-connect origin/master`
+2. Read `taosmd/_db.py` in full (about 60 lines) and
+   `taosmd/collections.py` from line 100 to line 165.
+3. Confirm for yourself that nothing depends on the journal mode:
+
+```
+grep -n "journal\|VACUUM\|ATTACH\|isolation_level\|backup" taosmd/collections.py
+```
+
+   This must print nothing. If it prints anything, STOP.
+4. Write the test FIRST, in a new file `tests/test_collections_db_connect.py`:
+
+```python
+"""collections.db must be opened like every other store: WAL, busy timeout."""
+
+from taosmd.collections import CollectionStore
+
+
+def test_collections_db_is_in_wal_mode(tmp_path):
+    store = CollectionStore(tmp_path)
+    try:
+        mode = store._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+    finally:
+        store.close()
+
+
+def test_collections_db_has_a_busy_timeout(tmp_path):
+    store = CollectionStore(tmp_path)
+    try:
+        timeout = store._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout > 0
+    finally:
+        store.close()
+```
+
+5. Run it and watch it FAIL:
+   `python3 -m pytest tests/test_collections_db_connect.py -q`
+   Expect the journal-mode test to report `delete` instead of `wal`. If it
+   already passes, the fix is already in: STOP and say so in a PR comment
+   rather than committing a no-op.
+6. Fix `taosmd/collections.py`. Two edits, nothing else:
+
+   a. Add the import. The file already has other relative imports; put this
+      one with them, matching the style used in `taosmd/access_tracker.py`:
+
+```python
+from . import _db
+```
+
+   b. Change line 116 from
+
+```python
+        self._conn = sqlite3.connect(str(path / "collections.db"))
+```
+
+   to
+
+```python
+        self._conn = _db.connect(str(path / "collections.db"))
+```
+
+   Leave the `self._conn.row_factory = sqlite3.Row` line immediately below it
+   exactly as it is. Do NOT remove `import sqlite3` from the top of the file:
+   `sqlite3.Row` still needs it. Confirm with
+   `grep -n "sqlite3\." taosmd/collections.py` that other uses remain.
+7. `python3 -m pytest tests/test_collections_db_connect.py -q` (2 passed),
+   then the FULL suite `python3 -m pytest -q -m "not slow"`, then
+   `python3 -m ruff check taosmd/collections.py tests/test_collections_db_connect.py`.
+8. One commit, push, open the PR. PR body: the inconsistency, the one-line
+   fix, confirmation that nothing in the store depended on the journal mode,
+   and the test count. Reference issue #202. Do not merge.
+
+## STOP conditions
+
+- If the grep in step 3 finds anything, or any existing test asserts which
+  files exist in the data directory, STOP. WAL creates `collections.db-wal`
+  and `collections.db-shm` sidecar files, and a test that counted files would
+  now fail. That makes this a judgment call rather than a swap, so it stops
+  being your job. Open the PR with the test only, describe what you found,
+  and stop.
+- If the full suite shows failures in collections tests after the swap, do
+  NOT start adjusting those tests. STOP, open the PR with what you have, and
+  list the failures.
+- Issue #202 is one of several databases-and-schema issues. Do not touch any
+  other store, and do not go near `taosmd/migrations.py`.

--- a/docs/agent-jobs/job-005-collections-db-connect.md
+++ b/docs/agent-jobs/job-005-collections-db-connect.md
@@ -40,7 +40,7 @@ find otherwise, that changes the job: STOP per the STOP conditions below.
 3. Confirm for yourself that nothing depends on the journal mode:
 
 ```
-grep -n "journal\|VACUUM\|ATTACH\|isolation_level\|backup" taosmd/collections.py
+grep -E -n "journal|VACUUM|ATTACH|isolation_level|backup" taosmd/collections.py
 ```
 
    This must print nothing. If it prints anything, STOP.


### PR DESCRIPTION
The pack was written 2026-06-12 and has not been touched since. The weekly
usage gate is close, so this verifies every existing job against current
master and adds the jobs worth handing over from today's issue triage.

## Verified, still open

- **JOB-001** (em dashes in docs/benchmarks.md). `grep -c` prints 120 on
  master, so the sweep never happened. Job says "roughly 121"; corrected to
  120 and added a Status line.
- **JOB-003** (dead importlib block in `_webui_dir`). Still present. The
  function moved from around line 112 to around line 165 and `_pkg_files`
  moved to line 155, so the job's line numbers were stale. Confirmed
  `_pkg_files` still has exactly one user, the dead block itself, so step 4
  will resolve to "remove that import too". Status line added with the
  current locations.

## Put ON HOLD, and this one matters

**JOB-002** (cross-encoder default path). The bug is real and unfixed:
`cross_encoder.py` line 21 still defaults to the relative
`"models/cross-encoder-onnx"`. But the fix the job spells out would make
things worse, so it must not be handed to an agent that will follow it
literally.

`api.py` line 635 builds `CrossEncoderReranker()` with no argument, and line
641 calls `_recipes.ensure_reranker_model(block=False)`. That function has
its own independent copy of the same relative default at `recipes.py` line
457, and it is the download destination. JOB-002 changes only the reader. The
result would be a downloader writing to `$CWD/models/` and a reader looking
in the repo root, so `available` never becomes true and a fresh deployment
re-fires a roughly 600MB download on every search. Resolving against the repo
root is also wrong for a wheel install, where the repo root is site-packages
and is not writable.

This is the same ground as #199, which asks for the embedder's
`_resolve_onnx_path(data_dir, ...)` mechanism or an env override, and
separately asks whether a live search should be pulling 600MB at all.
Choosing between those is a design decision. The job file is kept for history
with a do-not-start banner and the reasoning.

## Added

- **JOB-004**, from #205. The EventQA runner prints an ERROR and bare-returns
  when it refuses to run, so it exits 0 and a chain checking `$?` reads the
  refusal as success. PR #204 does exactly this fix for the LongMemEval
  runner, so the job points at
  `benchmarks/longmemeval_runner.py` and `tests/test_longmemeval_retrieve_wiring.py`
  on `feat/longmemeval-retrieve-wiring` as a worked reference to copy, with
  `git show` commands so nothing gets merged in by accident. The job covers
  both fails-open returns (the support probe and the empty-rows check) and
  explicitly fences off a third bare return nearby that is a legitimate
  dry-run success path.
- **JOB-005**, from #202. `CollectionStore` uses a bare `sqlite3.connect`
  while every other store goes through `_db.connect`. Checked the
  precondition the issue raises: `collections.py` has no `PRAGMA
  journal_mode`, no `VACUUM`, no `ATTACH`, no `isolation_level` handling, and
  nothing in the tests asserts which files exist in the data dir. So it is a
  genuine one-line swap plus an import. The job includes the grep as a step
  and stops the agent if it finds anything, since WAL adds `-wal` and `-shm`
  sidecar files.

## Rejected

- **#203** (six databases unregistered with the migration framework). Left
  out. It is blocked on PR #201, which is not merged, and the API is still
  moving (the branch has already taken two rounds of review fixes). More to
  the point, the issue's claim that each entry is mechanical does not hold:
  a `REGISTRY` entry needs a `Migration` with a `detect` probe written
  against that database's real baseline schema, and PR #201's own validator
  docstring says a wrong probe stamps the wrong version against a live store
  rather than raising. That is the silent-corruption class the framework
  exists to prevent, and it is not weak-agent work. The `knowledge-graph.db`
  two-schema-owners half is design work outright.
- **#206** (CLI silently operating on a remote store). Left out. Two proposed
  options, one of which is a breaking change for anyone scripting against a
  remote. Picking between them is the actual work.

## Also

Rule 7 said to expect "roughly 850 tests". The suite is well past that now,
so the rule asks for the exact number in the PR body instead of naming a
figure that will go stale again. The README index now carries a status column
and a section recording the rejected candidates, so the next refresh does not
re-litigate them.

Docs only, no code touched. Not merging; for review on wake.