### PR TITLE
A2A ref resolution + fetch auth: make a #212 ref fetchable cross-machine (reduced file-sharing, 1481)

### DIFF
--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -484,6 +484,36 @@ def _a2a_bridge_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
+def _a2a_fetch_ref_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd a2a-fetch-ref``: fetch bytes for a taOS Files-backed ref."""
+    import asyncio  # noqa: PLC0415
+    import base64  # noqa: PLC0415
+
+    from . import service  # noqa: PLC0415
+    from .ref_fetch import RefFetchError  # noqa: PLC0415
+
+    data_dir = args.data_dir
+    try:
+        ref = json.loads(args.ref_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        print(f"error: invalid ref JSON: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        result = asyncio.run(service.fetch_by_ref(ref, agent="cli", data_dir=data_dir))
+    except RefFetchError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    raw = base64.b64decode(result["bytes"])
+    if args.output:
+        Path(args.output).write_bytes(raw)
+        print(f"wrote {result['size']} bytes to {args.output}")
+    else:
+        sys.stdout.buffer.write(raw)
+    return 0
+
+
 def _a2a_poll_cmd(args: argparse.Namespace) -> int:
     """Handle ``taosmd a2a-poll``: fetch new messages and update state file."""
     import asyncio  # noqa: PLC0415
@@ -1683,6 +1713,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Exit after firing the trigger N times (default 0 = run forever)",
     )
 
+    # ----- a2a-fetch-ref subcommand ---------------------------------------
+    fetch_ref_p = sub.add_parser(
+        "a2a-fetch-ref",
+        help="Fetch bytes for a taOS Files-backed ref and verify its sha256",
+    )
+    fetch_ref_p.add_argument(
+        "ref_json",
+        help="JSON object with uri and sha256 fields",
+    )
+    fetch_ref_p.add_argument(
+        "--output", "-o", default=None,
+        help="Write bytes to FILE instead of stdout",
+    )
+
     # ----- serve subcommand (local HTTP/REST API) -----------------------
     serve_p = sub.add_parser(
         "serve",
@@ -1959,6 +2003,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "a2a-bridge":
         return _a2a_bridge_cmd(args)
+
+    if args.cmd == "a2a-fetch-ref":
+        return _a2a_fetch_ref_cmd(args)
 
     if args.cmd == "serve":
         from . import service_install  # noqa: PLC0415

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -39,6 +39,9 @@ _ADMIN_TOKEN_KEY = "admin_token"
 # Key under which the global default recipe id is stored.
 _DEFAULT_RECIPE_KEY = "default_recipe"
 _REGISTRY_URL_KEY = "registry_url"
+# Key under which the optional taOS Files base URL is stored.
+# Used by the ref-fetch helper to resolve taos:// refs to concrete endpoints.
+_FILES_URL_KEY = "files_url"
 # Key under which the registry auth token (taOS local/admin token) is stored.
 # Used to poll the auth-gated registry revoked feed; the pubkey feed is public.
 _REGISTRY_TOKEN_KEY = "registry_token"
@@ -416,6 +419,53 @@ def set_registry_token(token: str, clear: bool = False, data_dir=None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# taOS Files base URL (ref-fetch helper)
+# ---------------------------------------------------------------------------
+
+def get_files_url(data_dir=None) -> str | None:
+    """Return the configured taOS Files base URL, or ``None`` if unset.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_FILES_URL`` environment variable
+    2. ``files_url`` key in ``~/.taosmd/config.json``
+
+    When set, the ref-fetch helper resolves ``taos://`` refs against this
+    controller. When unset, the helper falls back to ``registry_url`` so a
+    single-controller install needs only one setting.
+    """
+    env = os.environ.get("TAOSMD_FILES_URL")
+    if env and env.strip():
+        return env.strip()
+    url = _read(data_dir).get(_FILES_URL_KEY)
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+    return None
+
+
+def set_files_url(url: str, clear: bool = False, data_dir=None) -> None:
+    """Persist the taOS Files base URL (or clear it).
+
+    Args:
+        url: Base URL of the taOS controller serving the Files API, e.g.
+            ``"http://taos:8000"``. Ignored when ``clear`` is True.
+        clear: when True, remove the setting (ref-fetch falls back to
+            ``registry_url``).
+
+    Raises:
+        ValueError: when ``clear`` is False and ``url`` is not a non-empty string.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_FILES_URL_KEY, None)
+    else:
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("url must be a non-empty string (or pass clear=True)")
+        data[_FILES_URL_KEY] = url.strip()
+    _write(data, data_dir)
+
+
+# ---------------------------------------------------------------------------
 # Remote server bearer token
 # ---------------------------------------------------------------------------
 
