### PR TITLE
A2A: reject implausible since values on stream/messages (id-vs-timestamp footgun, taOS-dev 1447)

### DIFF
--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -104,8 +104,8 @@ Endpoints
 ``POST /a2a/send``         ``{"from", "body", "thread"?, "reply_to"?, "refs"?, "blocks"?}`` -> send receipt
                            ``refs``: optional list (<=8) of ``{"kind": doc|report|spec|log, "title", "uri", "sha256"?, "doc_id"?, "version"?, "for"?, "summary"?}``
                            ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
-``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line)
-``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream)
+``GET  /a2a/messages``     ``?thread=&since=<epoch_ts>&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, values below 1_000_000_000 are rejected)
+``GET  /a2a/stream``       ``?thread=&since=<epoch_ts>``             -> SSE stream (text/event-stream; ``since`` is an epoch timestamp in seconds, values below 1_000_000_000 are rejected)
 ``GET  /a2a/channels``                                     -> ``{"channels": [...]}``
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 ``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
@@ -1511,6 +1511,11 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 since = float(since_raw) if since_raw is not None else None
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'since' must be a float timestamp") from exc
+            if since is not None and since < 1_000_000_000:
+                raise _BadRequest(
+                    "'since' is an epoch timestamp in seconds; got "
+                    f"{since_raw} which looks like a message id - use the message's ts field, or omit since"
+                )
             try:
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
@@ -1558,6 +1563,11 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 last_ts = float(since_raw) if since_raw is not None else time.time()
             except (TypeError, ValueError):
                 last_ts = time.time()
+            if since_raw is not None and last_ts < 1_000_000_000:
+                raise _BadRequest(
+                    "'since' is an epoch timestamp in seconds; got "
+                    f"{since_raw} which looks like a message id - use the message's ts field, or omit since"
+                )
 
             # Send SSE response headers before entering the poll loop.
             self.send_response(200)

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -310,6 +310,77 @@ def test_http_a2a_messages_since_filter(live_server):
     assert msgs[0]["body"] == "after pivot"
 
 
+def test_http_a2a_messages_since_message_id_rejected(live_server):
+    """since=1444 (a message id) is rejected with 400 on /a2a/messages."""
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=any&since=1444"
+    )
+    assert status == 400
+    assert "timestamp" in body["error"]
+    assert "1444" in body["error"]
+
+
+def test_http_a2a_stream_since_message_id_rejected(live_server):
+    """since=1444 (a message id) is rejected with 400 on /a2a/stream."""
+    status, body = _get(
+        f"{live_server}/a2a/stream?thread=any&since=1444"
+    )
+    assert status == 400
+    assert "timestamp" in body["error"]
+    assert "1444" in body["error"]
+
+
+def test_http_a2a_messages_since_zero_rejected(live_server):
+    """since=0 is rejected with 400 on /a2a/messages."""
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=any&since=0"
+    )
+    assert status == 400
+    assert "timestamp" in body["error"]
+    assert "0" in body["error"]
+
+
+def test_http_a2a_messages_since_negative_rejected(live_server):
+    """since=-1 is rejected with 400 on /a2a/messages."""
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=any&since=-1"
+    )
+    assert status == 400
+    assert "timestamp" in body["error"]
+    assert "-1" in body["error"]
+
+
+def test_http_a2a_messages_since_omitted_unchanged(live_server):
+    """Omitting since returns all messages (behavior unchanged)."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg1", "thread": "since-omit"})
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg2", "thread": "since-omit"})
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=since-omit")
+    assert status == 200
+    assert len(body["messages"]) == 2
+
+
+def test_http_a2a_messages_since_recent_epoch_unchanged(live_server):
+    """A recent epoch timestamp still filters correctly."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "before pivot", "thread": "since-recent"})
+    time.sleep(0.02)
+    pivot = time.time()
+    time.sleep(0.02)
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "after pivot", "thread": "since-recent"})
+
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=since-recent&since={pivot}"
+    )
+    assert status == 200
+    msgs = body["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "after pivot"
+
+
 # ---------------------------------------------------------------------------
 # SSE smoke test
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A: reject implausible since values on stream/messages (id-vs-timestamp footgun, taOS-dev 1447)

Autonomous build of board card tsk-jpioif.



Files:
 taosmd/http_server.py | 14 ++++++++--
 tests/test_a2a.py     | 71 +++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 83 insertions(+), 2 deletions(-)