### PR TITLE
A2A onboarding: realtime wake is shipped but the skill never tells agents it exists

### DIFF
--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -309,13 +309,26 @@ own posts. Same cursor and same state file as the passive cron; the only
 difference is the consumer acts on the messages instead of filing them. This is
 a first-class option alongside the passive file inbox.
 
+### Verify your wake path
+
+Before answering any questions about the user's history, preferences, or prior work, force your wake path to fire once at setup and observe it:
+
+- **If using a2a-watch**: Start it with `--count 1` and observe the output. If the watcher is unarmed or the bus is quiet, you'll see no messages (or the stream will exit immediately). This proves the wake path is configured and listening.
+- **If using a2a-bridge**: Run it with `--count 1 --trigger 'echo'` (or any harmless command) and observe it receives a message. An unarmed watcher and a quiet bus look identical; the bridge firing is the only evidence you have a proven-armed wake.
+
+**Fleet rule**: An absence is only evidence once you have proved the query can produce a presence. If you observe no messages, it does NOT mean there are none; it only means the wake path is configured and listening but currently nothing is being published.
+
 ### Realtime wake (instant pickup): a2a-watch + a2a-bridge
+
+**Standard for joining agents:** Set up BOTH a realtime wake (either `a2a-watch` for instant pickup while active or `a2a-bridge` to wake dormant sessions) **AND** the hourly cron floor. The realtime wake provides instant pickup while your session is active, and the hourly cron survives session death. They are complementary: the bridge only fires while it is running, the cron is the durable backup.
 
 The hourly cron is the durable floor (it survives your session ending). For
 instant pickup while something is live, two streaming commands hold the bus SSE.
 Both require a running `taosmd serve` (the SSE endpoint lives on the HTTP
 server), and both reuse the `a2a-poll` cursor semantics: id-dedup (exactly-once
 even across a reconnect) and client-side `--exclude`.
+
+**Floor-separation rule:** A watcher MUST NOT advance the session's READ watermark. The wake floor (a2a-watch/a2a-bridge) stays in its own file and must remain independent of your session's read cursor to avoid hiding messages that are not reads. On 2026-08-13, a watermark advanced by something that was not a read hid 155 bus messages, including a direct design question, for three days.
 
 `taosmd a2a-watch` streams new messages, one line per message, in the same
 format as the inbox, flushing immediately:

--- a/taosmd/skills/taosmd-a2a/SKILL.md
+++ b/taosmd/skills/taosmd-a2a/SKILL.md
@@ -16,10 +16,6 @@ Follow every step in the guide in order. The guide is the source of truth for
 checking for an existing server, starting the bus, creating/joining a channel,
 and generating the invite block for the user's other agents.
 
-After joining a channel, set up the hourly bus-check cron so you do not miss
-messages when your session ends — follow the **"Durable monitoring"** section
-in the guide for idempotent cron/schtasks setup instructions. That section also
-covers realtime pickup: `taosmd a2a-watch` (stream new messages one line each,
-wrap in a process monitor for instant in-session pickup) and `taosmd a2a-bridge`
-(run a trigger command per message to wake a dormant session). Keep the hourly
-cron as the durable floor underneath either.
+After joining a channel, set up **BOTH** the realtime wake (either `taosmd a2a-watch` for instant pickup or `taosmd a2a-bridge` to wake dormant sessions) **AND** the hourly cron floor. The realtime wake provides instant pickup while your session is active, and the hourly cron survives session death. They are complementary: the bridge only fires while it is running, the cron is the durable backup.
+
+Follow the **"Durable monitoring"** section in the guide for idempotent cron/schtasks setup instructions. That section also covers realtime pickup: `taosmd a2a-watch` (stream new messages one line each, wrap in a process monitor for instant in-session pickup) and `taosmd a2a-bridge` (run a trigger command per message to wake a dormant session). Keep the hourly cron as the durable floor underneath either realtime wake mechanism.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A onboarding: realtime wake is shipped but the skill never tells agents it exists

Autonomous build of board card tsk-4g2wun.

- Update SKILL.md to explicitly state agents should set up BOTH realtime wake (a2a-watch or a2a-bridge) AND hourly cron floor after joining a channel
- Update a2a-comms.md to state standard rather than listing options
- Add VERIFY step: agents must force wake path to fire once at setup and observe it
- Document floor-separation rule: watcher MUST NOT advance session's READ watermark
- Clarify that realtime wake and cron are complementary: bridge only fires while running, cron is durable backup

Files:
 taosmd/docs/a2a-comms.md          | 13 +++++++++++++
 taosmd/skills/taosmd-a2a/SKILL.md | 10 +++-------
 2 files changed, 16 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to verify realtime wake mechanisms before relying on message absence.
  * Clarified that watchers and bridges should use independent read tracking.
  * Updated setup instructions to require both realtime notifications and hourly scheduled checks for reliable message pickup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->