@@ -683,6 +733,8 @@ __all__ = [
     "set_registry_url",
     "get_registry_token",
     "set_registry_token",
+    "get_files_url",
+    "set_files_url",
     "get_managed_by",
     "set_managed_by",
     "get_serve_dashboard",

--- a/taosmd/mcp_server.py
+++ b/taosmd/mcp_server.py
@@ -251,6 +251,18 @@ def build_server(data_dir=None, *, runner: _ServiceLoop | None = None):
             )
         )
 
+    @mcp.tool()
+    async def a2a_fetch_ref(ref: dict, agent: str) -> dict:
+        """Fetch bytes for a taOS Files-backed ref and verify its sha256.
+
+        ``ref`` must be a dict with ``uri`` (a ``taos://`` uri) and ``sha256``.
+        Returns ``{"bytes": <base64-str>, "sha256": <hash>, "size": <int>}``
+        on success, or raises a typed error (mismatch / not-found / unauthorized).
+        """
+        return await _dispatch(
+            service.fetch_by_ref(ref, agent=agent, data_dir=data_dir)
+        )
+
     # ---- Task graph tools -------------------------------------------------------
 
     @mcp.tool()

--- a/taosmd/ref_fetch.py
+++ b/taosmd/ref_fetch.py
@@ -1,0 +1,147 @@
+"""Resolve and fetch taOS Files-backed refs with hash verification.
+
+A ref uri of the form ``taos://<project-slug>/files/<path>`` is resolved to
+``GET /api/projects/{slug}/files/{path}`` on the configured controller. The
+fetch helper verifies the returned bytes against the ref's ``sha256`` and
+returns the verified bytes or a typed error.
+
+No new server storage is introduced: this is purely a client-side helper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import urllib.parse
+
+
+class RefFetchError(Exception):
+    """Base error for ref fetch failures."""
+
+
+class HashMismatchError(RefFetchError):
+    """Raised when the fetched bytes do not match the ref's sha256."""
+
+
+class NotFoundError(RefFetchError):
+    """Raised when the Files API reports the resource is missing."""
+
+
+class UnauthorizedError(RefFetchError):
+    """Raised when the Files API reports an auth failure."""
+
+
+_SCHEME_PREFIX = "taos://"
+_FILES_SEGMENT = "files/"
+
+
+def resolve_ref_uri(ref: dict, files_url: str) -> str:
+    """Map a taos:// ref uri to the concrete Files API fetch endpoint.
+
+    Args:
+        ref: A ref dict with at least a ``uri`` field.
+        files_url: Base URL of the taOS controller (same config family as
+            ``registry_url``).
+
+    Returns:
+        The full URL for ``GET /api/projects/{slug}/files/{path}``.
+
+    Raises:
+        ValueError: If the uri scheme is not ``taos://`` or the shape is invalid.
+    """
+    uri = ref.get("uri", "")
+    if not isinstance(uri, str) or not uri.startswith(_SCHEME_PREFIX):
+        raise ValueError(
+            f"unsupported uri scheme: {uri!r} (only taos:// is accepted)"
+        )
+    rest = uri[len(_SCHEME_PREFIX):]
+    parts = rest.split("/", 1)
+    if len(parts) != 2 or not parts[1].startswith(_FILES_SEGMENT):
+        raise ValueError(
+            f"invalid taos ref uri: {uri!r} (expected taos://<slug>/files/<path>)"
+        )
+    slug = urllib.parse.quote(parts[0], safe="")
+    path = parts[1][len(_FILES_SEGMENT):]
+    if not path:
+        raise ValueError(
+            f"invalid taos ref uri: {uri!r} (path is empty)"
+        )
+    encoded_path = urllib.parse.quote(path, safe="/")
+    base = files_url.rstrip("/")
+    return f"{base}/api/projects/{slug}/files/{encoded_path}"
+
+
+async def fetch_by_ref(ref: dict, fetcher, agent: str) -> bytes:
+    """Fetch bytes for a ref using an injected fetcher and verify the hash.
+
+    Args:
+        ref: A ref dict with ``uri`` and ``sha256`` fields.
+        fetcher: A callable ``fetcher(url: str, agent: str) -> bytes`` that
+            performs the HTTP GET and returns the raw response body. It should
+            raise :class:`NotFoundError` or :class:`UnauthorizedError` for
+            those HTTP status codes.
+        agent: The agent identity (passed to ``fetcher`` for auth context).
+
+    Returns:
+        The verified raw bytes.
+
+    Raises:
+        ValueError: If the uri cannot be resolved.
+        HashMismatchError: If the fetched bytes' sha256 does not match ref.sha256.
+        NotFoundError: If the fetcher reports the resource is missing.
+        UnauthorizedError: If the fetcher reports an auth failure.
+        RefFetchError: For other fetch failures.
+    """
+    import asyncio
+
+    files_url = _get_files_url()
+    url = resolve_ref_uri(ref, files_url)
+    loop = asyncio.get_running_loop()
+    raw = await loop.run_in_executor(None, fetcher, url, agent)
+    expected = ref.get("sha256")
+    if not expected:
+        raise RefFetchError("ref has no sha256")
+    actual = hashlib.sha256(raw).hexdigest()
+    if actual != expected:
+        raise HashMismatchError(
+            f"sha256 mismatch: expected {expected}, got {actual}"
+        )
+    return raw
+
+
+def _get_files_url() -> str:
+    """Resolve the files base URL from env or config.
+
+    Falls back to ``registry_url`` when ``files_url`` is unset, so a
+    single-controller install needs only one setting.
+    """
+    env = os.environ.get("TAOSMD_FILES_URL")
+    if env and env.strip():
+        return env.strip()
+    try:
+        from .config import get_files_url
+        url = get_files_url()
+        if url:
+            return url
+    except Exception:
+        pass
+    try:
+        from .config import get_registry_url
+        url = get_registry_url()
+        if url:
+            return url
+    except Exception:
+        pass
+    raise RefFetchError(
+        "files_url is not configured: set TAOSMD_FILES_URL or files_url in config.json"
+    )
+
+
+__all__ = [
+    "RefFetchError",
+    "HashMismatchError",
+    "NotFoundError",
+    "UnauthorizedError",
+    "resolve_ref_uri",
+    "fetch_by_ref",
+]

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -400,5 +400,12 @@ class RemoteClient:
             {"to_id": to_id, "type": edge_type},
         )
 
