### PR TITLE
PR #235 follow-up: run the revocation check for human principals, and log the human-principal path

### DIFF
--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1575,6 +1575,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     try:
                         _registry_verifier.authorize(token, from_)
                     except registry_auth.HumanAuthError as exc:
+                        logger.warning("human principal %r rejected: %s", from_, exc)
                         self._send_json(403, {"error": f"registry auth: {exc}"})
                         return
                     except registry_auth.AuthError as exc:
@@ -1596,6 +1597,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                             warn_reason = str(exc)
                             _reject_status = 403
                             _reject_msg = f"registry auth: {exc}"
+                    else:
+                        logger.info("grants check skipped for human principal %r", from_)
 
                 if warn_reason is not None:
                     enforce = _config.get_a2a_auth_enforce(data_dir)

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -81,6 +81,8 @@ def authorize_sender(token: str, claimed_from: str, *, public_key: str,
         raise AuthError("token has no 'sub' (canonical_id) claim")
     if sub != claimed_from:
         if human_principal_ids and sub in human_principal_ids:
+            logger.warning("human principal %r sub/from mismatch: sub=%r, from=%r",
+                           sub, sub, claimed_from)
             raise HumanAuthError(
                 f"human token sub {sub!r} does not match from {claimed_from!r}"
             )
@@ -129,6 +131,8 @@ class RegistryVerifier:
         self._clock = clock
         self._expected_iss = expected_iss
         self._human_principal_ids = human_principal_ids or set()
+        logger.info("resolved human principal set: %s",
+                    sorted(self._human_principal_ids))
         self._pubkey: str | None = None
         self._revoked: set[str] = set()
         self._revoked_fetched_at: float | None = None

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -524,3 +524,28 @@ def test_decode_and_verify_is_single_entry_point_for_human_and_agent():
         registry_auth.decode_and_verify(bad_human, pub_pem)
     with pytest.raises(registry_auth.AuthError):
         registry_auth.decode_and_verify(bad_agent, pub_pem)
+
+
+def test_authorize_sender_logs_human_auth_error(caplog):
+    priv_pem, pub_pem = _keypair()
+    token = _sign(priv_pem, {"sub": "human-1"})
+
+    with pytest.raises(registry_auth.HumanAuthError):
+        registry_auth.authorize_sender(
+            token, "human-2", public_key=pub_pem, revoked=set(),
+            human_principal_ids={"human-1"},
+        )
+    assert any("human principal 'human-1' sub/from mismatch" in r.message
+               for r in caplog.records)
+
+
+def test_registry_verifier_logs_human_principal_set(caplog):
+    import logging
+    with caplog.at_level(logging.INFO, logger="taosmd.registry_auth"):
+        v = registry_auth.RegistryVerifier(
+            pubkey_loader=lambda: "pk",
+            revoked_loader=lambda: set(),
+            human_principal_ids={"human-1", "user-alice"},
+        )
+    assert any("resolved human principal set: ['human-1', 'user-alice']" in r.message
+               for r in caplog.records)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): PR #235 follow-up: run the revocation check for human principals, and log the human-principal path

Autonomous build of board card tsk-oxhuwe.



Files:
 taosmd/config.py            |  30 +++++++++
 taosmd/http_server.py       |  27 +++++---
 taosmd/registry_auth.py     |  52 +++++++++++++--
 tests/test_registry_auth.py | 158 ++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 254 insertions(+), 13 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring recognized human principal IDs through environment variables or application configuration.
  * Human principals can authenticate without grant checks.
  * Human identity mismatches now receive an immediate authorization failure.
  * Existing agent authentication and grant validation behavior remains unchanged.

* **Bug Fixes**
  * Improved handling of revoked or mismatched human identities during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->