### PR TITLE
deleted-symbols gate: the failure message never tells you the waiver exists

### DIFF
--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -226,6 +226,15 @@ def main(argv: list[str] | None = None) -> int:
         )
         for v in violations:
             print(f"  - {v.symbol} (added by {v.added_by})")
+
+        trailer_symbols = ", ".join(v.symbol for v in violations)
+        print()
+        print(
+            "If these deletions are intentional, add this trailer to the PR body and "
+            "the gate will re-run automatically:"
+        )
+        print()
+        print(f"    {TRAILER} {trailer_symbols}")
         return 1
 
     print("deleted-symbols-guard: clean")

--- a/tests/test_deleted_symbols.py
+++ b/tests/test_deleted_symbols.py
@@ -206,3 +206,28 @@ class TestDeletedSymbolsIntegration:
         captured = capsys.readouterr()
         assert "DELETED-SYMBOLS FAIL" in captured.out
         assert "taosmd/service.py:a2a_send" in captured.out
+
+    def test_main_prints_waiver_hint_on_failure(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "Removes-Intentionally:" in captured.out
+        assert "If these deletions are intentional" in captured.out
+        assert f"{TRAILER} taosmd/service.py:a2a_send" in captured.out
+
+    def test_main_omits_waiver_hint_when_clean(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main([
+            "--base", "HEAD~1",
+            "--pr-body", "Removes-Intentionally: taosmd/service.py:a2a_send",
+        ])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "If these deletions are intentional" not in captured.out


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deleted-symbols gate: the failure message never tells you the waiver exists

Autonomous build of board card tsk-gkmvcp.

The waiver trailer is documented only in a workflow comment and the
module docstring, neither of which a contributor reads while CI is red.
Print a ready-to-paste trailer line built from the symbols that actually
failed right in the FAIL message so the escape hatch is discoverable.

Add tests asserting the hint appears on failure and is absent from the
clean output.

Files:
 scripts/check_deleted_symbols.py |  9 +++++++++
 tests/test_deleted_symbols.py    | 25 +++++++++++++++++++++++++
 2 files changed, 34 insertions(+)