+    async def fetch_by_ref(self, ref: dict, agent: str, **opts) -> dict:
+        """POST /refs/fetch: proxy a ref fetch to the remote server.
+
+        Returns ``{"bytes": <base64-str>, "sha256": <hash>, "size": <int>}``.
+        """
+        return await self._run("POST", "/refs/fetch", {"ref": ref, "agent": agent})
+
 
 __all__ = ["RemoteClient"]

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -25,6 +25,7 @@ server, and Python API all go remote transparently.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 
@@ -339,6 +340,61 @@ async def stats(*, agent: str, data_dir=None) -> dict:
         total_chunks=record.get("total_chunks", 0),
     )
     return out
+
+
+async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
+    """Fetch and verify bytes for a taOS Files-backed ref.
+
+    Thin wrapper over :func:`taosmd.ref_fetch.fetch_by_ref`. Resolves the
+    controller base URL from config, builds a fetcher that authenticates with
+    the registry token, and returns the verified bytes as a base64-encoded
+    string together with its sha256 and size.
+
+    Returns ``{"bytes": <base64-str>, "sha256": <hash>, "size": <int>}``.
+
+    Raises :class:`ValueError` for an unresolvable uri,
+    :class:`~taosmd.ref_fetch.HashMismatchError` for a hash mismatch,
+    :class:`~taosmd.ref_fetch.NotFoundError` for a 404, or
+    :class:`~taosmd.ref_fetch.UnauthorizedError` for a 401/403.
+    """
+    import base64
+
+    from . import config as _config
+    from .ref_fetch import HashMismatchError, NotFoundError, RefFetchError, UnauthorizedError, fetch_by_ref as _fetch_by_ref
+
+    files_url = _config.get_files_url(data_dir)
+    if not files_url:
+        raise RefFetchError(
+            "files_url is not configured: set TAOSMD_FILES_URL or files_url in config.json"
+        )
+    registry_token = _config.get_registry_token(data_dir)
+
+    def _fetcher(url: str, agent: str) -> bytes:
+        import urllib.error
+        import urllib.request
+
+        headers = {"Accept": "application/octet-stream"}
+        if registry_token:
+            headers["Authorization"] = f"Bearer {registry_token}"
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise UnauthorizedError(f"HTTP {exc.code} from {url}") from exc
+            if exc.code == 404:
+                raise NotFoundError(f"HTTP 404 from {url}") from exc
+            raise
+        except urllib.error.URLError as exc:
+            raise RefFetchError(f"fetch failed for {url}: {exc}") from exc
+
+    raw = await _fetch_by_ref(ref, _fetcher, agent)
+    return {
+        "bytes": base64.b64encode(raw).decode("ascii"),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "size": len(raw),
+    }
 
 
 async def a2a_send(
@@ -1034,6 +1090,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
+           "fetch_by_ref",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",
            "admin_a2a_supersede_message",

--- a/tests/test_config_files_url.py
+++ b/tests/test_config_files_url.py
@@ -1,0 +1,42 @@
+"""Tests for the opt-in Files URL config (drives ref-fetch helper).
+
+When unset, the ref-fetch helper falls back to ``registry_url``. When set
+(env or config file), the helper resolves ``taos://`` refs against this base.
+"""
+from __future__ import annotations
+
+import pytest
+
+from taosmd import config
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("TAOSMD_FILES_URL", raising=False)
+    return str(tmp_path)
+
+
+def test_unset_is_none(data_dir):
+    assert config.get_files_url(data_dir) is None
+
+
+def test_set_then_get_round_trip(data_dir):
+    config.set_files_url("http://files.local:8000", data_dir=data_dir)
+    assert config.get_files_url(data_dir) == "http://files.local:8000"
+
+
+def test_env_overrides_config_file(data_dir, monkeypatch):
+    config.set_files_url("http://from-file:8000", data_dir=data_dir)
+    monkeypatch.setenv("TAOSMD_FILES_URL", "http://from-env:8000")
+    assert config.get_files_url(data_dir) == "http://from-env:8000"
+
+
+def test_clear_returns_none(data_dir):
+    config.set_files_url("http://files.local:8000", data_dir=data_dir)
+    config.set_files_url("", clear=True, data_dir=data_dir)
+    assert config.get_files_url(data_dir) is None
+
+
+def test_set_empty_string_raises(data_dir):
+    with pytest.raises(ValueError):
+        config.set_files_url("", data_dir=data_dir)

--- a/tests/test_ref_fetch.py
+++ b/tests/test_ref_fetch.py
@@ -1,0 +1,146 @@
+"""Tests for taosmd.ref_fetch: resolver + verified fetch helper."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+
+import pytest
+
+from taosmd.ref_fetch import (
+    HashMismatchError,
+    NotFoundError,
+    RefFetchError,
+    UnauthorizedError,
+    fetch_by_ref,
+    resolve_ref_uri,
+)
+
+
+# ---------------------------------------------------------------------------
+# Resolver tests
+# ---------------------------------------------------------------------------
+
+class TestResolveRefUri:
+    def test_taos_uri_maps_to_files_endpoint(self):
+        ref = {"uri": "taos://myproj/files/docs/readme.md", "sha256": "abc123"}
+        url = resolve_ref_uri(ref, "http://controller:8000")
+        assert url == "http://controller:8000/api/projects/myproj/files/docs/readme.md"
+
+    def test_taos_uri_with_special_characters_is_quoted(self):
+        ref = {"uri": "taos://my proj/files/path with spaces/file.txt", "sha256": "abc123"}
+        url = resolve_ref_uri(ref, "http://controller:8000")
+        assert "my%20proj" in url
+        assert "path%20with%20spaces" in url
+        assert url == "http://controller:8000/api/projects/my%20proj/files/path%20with%20spaces/file.txt"
+
+    def test_non_taos_uri_raises(self):
+        ref = {"uri": "https://example.com/file", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_empty_uri_raises(self):
+        ref = {"uri": "", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_missing_uri_field_raises(self):
+        ref = {"sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_invalid_taos_shape_raises(self):
+        ref = {"uri": "taos://myproj", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="invalid taos ref uri"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_taos_uri_without_files_segment_raises(self):
+        ref = {"uri": "taos://myproj/other/file.txt", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="invalid taos ref uri"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_taos_uri_empty_path_raises(self):
+        ref = {"uri": "taos://myproj/files/", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="path is empty"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+
+# ---------------------------------------------------------------------------
+# fetch_by_ref tests
+# ---------------------------------------------------------------------------
+
+class TestFetchByRef:
+    def test_fetch_match_returns_verified_bytes(self, monkeypatch):
+        content = b"hello world"
+        expected_sha = hashlib.sha256(content).hexdigest()
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": expected_sha}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        captured = {}
+
+        def fake_fetcher(url, agent):
+            captured["url"] = url
+            captured["agent"] = agent
+            return content
+
+        result = asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+        assert result == content
+        assert captured["url"] == "http://ctrl:8000/api/projects/proj/files/hello.txt"
+        assert captured["agent"] == "test-agent"
+
+    def test_fetch_mismatch_raises_hash_error_bytes_not_returned(self, monkeypatch):
+        content = b"hello world"
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "deadbeef" * 8}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            return content
+
+        with pytest.raises(HashMismatchError, match="sha256 mismatch"):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_fetcher_not_found_propagates(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/missing.txt", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise NotFoundError(f"HTTP 404 from {url}")
+
+        with pytest.raises(NotFoundError):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_fetcher_unauthorized_propagates(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/secret.txt", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise UnauthorizedError(f"HTTP 401 from {url}")
+
+        with pytest.raises(UnauthorizedError):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_non_taos_ref_raises_before_fetch(self, monkeypatch):
+        ref = {"uri": "https://example.com/file", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise AssertionError("fetcher should not be called for non-taos:// uri")
+
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_ref_without_sha256_raises(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/hello.txt"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            return b"data"
+
+        with pytest.raises(RefFetchError, match="no sha256"):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A ref resolution + fetch auth: make a #212 ref fetchable cross-machine (reduced file-sharing, 1481)

Autonomous build of board card tsk-doocq4.

Adds a client-side fetch-by-ref helper that resolves taos://<slug>/files/<path>
URIs to the controller Files API endpoint, fetches bytes using the registry
credential path, and verifies the returned content against the ref sha256.

- taosmd/config.py: new files_url config key (env TAOSMD_FILES_URL, config.json
  files_url), falls back to registry_url for single-controller installs
- taosmd/ref_fetch.py: resolve_ref_uri maps taos:// URIs to /api/projects/{slug}/files/{path},
  fetch_by_ref verifies sha256 and returns bytes or typed errors (mismatch,
  not-found, unauthorized)
- taosmd/service.py: thin wrapper that builds a registry-token-authenticated
  fetcher and returns base64-encoded verified bytes
- taosmd/remote.py: RemoteClient.fetch_by_ref proxy endpoint
- taosmd/mcp_server.py: a2a_fetch_ref MCP tool
- taosmd/cli.py: a2a-fetch-ref subcommand with --output flag
- tests: unit tests for resolver, fetch-match, fetch-mismatch-rejected,
  non-taos-refused, and files_url config round-trip

Files:
 taosmd/config.py               |  52 +++++++++++++++
 taosmd/mcp_server.py           |  12 ++++
 taosmd/ref_fetch.py            | 147 +++++++++++++++++++++++++++++++++++++++++
 taosmd/remote.py               |   7 ++
 taosmd/service.py              |  57 ++++++++++++++++
 tests/test_config_files_url.py |  42 ++++++++++++
 tests/test_ref_fetch.py        | 146 ++++++++++++++++++++++++++++++++++++++++
 8 files changed, 510 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fetching and verifying referenced files through the CLI, MCP tools, and remote service.
  * Added configuration for the Files service URL, including environment-variable and saved settings support.
  * Fetched content includes verified SHA-256 metadata and size information.
  * Added clear handling for invalid references, missing files, authorization failures, and verification mismatches.

* **Tests**
  * Added coverage for Files URL configuration, reference resolution, fetching, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->