### PR TITLE
Bus auth Stage 1: accept-and-annotate every /a2a/send with verified sub, raw handle, and normalised identity

### DIFF
--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1440,6 +1440,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     raise _BadRequest(
                         "'body' (non-empty string) is required when 'blocks' is present"
                     )
+            # Build the Stage 1 auth annotation (observe only, never reject).
+            _auth_annotation = {
+                "auth": "unsigned",
+                "verified_sub": None,
+                "from_raw": from_,
+                "from_normalised": from_.lstrip("@").casefold(),
+                "from_mismatch": False,
+            }
             # Registry auth (opt-in): when a verifier is configured, run the
             # identity + grant checks and collect any failure reason.
             # In enforce mode (a2a_auth_enforce=true) failures are rejected with
@@ -1448,8 +1456,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             # violations before enabling hard enforcement.
             if _registry_verifier is not None:
                 from . import registry_auth  # noqa: PLC0415 - optional path
-                auth = self.headers.get("Authorization", "")
-                token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+                auth_header = self.headers.get("Authorization", "")
+                token = auth_header[len("Bearer "):].strip() if auth_header.startswith("Bearer ") else ""
 
                 # Compute warn_reason (None = auth passed) and the status/message
                 # to use in enforce mode. We collect these without returning early
@@ -1464,11 +1472,23 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     _reject_msg = "registry auth: Bearer token required"
                 else:
                     try:
-                        _registry_verifier.authorize(token, from_)
+                        claims = _registry_verifier.authorize(token, from_)
+                        _auth_annotation["auth"] = "verified"
+                        _auth_annotation["verified_sub"] = claims.get("sub")
                     except registry_auth.AuthError as exc:
                         warn_reason = str(exc)
                         _reject_status = 403
                         _reject_msg = f"registry auth: {exc}"
+                        _auth_annotation["auth"] = "invalid"
+                        _auth_annotation["reason"] = warn_reason
+                        try:
+                            import jwt as _jwt  # noqa: PLC0415 - optional path
+                            decoded = _jwt.decode(token, options={"verify_signature": False})
+                            sub = decoded.get("sub")
+                            if sub:
+                                _auth_annotation["verified_sub"] = str(sub)
+                        except Exception:
+                            pass
 
                 # Grant check: token proves identity; grant proves permission.
                 if warn_reason is None and _grants_verifier is not None:
@@ -1483,6 +1503,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         _reject_msg = f"registry auth: {exc}"
 
                 if warn_reason is not None:
+                    _auth_annotation.setdefault("reason", warn_reason)
                     enforce = _config.get_a2a_auth_enforce(data_dir)
                     if enforce:
                         self._send_json(_reject_status, {"error": _reject_msg})
@@ -1491,12 +1512,17 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         "a2a verify-and-warn: accepting unverified post from %r: %s",
                         from_, warn_reason,
                     )
+            # Normalised identity and mismatch flag.
+            if _auth_annotation["verified_sub"] is not None:
+                _auth_annotation["from_normalised"] = _auth_annotation["verified_sub"].lstrip("@").casefold()
+            _auth_annotation["from_mismatch"] = from_.lstrip("@").casefold() != _auth_annotation["from_normalised"]
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
                     thread=thread, reply_to=reply_to,
                     refs=refs, blocks=blocks,
                     data_dir=data_dir,
+                    _auth=_auth_annotation,
                 )
             )
             self._send_json(200, result)

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -34,6 +34,11 @@ from .archive import EVENT_A2A
 
 logger = logging.getLogger(__name__)
 
+
+def _normalise_handle(handle: str) -> str:
+    return handle.lstrip("@").casefold()
+
+
 # Cache of RemoteClient instances keyed by (base_url, token) so we don't
 # create a fresh object on every call.  Access from async coroutines is safe
 # because Python dict operations are GIL-protected.
