### PR TITLE
A2A ref fetch: rebuild #238 with path-traversal fix, working remote route, and real registry_url fallback

### DIFF
--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -42,6 +42,8 @@ _REGISTRY_URL_KEY = "registry_url"
 # Key under which the registry auth token (taOS local/admin token) is stored.
 # Used to poll the auth-gated registry revoked feed; the pubkey feed is public.
 _REGISTRY_TOKEN_KEY = "registry_token"
+# Key under which the taOS Files base URL is stored.
+_FILES_URL_KEY = "files_url"
 # Who manages this taosmd instance: "standalone" (default) or "taos".
 _MANAGED_BY_KEY = "managed_by"
 # Override: serve the web dashboard even when managed_by=taos.
@@ -415,6 +417,49 @@ def set_registry_token(token: str, clear: bool = False, data_dir=None) -> None:
     _write(data, data_dir)
 
 
+def get_files_url(data_dir=None) -> str | None:
+    """Return the configured taOS Files base URL, or ``None`` if unset.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_FILES_URL`` environment variable
+    2. ``files_url`` key in ``~/.taosmd/config.json``
+
+    When set, the ref-fetch helper resolves ``taos://`` refs against this
+    controller. When unset, the helper falls back to ``registry_url`` so a
+    single-controller install needs only one setting.
+    """
+    env = os.environ.get("TAOSMD_FILES_URL")
+    if env and env.strip():
+        return env.strip()
+    url = _read(data_dir).get(_FILES_URL_KEY)
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+    return None
+
+
+def set_files_url(url: str, clear: bool = False, data_dir=None) -> None:
+    """Persist the taOS Files base URL (or clear it).
+
+    Args:
+        url: Base URL of the taOS controller serving the Files API, e.g.
+            ``"http://taos:8000"``. Ignored when ``clear`` is True.
+        clear: when True, remove the setting (ref-fetch falls back to
+            ``registry_url``).
+
+    Raises:
+        ValueError: when ``clear`` is False and ``url`` is not a non-empty string.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_FILES_URL_KEY, None)
+    else:
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("url must be a non-empty string (or pass clear=True)")
+        data[_FILES_URL_KEY] = url.strip()
+    _write(data, data_dir)
+
+
 # ---------------------------------------------------------------------------
 # Remote server bearer token
 # ---------------------------------------------------------------------------
@@ -681,6 +726,8 @@ __all__ = [
     "set_admin_token",
     "get_registry_url",
     "set_registry_url",
+    "get_files_url",
+    "set_files_url",
     "get_registry_token",
     "set_registry_token",
     "get_managed_by",

--- a/taosmd/ref_fetch.py
+++ b/taosmd/ref_fetch.py
@@ -1,0 +1,153 @@
+"""Resolve and fetch taOS Files-backed refs with hash verification.
+
+A ref uri of the form ``taos://<project-slug>/files/<path>`` is resolved to
+``GET /api/projects/{slug}/files/{path}`` on the configured controller. The
+fetch helper verifies the returned bytes against the ref's ``sha256`` and
+returns the verified bytes or a typed error.
+
+No new server storage is introduced: this is purely a client-side helper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import urllib.parse
+
+
+class RefFetchError(Exception):
+    """Base error for ref fetch failures."""
+
+
+class HashMismatchError(RefFetchError):
+    """Raised when the fetched bytes do not match the ref's sha256."""
+
+
+class NotFoundError(RefFetchError):
+    """Raised when the Files API reports the resource is missing."""
+
+
+class UnauthorizedError(RefFetchError):
+    """Raised when the Files API reports an auth failure."""
+
+
+_SCHEME_PREFIX = "taos://"
+_FILES_SEGMENT = "files/"
+
+
+def _reject_dot_segments(path: str) -> None:
+    """Raise ValueError if path contains . or .. segments (literal or encoded)."""
+    decoded = urllib.parse.unquote(path)
+    for segment in decoded.split("/"):
+        if segment in (".", ".."):
+            raise ValueError(
+                f"invalid taos ref uri: path contains dot segment {segment!r}"
+            )
+
+
+def resolve_ref_uri(ref, files_url: str) -> str:
+    """Map a taos:// ref uri to the concrete Files API fetch endpoint.
+
+    Args:
+        ref: A ref dict with at least a ``uri`` field.
+        files_url: Base URL of the taOS controller.
+
+    Returns:
+        The full URL for ``GET /api/projects/{slug}/files/{path}``.
+
+    Raises:
+        ValueError: If the uri scheme is not ``taos://`` or the shape is invalid.
+    """
+    uri = ref.get("uri") if isinstance(ref, dict) else None
+    if not isinstance(uri, str) or not uri.startswith(_SCHEME_PREFIX):
+        raise ValueError(
+            f"unsupported uri scheme: {uri!r} (only taos:// is accepted)"
+        )
+    rest = uri[len(_SCHEME_PREFIX):]
+    parts = rest.split("/", 1)
+    if len(parts) != 2 or not parts[1].startswith(_FILES_SEGMENT):
+        raise ValueError(
+            f"invalid taos ref uri: {uri!r} (expected taos://<slug>/files/<path>)"
+        )
+    slug = urllib.parse.quote(parts[0], safe="")
+    path = parts[1][len(_FILES_SEGMENT):]
+    if not path:
+        raise ValueError(
+            f"invalid taos ref uri: {uri!r} (path is empty)"
+        )
+    if path.startswith("/"):
+        raise ValueError(
+            f"invalid taos ref uri: {uri!r} (path must not be absolute)"
+        )
+    _reject_dot_segments(path)
+    encoded_path = urllib.parse.quote(path, safe="/")
+    base = files_url.rstrip("/") if files_url else files_url
+    return f"{base}/api/projects/{slug}/files/{encoded_path}"
+
+
+async def fetch_by_ref(ref, fetcher, agent) -> bytes:
+    """Fetch bytes for a ref using an injected fetcher and verify the hash.
+
+    Args:
+        ref: A ref dict with ``uri`` and ``sha256`` fields.
+        fetcher: A callable ``fetcher(url: str, agent: str) -> bytes`` that
+            performs the HTTP GET and returns the raw response body. It should
+            raise :class:`NotFoundError` or :class:`UnauthorizedError` for
+            those HTTP status codes.
+        agent: The agent identity (passed to ``fetcher`` for auth context).
+
+    Returns:
+        The verified raw bytes.
+
+    Raises:
+        ValueError: If the uri cannot be resolved.
+        HashMismatchError: If the fetched bytes' sha256 does not match ref.sha256.
+        NotFoundError: If the fetcher reports the resource is missing.
+        UnauthorizedError: If the fetcher reports an auth failure.
+        RefFetchError: For other fetch failures.
+    """
+    import asyncio
+
+    files_url = _get_files_url()
+    url = resolve_ref_uri(ref, files_url)
+    loop = asyncio.get_running_loop()
+    raw = await loop.run_in_executor(None, fetcher, url, agent)
+    expected = ref.get("sha256") if isinstance(ref, dict) else None
+    if not expected:
+        raise RefFetchError("ref has no sha256")
+    actual = hashlib.sha256(raw).hexdigest()
+    if actual != expected:
+        raise HashMismatchError("sha256 mismatch")
+    return raw
+
+
+def _get_files_url() -> str:
+    """Resolve the files base URL from env or config.
+
+    Falls back to ``registry_url`` when ``files_url`` is unset, so a
+    single-controller install needs only one setting.
+    """
+    env = os.environ.get("TAOSMD_FILES_URL")
+    if env and env.strip():
+        return env.strip()
+    from .config import get_files_url
+    url = get_files_url()
+    if url:
+        return url
+    from .config import get_registry_url
+    url = get_registry_url()
+    if url:
+        return url
+    raise RefFetchError(
+        "files_url is not configured: set TAOSMD_FILES_URL or files_url in config.json"
+    )
+
+
+__all__ = [
+    "RefFetchError",
+    "HashMismatchError",
+    "NotFoundError",
+    "UnauthorizedError",
+    "resolve_ref_uri",
+    "fetch_by_ref",
+]

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -401,4 +401,12 @@ class RemoteClient:
         )
 
 
