### PR TITLE
Tests that need a live embed backend must SKIP, not FAIL, so the CI deselect list can be deleted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,4 @@ jobs:
       - name: Compile check (two merged branches previously shipped files that do not parse)
         run: uv run python -m compileall -q taosmd/
       - name: Tests
-        # The --deselect list below is the set of tests that require a live
-        # embed backend (ONNX model or qmd service) and FAIL rather than skip
-        # when none is configured. They still run in full on a configured dev
-        # box. Tracked to get proper skip-if-no-backend guards; remove the
-        # deselects when that lands. Do NOT grow this list to hide new
-        # failures.
-        run: >
-          uv run pytest tests/ -q
-          --deselect tests/test_catalog_pipeline.py::TestCrystallizeAgentScoping::test_crystallize_stage_passes_agent_name_to_lookup_date
-          --deselect tests/test_hermes_audit_batch2.py::test_bm25_cache_is_populated_after_search
-          --deselect tests/test_hermes_audit_batch2.py::test_bm25_cache_invalidated_on_add
-          --deselect tests/test_hermes_audit_batch2.py::test_bm25_cache_not_rebuilt_on_second_query
-          --deselect tests/test_http_server_registry_auth.py::test_search_token_project_id_scopes_results
-          --deselect tests/test_project_storage.py::TestIngestProject::test_ingest_different_agents_same_project
-          --deselect tests/test_project_storage.py::TestSearchProject::test_search_scoped_to_project
-          --deselect tests/test_project_storage.py::TestSearchProject::test_search_without_project_sees_all
-          --deselect tests/test_project_storage.py::TestSearchProject::test_cross_agent_search_with_also_include
-          --deselect tests/test_reindex.py::test_reindex_preserves_project_and_provenance
+        run: uv run pytest tests/ -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,45 @@ explicitly still wins.
 """
 from __future__ import annotations
 
+import json
+import os
+import urllib.request
+from pathlib import Path
+
 import pytest
+
+
+def _has_onnx_model() -> bool:
+    """True if an ONNX embedding model is available on disk."""
+    env = os.environ.get("TAOSMD_ONNX_PATH")
+    if env:
+        p = Path(env)
+        if (p / "model.onnx").exists() or (p / "onnx" / "model.onnx").exists():
+            return True
+    candidates = [
+        Path("~/.taosmd/models/minilm-onnx").expanduser(),
+        Path(os.environ.get("TAOSMD_DIR", "~/taosmd")).expanduser() / "models" / "minilm-onnx",
+    ]
+    for candidate in candidates:
+        if (candidate / "model.onnx").exists() or (candidate / "onnx" / "model.onnx").exists():
+            return True
+    return False
+
+
+def _has_qmd_service() -> bool:
+    """True if the QMD embed service is reachable at the default URL."""
+    try:
+        data = json.dumps({"text": "probe"}).encode()
+        req = urllib.request.Request(
+            "http://localhost:7832/embed",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 @pytest.fixture(autouse=True)
@@ -32,3 +70,19 @@ def _no_reranker_network(monkeypatch):
     # ensure_reranker_model into returning "downloading" without doing work).
     monkeypatch.setattr(recipes, "_RERANKER_DOWNLOADS", {})
     yield
+
+
+@pytest.fixture
+def live_embed_backend():
+    """Skip unless a live embed backend (ONNX model or QMD service) is available.
+
+    Configure an ONNX model with ``scripts/setup.sh`` or ``TAOSMD_ONNX_PATH``.
+    Start the QMD service with ``qmd serve`` (default http://localhost:7832).
+    """
+    if _has_onnx_model() or _has_qmd_service():
+        return True
+    pytest.skip(
+        "No live embed backend available. "
+        "Install an ONNX model (run scripts/setup.sh or set TAOSMD_ONNX_PATH) "
+        "or start the QMD service (qmd serve on http://localhost:7832)."
+    )

--- a/tests/test_catalog_pipeline.py
+++ b/tests/test_catalog_pipeline.py
@@ -148,7 +148,7 @@ class TestCrystallizeAgentScoping:
     def teardown_method(self, method):
         self._tmpdir.cleanup()
 
-    def test_crystallize_stage_passes_agent_name_to_lookup_date(self):
+    def test_crystallize_stage_passes_agent_name_to_lookup_date(self, live_embed_backend):
         """index_day(agent_name='alice') must call lookup_date with agent_name='alice'
         in the crystallize stage, so bob's sessions are never touched."""
         from unittest.mock import AsyncMock, patch

--- a/tests/test_hermes_audit_batch2.py
+++ b/tests/test_hermes_audit_batch2.py
@@ -174,7 +174,7 @@ def test_adapt_kg_incoming_and_outgoing_differ():
 # ---------------------------------------------------------------------------
 
 
-def test_bm25_cache_is_populated_after_search(tmp_path):
+def test_bm25_cache_is_populated_after_search(tmp_path, live_embed_backend):
     """After a bm25_rrf search the cache entry must be set."""
     from taosmd.vector_memory import VectorMemory
 
@@ -201,7 +201,7 @@ def test_bm25_cache_is_populated_after_search(tmp_path):
     asyncio.run(go())
 
 
-def test_bm25_cache_invalidated_on_add(tmp_path):
+def test_bm25_cache_invalidated_on_add(tmp_path, live_embed_backend):
     """Adding a new document must mark the cache dirty."""
     from taosmd.vector_memory import VectorMemory
 
@@ -223,7 +223,7 @@ def test_bm25_cache_invalidated_on_add(tmp_path):
     asyncio.run(go())
 
 
-def test_bm25_cache_not_rebuilt_on_second_query(tmp_path):
+def test_bm25_cache_not_rebuilt_on_second_query(tmp_path, live_embed_backend):
     """Two consecutive queries on the same corpus must reuse the cached index."""
     from taosmd.vector_memory import VectorMemory
 

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -293,7 +293,7 @@ def test_ingest_token_project_id_overrides_body_project(project_server):
     assert status == 200, body
 
 
-def test_search_token_project_id_scopes_results(project_server):
+def test_search_token_project_id_scopes_results(project_server, live_embed_backend):
     """Ingest under token proj-a, then search with same token and find the memory."""
     token = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
     # Ingest (token forces project=proj-a regardless of body)

--- a/tests/test_project_storage.py
+++ b/tests/test_project_storage.py
@@ -37,7 +37,7 @@ class TestIngestProject:
         assert result["project"] is None
 
     @pytest.mark.asyncio
-    async def test_ingest_different_agents_same_project(self, data_dir):
+    async def test_ingest_different_agents_same_project(self, data_dir, live_embed_backend):
         await ingest("Fact from Claude", agent="claude", project="proj1", data_dir=data_dir)
         await ingest("Fact from Kilo", agent="kilo", project="proj1", data_dir=data_dir)
         # Both should succeed — no conflict
@@ -50,7 +50,7 @@ class TestIngestProject:
 
 class TestSearchProject:
     @pytest.mark.asyncio
-    async def test_search_scoped_to_project(self, data_dir):
+    async def test_search_scoped_to_project(self, data_dir, live_embed_backend):
         await ingest("OAuth2 on login page", agent="claude", project="proj-a", data_dir=data_dir)
         await ingest("OAuth2 on signup page", agent="claude", project="proj-b", data_dir=data_dir)
 
@@ -64,7 +64,7 @@ class TestSearchProject:
         assert any("signup" in t for t in texts_b)
 
     @pytest.mark.asyncio
-    async def test_search_without_project_sees_all(self, data_dir):
+    async def test_search_without_project_sees_all(self, data_dir, live_embed_backend):
         await ingest("Fact A", agent="claude", project="proj-a", data_dir=data_dir)
         await ingest("Fact B", agent="claude", project="proj-b", data_dir=data_dir)
 
@@ -72,7 +72,7 @@ class TestSearchProject:
         assert len(hits) >= 2
 
     @pytest.mark.asyncio
-    async def test_cross_agent_search_with_also_include(self, data_dir):
+    async def test_cross_agent_search_with_also_include(self, data_dir, live_embed_backend):
         await ingest("Database schema uses UUIDs", agent="claude", project="proj1", data_dir=data_dir)
         await ingest("API returns JSON:API format", agent="kilo", project="proj1", data_dir=data_dir)
 

--- a/tests/test_reindex.py
+++ b/tests/test_reindex.py
@@ -233,7 +233,7 @@ def test_reindex_empty_agent_is_consistent(isolated):
     assert result["reindexed_ok"] is True
 
 
-def test_reindex_preserves_project_and_provenance(isolated):
+def test_reindex_preserves_project_and_provenance(isolated, live_embed_backend):
     """A reindexed row must carry the same scope + provenance the hot path
     wrote: the project scope, the archive_span_id of the row it backs, and the
     nested user metadata (source_id/forget_after). Without the project tag the


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Tests that need a live embed backend must SKIP, not FAIL, so the CI deselect list can be deleted

Autonomous build of board card tsk-hfy6dg.



Files:
 .github/workflows/ci.yml                | 19 +-----------
 tests/conftest.py                       | 54 +++++++++++++++++++++++++++++++++
 tests/test_catalog_pipeline.py          |  2 +-
 tests/test_hermes_audit_batch2.py       |  6 ++--
 tests/test_http_server_registry_auth.py |  2 +-
 tests/test_project_storage.py           |  8 ++---
 tests/test_reindex.py                   |  2 +-
 7 files changed, 65 insertions(+), 28 deletions(-)