@@ -350,6 +355,7 @@ async def a2a_send(
     refs: list | None = None,
     blocks: list | None = None,
     data_dir=None,
+    _auth: dict | None = None,
 ) -> dict:
     """Post a message onto the agent-to-agent bus.
 
@@ -364,8 +370,14 @@ async def a2a_send(
     payload and echoed back in the receipt and on feed/SSE reads. When
     absent they are omitted from output entirely (no null noise).
 
+    ``_auth`` is an internal dict produced by the HTTP handler with keys
+    ``auth`` (``"verified"``, ``"unsigned"``, or ``"invalid"``),
+    ``verified_sub``, ``from_raw``, ``from_normalised``, and
+    ``from_mismatch``.  When omitted a default unsigned annotation is
+    recorded.
+
     Returns ``{"id", "from", "thread", "reply_to"}`` plus ``refs`` and/or
-    ``blocks`` when those were supplied.
+    ``blocks`` when those were supplied, plus the auth annotation fields.
 
     When a remote server URL is configured the call is forwarded to
     :class:`~taosmd.remote.RemoteClient` transparently.
@@ -374,6 +386,14 @@ async def a2a_send(
         raise ValueError("sender must be a non-empty string")
     if not isinstance(body, str) or not body:
         raise ValueError("body must be a non-empty string")
+    if _auth is None:
+        _auth = {
+            "auth": "unsigned",
+            "verified_sub": None,
+            "from_raw": sender,
+            "from_normalised": _normalise_handle(sender),
+            "from_mismatch": False,
+        }
     remote = _get_remote(data_dir)
     if remote is not None:
         return await remote.a2a_send(
@@ -389,6 +409,13 @@ async def a2a_send(
         _admin = A2AAdminState(data_dir)
         thread = _admin.resolve_channel(thread)
     data = {"from": sender, "body": body, "thread": thread, "reply_to": reply_to}
+    data["auth"] = _auth["auth"]
+    data["verified_sub"] = _auth["verified_sub"]
+    data["from_raw"] = _auth["from_raw"]
+    data["from_normalised"] = _auth["from_normalised"]
+    data["from_mismatch"] = _auth["from_mismatch"]
+    if "reason" in _auth:
+        data["reason"] = _auth["reason"]
     if refs is not None:
         data["refs"] = refs
     if blocks is not None:
@@ -401,6 +428,13 @@ async def a2a_send(
         summary=body[:200],
     )
     receipt = {"id": row_id, "from": sender, "thread": thread, "reply_to": reply_to}
+    receipt["auth"] = _auth["auth"]
+    receipt["verified_sub"] = _auth["verified_sub"]
+    receipt["from_raw"] = _auth["from_raw"]
+    receipt["from_normalised"] = _auth["from_normalised"]
+    receipt["from_mismatch"] = _auth["from_mismatch"]
+    if "reason" in _auth:
+        receipt["reason"] = _auth["reason"]
     if refs is not None:
         receipt["refs"] = refs
     if blocks is not None:
@@ -509,6 +543,11 @@ async def a2a_feed(
             msg["refs"] = data["refs"]
         if "blocks" in data:
             msg["blocks"] = data["blocks"]
+        # Bus auth Stage 1 annotation: present on messages sent after the
+        # transition, absent on older archive rows.
+        for _key in ("auth", "verified_sub", "from_raw", "from_normalised", "from_mismatch", "reason"):
+            if _key in data:
+                msg[_key] = data[_key]
         result.append(msg)
     return result
 

--- a/tests/test_a2a_bus_auth_stage1.py
+++ b/tests/test_a2a_bus_auth_stage1.py
@@ -1,0 +1,305 @@
+"""A2A bus auth Stage 1: accept-and-annotate every /a2a/send.
+
+Stage 1 observes identity without rejecting anything.  Every send that was
+accepted before is still accepted.  The annotation records:
+  * auth        -- verified | unsigned | invalid
+  * verified_sub-- the token sub, or null when unsigned
+  * from_raw    -- literal from string as sent
+  * from_normalised-- strip leading @, casefold; mapped from verified_sub
+                     when present, otherwise from from_raw
+  * from_mismatch-- whether from_raw disagrees with from_normalised
+  * reason      -- present only when auth is invalid or a grant check failed
+
+Tests:
+  - unsigned send: accepted, auth=unsigned, verified_sub null
+  - valid token: accepted, auth=verified, verified_sub set, from_normalised set
+  - invalid signature: ACCEPTED (not rejected), auth=invalid, reason recorded
+  - from disagrees with token sub: ACCEPTED, from_mismatch true
+  - both handle spellings (@taOSmd-dev and taosmd-dev) normalise to ONE identity
+  - regression: a request master accepts, this accepts
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg
+from taosmd import http_server, registry_auth, service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _mint(canonical_id: str) -> str:
+    return pyjwt.encode(
+        {"sub": canonical_id, "iss": registry_auth.REGISTRY_ISS},
+        PRIV_PEM, algorithm="EdDSA",
+    )
+
+
+def _post_send(base_url, from_, body, token=None):
+    payload = json.dumps({"from": from_, "body": body}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        base_url + "/a2a/send", data=payload, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-stage1"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    yield data_dir
+    for s in list(taosmd_api._stores_cache.values()):
+        for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-stage1-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def warn_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-stage1-warn"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    def fake_opener(url, timeout=5.0, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([])
+        if url.endswith(registry_auth.GRANTS_PATH):
+            return json.dumps({"grants": [{"canonical_id": "taosmd-dev"}]})
+        raise ValueError(f"unexpected url: {url}")
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS,
+    )
+    gv = registry_auth.grants_verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Service-layer annotation defaults
+# ---------------------------------------------------------------------------
+
+def test_unsigned_service_layer_defaults(isolated_data_dir):
+    """service.a2a_send without _auth records unsigned annotation."""
+    dd = str(isolated_data_dir)
+    receipt = asyncio.run(service.a2a_send("alice", "hello", data_dir=dd))
+    assert receipt["auth"] == "unsigned"
+    assert receipt["verified_sub"] is None
+    assert receipt["from_raw"] == "alice"
+    assert receipt["from_normalised"] == "alice"
+    assert receipt["from_mismatch"] is False
+    assert "reason" not in receipt
+
+    msgs = asyncio.run(service.a2a_feed(data_dir=dd))
+    assert len(msgs) == 1
+    m = msgs[0]
+    assert m["auth"] == "unsigned"
+    assert m["verified_sub"] is None
+    assert m["from_raw"] == "alice"
+    assert m["from_normalised"] == "alice"
+    assert m["from_mismatch"] is False
+    assert "reason" not in m
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: no verifier configured (unsigned baseline)
+# ---------------------------------------------------------------------------
+
+def test_unsigned_http_accepted(live_server):
+    """No verifier: send is accepted with unsigned annotation."""
+    status, body = _post_send(live_server, "alice", "hello")
+    assert status == 200, body
+    assert body["auth"] == "unsigned"
+    assert body["verified_sub"] is None
+    assert body["from_raw"] == "alice"
+    assert body["from_normalised"] == "alice"
+    assert body["from_mismatch"] is False
+    assert "reason" not in body
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: valid token
+# ---------------------------------------------------------------------------
+
+def test_valid_token_accepted_and_annotated(warn_server):
+    token = _mint("taosmd-dev")
+    status, body = _post_send(warn_server, "taosmd-dev", "hello", token=token)
+    assert status == 200, body
+    assert body["auth"] == "verified"
+    assert body["verified_sub"] == "taosmd-dev"
+    assert body["from_raw"] == "taosmd-dev"
+    assert body["from_normalised"] == "taosmd-dev"
+    assert body["from_mismatch"] is False
+    assert "reason" not in body
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: invalid signature (accepted, not rejected)
+# ---------------------------------------------------------------------------
+
+def test_invalid_signature_accepted_and_annotated(warn_server):
+    token = "not-a-jwt-at-all"
+    status, body = _post_send(warn_server, "alice", "hello", token=token)
+    assert status == 200, body
+    assert body["auth"] == "invalid"
+    assert body["verified_sub"] is None
+    assert body["from_raw"] == "alice"
+    assert body["from_normalised"] == "alice"
+    assert body["from_mismatch"] is False
+    assert "reason" in body
+    assert "token verification failed" in body["reason"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: from disagrees with token sub (accepted, from_mismatch true)
+# ---------------------------------------------------------------------------
+
+def test_from_mismatch_accepted_and_annotated(warn_server):
+    token = _mint("agent-1")
+    status, body = _post_send(warn_server, "agent-OTHER", "hello", token=token)
+    assert status == 200, body
+    assert body["auth"] == "invalid"
+    assert body["verified_sub"] == "agent-1"
+    assert body["from_raw"] == "agent-OTHER"
+    assert body["from_normalised"] == "agent-1"
+    assert body["from_mismatch"] is True
+    assert "reason" in body
+
+
+# ---------------------------------------------------------------------------
+# Normalisation: handle spellings collapse to one identity
+# ---------------------------------------------------------------------------
+
+def test_normalise_handle_at_prefix_and_casefold():
+    assert service._normalise_handle("@taOSmd-dev") == "taosmd-dev"
+    assert service._normalise_handle("taosmd-dev") == "taosmd-dev"
+    assert service._normalise_handle("@TAOSMD-DEV") == "taosmd-dev"
+
+
+def test_normalised_identity_matches_via_http(warn_server):
+    token = _mint("taosmd-dev")
+    status, body = _post_send(warn_server, "@taOSmd-dev", "hello", token=token)
+    assert status == 200, body
+    assert body["from_normalised"] == "taosmd-dev"
+    assert body["from_mismatch"] is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: no new 4xx
+# ---------------------------------------------------------------------------
+
+def test_no_new_4xx_without_verifier(live_server):
+    status, _ = _post_send(live_server, "any-agent", "hello")
+    assert status == 200
+
+
+def test_no_new_4xx_with_verifier_warn_mode(warn_server):
+    status, _ = _post_send(warn_server, "any-agent", "hello")
+    assert status == 200


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Bus auth Stage 1: accept-and-annotate every /a2a/send with verified sub, raw handle, and normalised identity

Autonomous build of board card tsk-547ipw.

Record auth metadata on every /a2a/send without changing the accept
contract. New per-message fields: auth (verified|unsigned|invalid),
verified_sub, from_raw, from_normalised, from_mismatch, and reason
when present. No new 4xx paths; warn mode still accepts every message
master would accept.

Files:
 taosmd/http_server.py             |  32 +++-
 taosmd/service.py                 |  41 ++++-
 tests/test_a2a_bus_auth_stage1.py | 305 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 374 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication status details to A2A messages, send receipts, and message feeds.
  * Authentication annotations now indicate unsigned, verified, or invalid credentials, including sender identity and optional failure reasons.
  * Sender handles are normalized for consistent identity matching.
  * Invalid credentials may include an unverified subject for improved observability.

* **Bug Fixes**
  * Preserved existing enforcement and warning behavior for authentication failures.
  * Sends continue to return successful HTTP responses in supported warning-mode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->