+    async def fetch_by_ref(self, ref: dict, agent: str, **opts) -> dict:
+        """POST /refs/fetch: proxy a ref fetch to the remote server.
+
+        Returns ``{"bytes": <base64-str>, "sha256": <hash>, "size": <int>}``.
+        """
+        return await self._run("POST", "/refs/fetch", {"ref": ref, "agent": agent})
+
+
 __all__ = ["RemoteClient"]

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -25,6 +25,7 @@ server, and Python API all go remote transparently.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 
@@ -339,6 +340,65 @@ async def stats(*, agent: str, data_dir=None) -> dict:
         total_chunks=record.get("total_chunks", 0),
     )
     return out
+
+
+async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
+    """Fetch and verify bytes for a taOS Files-backed ref.
+
+    Thin wrapper over :func:`taosmd.ref_fetch.fetch_by_ref`. Resolves the
+    controller base URL from config, builds a fetcher that authenticates with
+    the registry token, and returns the verified bytes as a base64-encoded
+    string together with its sha256 and size.
+
+    Returns ``{"bytes": <base64-str>, "sha256": <hash>, "size": <int>}``.
+
+    Raises :class:`ValueError` for an unresolvable uri,
+    :class:`~taosmd.ref_fetch.HashMismatchError` for a hash mismatch,
+    :class:`~taosmd.ref_fetch.NotFoundError` for a 404, or
+    :class:`~taosmd.ref_fetch.UnauthorizedError` for a 401/403.
+    """
+    import base64
+
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.fetch_by_ref(ref, agent=agent)
+
+    from . import config as _config
+    from .ref_fetch import HashMismatchError, NotFoundError, RefFetchError, UnauthorizedError, fetch_by_ref as _fetch_by_ref
+
+    files_url = _config.get_files_url(data_dir)
+    if not files_url:
+        raise RefFetchError(
+            "files_url is not configured: set TAOSMD_FILES_URL or files_url in config.json"
+        )
+    registry_token = _config.get_registry_token(data_dir)
+
+    def _fetcher(url: str, agent: str) -> bytes:
+        import urllib.error
+        import urllib.request
+
+        headers = {"Accept": "application/octet-stream"}
+        if registry_token:
+            headers["Authorization"] = f"Bearer {registry_token}"
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise UnauthorizedError(f"HTTP {exc.code} from {url}") from exc
+            if exc.code == 404:
+                raise NotFoundError(f"HTTP 404 from {url}") from exc
+            raise
+        except urllib.error.URLError as exc:
+            raise RefFetchError(f"fetch failed for {url}: {exc}") from exc
+
+    raw = await _fetch_by_ref(ref, _fetcher, agent)
+    return {
+        "bytes": base64.b64encode(raw).decode("ascii"),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "size": len(raw),
+    }
 
 
 async def a2a_send(
@@ -1031,7 +1091,7 @@ async def collections_archive(collection_id: str, *, data_dir=None) -> dict:
 
 
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
-           "supersede", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
+           "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_ref_fetch.py
+++ b/tests/test_ref_fetch.py
@@ -1,0 +1,247 @@
+"""Tests for taosmd.ref_fetch: resolver + verified fetch helper."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import urllib.parse
+
+import pytest
+
+from taosmd import config
+from taosmd.ref_fetch import (
+    HashMismatchError,
+    NotFoundError,
+    RefFetchError,
+    UnauthorizedError,
+    fetch_by_ref,
+    resolve_ref_uri,
+)
+
+
+# ---------------------------------------------------------------------------
+# Resolver tests
+# ---------------------------------------------------------------------------
+
+class TestResolveRefUri:
+    def test_taos_uri_maps_to_files_endpoint(self):
+        ref = {"uri": "taos://myproj/files/docs/readme.md", "sha256": "abc123"}
+        url = resolve_ref_uri(ref, "http://controller:8000")
+        assert url == "http://controller:8000/api/projects/myproj/files/docs/readme.md"
+
+    def test_taos_uri_with_special_characters_is_quoted(self):
+        ref = {"uri": "taos://my proj/files/path with spaces/file.txt", "sha256": "abc123"}
+        url = resolve_ref_uri(ref, "http://controller:8000")
+        assert "my%20proj" in url
+        assert "path%20with%20spaces" in url
+        assert url == "http://controller:8000/api/projects/my%20proj/files/path%20with%20spaces/file.txt"
+
+    def test_dot_segment_traversal_rejected(self):
+        ref = {"uri": "taos://proj/files/../../admin/secrets", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="dot segment"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_encoded_dot_segment_traversal_rejected(self):
+        ref = {"uri": "taos://proj/files/%2e%2e/%2e%2e/admin/secrets", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="dot segment"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_mixed_dot_segment_traversal_rejected(self):
+        ref = {"uri": "taos://proj/files/a/../../../api/registry/tokens", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="dot segment"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_leading_slash_path_rejected(self):
+        ref = {"uri": "taos://proj/files//etc/passwd", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="absolute"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_non_taos_uri_raises(self):
+        ref = {"uri": "https://example.com/file", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_empty_uri_raises(self):
+        ref = {"uri": "", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_missing_uri_field_raises(self):
+        ref = {"sha256": "abc123"}
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_invalid_taos_shape_raises(self):
+        ref = {"uri": "taos://myproj", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="invalid taos ref uri"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_taos_uri_without_files_segment_raises(self):
+        ref = {"uri": "taos://myproj/other/file.txt", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="invalid taos ref uri"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_taos_uri_empty_path_raises(self):
+        ref = {"uri": "taos://myproj/files/", "sha256": "abc123"}
+        with pytest.raises(ValueError, match="path is empty"):
+            resolve_ref_uri(ref, "http://controller:8000")
+
+    def test_non_dict_ref_raises(self):
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            resolve_ref_uri("not-a-dict", "http://controller:8000")
+
+
+# ---------------------------------------------------------------------------
+# fetch_by_ref tests
+# ---------------------------------------------------------------------------
+
+class TestFetchByRef:
+    def test_fetch_match_returns_verified_bytes(self, monkeypatch):
+        content = b"hello world"
+        expected_sha = hashlib.sha256(content).hexdigest()
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": expected_sha}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        captured = {}
+
+        def fake_fetcher(url, agent):
+            captured["url"] = url
+            captured["agent"] = agent
+            return content
+
+        result = asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+        assert result == content
+        assert captured["url"] == "http://ctrl:8000/api/projects/proj/files/hello.txt"
+        assert captured["agent"] == "test-agent"
+
+    def test_fetch_mismatch_error_contains_no_hash(self, monkeypatch):
+        content = b"hello world"
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "deadbeef" * 8}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            return content
+
+        with pytest.raises(HashMismatchError) as exc_info:
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+        assert "deadbeef" not in str(exc_info.value)
+        assert "sha256 mismatch" in str(exc_info.value)
+
+    def test_fetcher_not_found_propagates(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/missing.txt", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise NotFoundError(f"HTTP 404 from {url}")
+
+        with pytest.raises(NotFoundError):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_fetcher_unauthorized_propagates(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/secret.txt", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise UnauthorizedError(f"HTTP 401 from {url}")
+
+        with pytest.raises(UnauthorizedError):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_non_taos_ref_raises_before_fetch(self, monkeypatch):
+        ref = {"uri": "https://example.com/file", "sha256": "abc123"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            raise AssertionError("fetcher should not be called for non-taos:// uri")
+
+        with pytest.raises(ValueError, match="unsupported uri scheme"):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+    def test_ref_without_sha256_raises(self, monkeypatch):
+        ref = {"uri": "taos://proj/files/hello.txt"}
+
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://ctrl:8000")
+
+        def fake_fetcher(url, agent):
+            return b"data"
+
+        with pytest.raises(RefFetchError, match="no sha256"):
+            asyncio.run(fetch_by_ref(ref, fake_fetcher, "test-agent"))
+
+
+# ---------------------------------------------------------------------------
+# Single-controller fallback tests
+# ---------------------------------------------------------------------------
+
+class TestGetFilesUrlFallback:
+    def test_files_url_preferred_over_registry(self, monkeypatch):
+        from taosmd import config as cfg
+        monkeypatch.setattr(cfg, "get_files_url", lambda data_dir=None: "http://files:8000")
+        monkeypatch.setattr(cfg, "get_registry_url", lambda data_dir=None: "http://reg:8000")
+        from taosmd.ref_fetch import _get_files_url
+        assert _get_files_url() == "http://files:8000"
+
+    def test_registry_url_fallback_when_files_url_unset(self, monkeypatch):
+        from taosmd import config as cfg
+        monkeypatch.setattr(cfg, "get_files_url", lambda data_dir=None: None)
+        monkeypatch.setattr(cfg, "get_registry_url", lambda data_dir=None: "http://reg:8000")
+        from taosmd.ref_fetch import _get_files_url
+        assert _get_files_url() == "http://reg:8000"
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("TAOSMD_FILES_URL", "http://env-files:8000")
+        from taosmd.ref_fetch import _get_files_url
+        assert _get_files_url() == "http://env-files:8000"
+
+    def test_config_files_url_round_trip(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TAOSMD_FILES_URL", raising=False)
+        config.set_files_url("http://files:9000", data_dir=str(tmp_path))
+        assert config.get_files_url(str(tmp_path)) == "http://files:9000"
+
+    def test_config_files_url_clear(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TAOSMD_FILES_URL", raising=False)
+        config.set_files_url("http://files:9000", data_dir=str(tmp_path))
+        config.set_files_url("", clear=True, data_dir=str(tmp_path))
+        assert config.get_files_url(str(tmp_path)) is None
+
+
+# ---------------------------------------------------------------------------
+# Service remote routing tests
+# ---------------------------------------------------------------------------
+
+class TestServiceFetchByRefRouting:
+    def test_routes_to_remote_when_configured(self, monkeypatch):
+        from taosmd import service as svc
+
+        class FakeRemote:
+            async def fetch_by_ref(self, ref, agent, **kw):
+                return {"bytes": "dGVzdA==", "sha256": "abc", "size": 4}
+
+        fake_remote = FakeRemote()
+        monkeypatch.setattr(svc, "_get_remote", lambda data_dir: fake_remote)
+
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "abc"}
+        result = asyncio.run(svc.fetch_by_ref(ref, agent="test"))
+        assert result["bytes"] == "dGVzdA=="
+
+    def test_local_path_when_no_remote(self, monkeypatch):
+        from taosmd import config as cfg
+        from taosmd import service as svc
+        from taosmd.ref_fetch import fetch_by_ref as _orig_fetch
+
+        async def fake_fetch(ref, fetcher, agent):
+            return b"hello"
+
+        monkeypatch.setattr(svc, "_get_remote", lambda data_dir: None)
+        monkeypatch.setattr(cfg, "get_files_url", lambda data_dir: "http://ctrl:8000")
+        monkeypatch.setattr("taosmd.ref_fetch.fetch_by_ref", fake_fetch)
+
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "abc"}
+        result = asyncio.run(svc.fetch_by_ref(ref, agent="test", data_dir="/tmp"))
+        assert result["bytes"] == "aGVsbG8="


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A ref fetch: rebuild #238 with path-traversal fix, working remote route, and real registry_url fallback

Autonomous build of board card tsk-7xcsh5.



Files:
 taosmd/config.py        |  47 +++++++++
 taosmd/ref_fetch.py     | 153 ++++++++++++++++++++++++++++++
 taosmd/remote.py        |   8 ++
 taosmd/service.py       |  62 +++++++++++-
 tests/test_ref_fetch.py | 247 ++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 516 insertions(+), 1 deletion(-)