### PR TITLE
tsk-leewzc  [OPEN]  Make dev+test deps install by default: move to [de

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,16 @@ mcp = ["mcp"]
 # Install with: pip install taosmd[registry]
 registry = ["pyjwt>=2.8", "cryptography>=42"]
 
+# PEP 735 dependency groups. uv syncs these BY DEFAULT, so a bare `uv sync`
+# from a clean checkout yields a working test environment with no flags.
+# The `dev` group duplicates the auth deps from the `registry` extra on
+# purpose: the extra is the opt-in RUNTIME path (pip install taosmd[registry]),
+# while this group is the default-INSTALLED path for running the test suite.
+# Keeping both lets pip users keep using extras and uv users get tests for
+# free, without putting pyjwt/cryptography in core [project] dependencies.
+[dependency-groups]
+dev = ["pytest", "pytest-asyncio", "pyjwt>=2.8", "cryptography>=42"]
+
 [tool.setuptools.packages.find]
 include = ["taosmd*"]
 


### PR DESCRIPTION
Autonomous build of board card tsk-leewzc.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 pyproject.toml | 10 ++++++++++
 1 file changed, 10 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a standardized development dependency group for consistent test and development environment setup.
  * Included optional authentication and registry-related development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->