### PR TITLE
Revise PR #249: the gate's own test reads the lane's build worktree, which no longer exists

### DIFF
--- a/.github/workflows/remote-routes-gate.yml
+++ b/.github/workflows/remote-routes-gate.yml
@@ -1,0 +1,35 @@
+name: Remote routes gate
+
+# Ensures every RemoteClient call path in taosmd/remote.py has a matching
+# routed literal in taosmd/http_server.py.  A missing route is invisible to
+# review-by-reading and invisible to the local test suite because the tests
+# only exercise the local (non-remote) path.  This gate catches it
+# mechanically before it ships.
+#
+# Paths built by interpolation (f-strings, %s) cannot be extracted by a
+# literal scan.  They are counted as unparseable call sites and reported so
+# a silent drop in coverage is visible.
+#
+# A Missing-Route-Intentionally trailer in the PR body waives named missing
+# routes, making deliberate omissions a conscious, auditable act.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  remote-routes-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Install deps
+        run: uv sync --python 3.12
+      - name: Check remote routes
+        run: python scripts/check_remote_routes.py

--- a/scripts/check_remote_routes.py
+++ b/scripts/check_remote_routes.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""RemoteClient routes gate.
+
+Extracts every ``self._run("<METHOD>", "<path>"`` literal from
+``taosmd/remote.py`` and requires each path to appear as a routed literal
+in ``taosmd/http_server.py``.  Fails with the method and path named.
+
+Paths built by interpolation (f-strings, ``%s``) cannot be extracted by a
+literal scan.  They are counted as unparseable call sites and reported so
+a silent drop in coverage is visible.
+
+A ``Missing-Route-Intentionally:`` trailer in the PR body waives named
+missing routes, making deliberate omissions a conscious, auditable act.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REMOTE = REPO_ROOT / "taosmd" / "remote.py"
+DEFAULT_HTTP = REPO_ROOT / "taosmd" / "http_server.py"
+TRAILER = "Missing-Route-Intentionally:"
+
+
+@dataclass(frozen=True)
+class RemoteCall:
+    method: str
+    path: str
+    lineno: int
+
+
+@dataclass(frozen=True)
+class MissingRoute:
+    method: str
+    path: str
+    lineno: int
+
+
+def _parse_remote_calls(source: str) -> tuple[list[RemoteCall], int]:
+    """Extract literal ``self._run(method, path)`` calls from remote.py.
+
+    Returns (literal_calls, unparseable_count).
+    """
+    tree = ast.parse(source)
+    calls: list[RemoteCall] = []
+    unparseable = 0
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "_run":
+            continue
+        if not isinstance(node.func.value, ast.Name):
+            continue
+        if node.func.value.id != "self":
+            continue
+        if len(node.args) < 2:
+            continue
+        method_arg = node.args[0]
+        path_arg = node.args[1]
+        if not isinstance(method_arg, ast.Constant) or not isinstance(method_arg.value, str):
+            continue
+        method = method_arg.value.upper()
+        if isinstance(path_arg, ast.Constant) and isinstance(path_arg.value, str):
+            calls.append(RemoteCall(method=method, path=path_arg.value, lineno=path_arg.lineno))
+        else:
+            unparseable += 1
+
+    return calls, unparseable
+
+
+def _is_path_related(node: ast.AST) -> bool:
+    """Return True if the node references the local variable ``path``."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name) and child.id == "path":
+            return True
+    return False
+
+
+def _extract_route_literals(source: str) -> set[str]:
+    """Extract routed path literals from http_server.py.
+
+    Collects string literals that appear in comparisons or method calls
+    involving the local variable ``path``.
+    """
+    tree = ast.parse(source)
+    literals: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare):
+            if not _is_path_related(node):
+                continue
+            for comparator in node.comparators:
+                if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+                    literals.add(comparator.value)
+                elif isinstance(comparator, (ast.Tuple, ast.List)):
+                    for elt in comparator.elts:
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                            literals.add(elt.value)
+        elif isinstance(node, ast.Call):
+            if not _is_path_related(node):
+                continue
+            if isinstance(node.func, ast.Attribute) and node.func.attr in ("startswith", "endswith"):
+                if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                    literals.add(node.args[0].value)
+
+    return literals
+
+
+def parse_waived_routes(pr_body: str | None) -> set[str]:
+    """Parse Missing-Route-Intentionally trailer from PR body text."""
+    waived: set[str] = set()
+    if not pr_body:
+        return waived
+    for line in pr_body.splitlines():
+        if TRAILER in line:
+            routes_str = line.split(TRAILER, 1)[1].strip()
+            for route in routes_str.split(","):
+                route = route.strip()
+                if route:
+                    waived.add(route)
+    return waived
+
+
+def check_remote_routes(
+    remote_path: Path = DEFAULT_REMOTE,
+    http_path: Path = DEFAULT_HTTP,
+    pr_body: str | None = None,
+) -> tuple[list[MissingRoute], set[str], int]:
+    """Main check function.
+
+    Returns (missing_routes, waived_routes, unparseable_count).
+    """
+    remote_source = remote_path.read_text(encoding="utf-8")
+    http_source = http_path.read_text(encoding="utf-8")
+
+    calls, unparseable = _parse_remote_calls(remote_source)
+    route_literals = _extract_route_literals(http_source)
+
+    missing: list[MissingRoute] = []
+    waived: set[str] = set()
+
+    waived.update(parse_waived_routes(pr_body))
+
+    for call in calls:
+        key = f"{call.method} {call.path}"
+        if call.path not in route_literals and key not in waived:
+            missing.append(MissingRoute(method=call.method, path=call.path, lineno=call.lineno))
+
+    return missing, waived, unparseable
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--remote", default=str(DEFAULT_REMOTE), help="Path to remote.py")
+    parser.add_argument("--http", default=str(DEFAULT_HTTP), help="Path to http_server.py")
+    parser.add_argument("--pr-body", default=None, help="PR body text (for Missing-Route-Intentionally trailer)")
+    args = parser.parse_args(argv)
+
+    pr_body = args.pr_body
+    if pr_body is None:
+        pr_body = os.environ.get("PR_BODY")
+
+    missing, waived, unparseable = check_remote_routes(
+        remote_path=Path(args.remote),
+        http_path=Path(args.http),
+        pr_body=pr_body,
+    )
+
+    if unparseable:
+        print(f"remote-routes-gate: {unparseable} unparseable call site(s) (interpolated paths not checked)")
+
+    if waived:
+        for route in sorted(waived):
+            print(f"remote-routes-gate: waived via {TRAILER} {route}")
+
+    if missing:
+        print(
+            f"REMOTE-ROUTES FAIL: {len(missing)} RemoteClient call path(s) have no matching "
+            f"routed literal in http_server.py:"
+        )
+        for m in missing:
+            print(f"  {m.method} {m.path} (remote.py:{m.lineno})")
+        print()
+        trailer_routes = ", ".join(f"{m.method} {m.path}" for m in missing)
+        print(
+            "If these omissions are intentional, add this trailer to the PR body and "
+            "the gate will re-run automatically:"
+        )
+        print()
+        print(f"    {TRAILER} {trailer_routes}")
+        return 1
+
+    print("remote-routes-gate: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_remote_routes_gate.py
+++ b/tests/test_remote_routes_gate.py
@@ -1,0 +1,230 @@
+"""Tests for scripts/check_remote_routes.py."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.check_remote_routes import (
+    MissingRoute,
+    check_remote_routes,
+    _extract_route_literals,
+    _parse_remote_calls,
+    parse_waived_routes,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(src: str, text: str) -> Path:
+    p = src / "tmp.py"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+REMOTE_BASE = '''
+from taosmd.remote import RemoteClient
+
+class Foo:
+    def _run(self, method, path):
+        pass
+
+    async def ok(self):
+        return await self._run("POST", "/ingest")
+
+    async def missing(self):
+        return await self._run("POST", "/no-route")
+
+    async def fstring(self):
+        return await self._run("POST", f"/tasks/{{x}}")
+'''
+
+
+HTTP_BASE = '''
+def _dispatch(self, method, path):
+    if method == "POST" and path == "/ingest":
+        pass
+    if method == "POST" and path == "/no-route":
+        pass
+'''
+
+
+# ---------------------------------------------------------------------------
+# _parse_remote_calls
+# ---------------------------------------------------------------------------
+
+class TestParseRemoteCalls:
+    def test_literal_calls_extracted(self):
+        calls, unparseable = _parse_remote_calls(REMOTE_BASE)
+        methods = {c.method for c in calls}
+        paths = {c.path for c in calls}
+        assert "POST" in methods
+        assert "/ingest" in paths
+        assert "/no-route" in paths
+        assert unparseable == 1
+
+    def test_unparseable_count(self):
+        _, unparseable = _parse_remote_calls(REMOTE_BASE)
+        assert unparseable == 1
+
+
+# ---------------------------------------------------------------------------
+# _extract_route_literals
+# ---------------------------------------------------------------------------
+
+class TestExtractRouteLiterals:
+    def test_exact_match(self):
+        src = '''
+def _dispatch(self, method, path):
+    if method == "POST" and path == "/ingest":
+        pass
+'''
+        assert "/ingest" in _extract_route_literals(src)
+
+    def test_prefix_match(self):
+        src = '''
+def _dispatch(self, method, path):
+    if method == "POST" and path.startswith("/tasks/"):
+        pass
+'''
+        assert "/tasks/" in _extract_route_literals(src)
+
+    def test_suffix_match(self):
+        src = '''
+def _dispatch(self, method, path):
+    if path.endswith("/edges"):
+        pass
+'''
+        assert "/edges" in _extract_route_literals(src)
+
+    def test_in_operator(self):
+        src = '''
+def _dispatch(self, method, path):
+    if path in ("/a", "/b"):
+        pass
+'''
+        assert "/a" in _extract_route_literals(src)
+        assert "/b" in _extract_route_literals(src)
+
+
+# ---------------------------------------------------------------------------
+# parse_waived_routes
+# ---------------------------------------------------------------------------
+
+class TestParseWaivedRoutes:
+    def test_no_trailer(self):
+        assert parse_waived_routes(None) == set()
+        assert parse_waived_routes("hello world") == set()
+
+    def test_single_route(self):
+        body = "Some description\n\nMissing-Route-Intentionally: POST /no-route"
+        assert parse_waived_routes(body) == {"POST /no-route"}
+
+    def test_multiple_routes(self):
+        body = "Missing-Route-Intentionally: POST /a, GET /b"
+        assert parse_waived_routes(body) == {"POST /a", "GET /b"}
+
+    def test_trailer_with_surrounding_text(self):
+        body = "Fixed in another PR. Missing-Route-Intentionally: POST /x"
+        assert parse_waived_routes(body) == {"POST /x"}
+
+
+# ---------------------------------------------------------------------------
+# check_remote_routes
+# ---------------------------------------------------------------------------
+
+class TestCheckRemoteRoutes:
+    def test_clean_when_all_routes_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            remote = Path(tmp) / "remote.py"
+            http = Path(tmp) / "http_server.py"
+            remote.write_text(REMOTE_BASE, encoding="utf-8")
+            http.write_text(HTTP_BASE, encoding="utf-8")
+            missing, waived, unparseable = check_remote_routes(remote_path=remote, http_path=http)
+            assert missing == []
+            assert waived == set()
+            assert unparseable == 1
+
+    def test_detects_missing_route(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            remote = Path(tmp) / "remote.py"
+            http = Path(tmp) / "http_server.py"
+            remote.write_text(REMOTE_BASE, encoding="utf-8")
+            # http_server.py has only /ingest, not /no-route
+            http_src = '''
+def _dispatch(self, method, path):
+    if method == "POST" and path == "/ingest":
+        pass
+'''
+            http.write_text(http_src, encoding="utf-8")
+            missing, _, unparseable = check_remote_routes(remote_path=remote, http_path=http)
+            assert len(missing) == 1
+            m = missing[0]
+            assert isinstance(m, MissingRoute)
+            assert m.method == "POST"
+            assert m.path == "/no-route"
+            assert m.lineno == 12
+            assert unparseable == 1
+
+    def test_waiver_trailer_suppresses_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            remote = Path(tmp) / "remote.py"
+            http = Path(tmp) / "http_server.py"
+            remote.write_text(REMOTE_BASE, encoding="utf-8")
+            http.write_text(HTTP_BASE, encoding="utf-8")
+            missing, waived, unparseable = check_remote_routes(
+                remote_path=remote,
+                http_path=http,
+                pr_body="Missing-Route-Intentionally: POST /no-route",
+            )
+            assert missing == []
+            assert waived == {"POST /no-route"}
+            assert unparseable == 1
+
+    def test_multiple_missing_routes(self):
+        remote_src = '''
+class Foo:
+    def _run(self, method, path):
+        pass
+
+    async def a(self):
+        return await self._run("POST", "/alpha")
+
+    async def b(self):
+        return await self._run("GET", "/beta")
+'''
+        http_src = '''
+def _dispatch(self, method, path):
+    if path == "/alpha":
+        pass
+'''
+        with tempfile.TemporaryDirectory() as tmp:
+            remote = Path(tmp) / "remote.py"
+            http = Path(tmp) / "http_server.py"
+            remote.write_text(remote_src, encoding="utf-8")
+            http.write_text(http_src, encoding="utf-8")
+            missing, _, _ = check_remote_routes(remote_path=remote, http_path=http)
+            assert len(missing) == 1
+            assert missing[0].path == "/beta"
+
+
+# ---------------------------------------------------------------------------
+# Integration: current repo files
+# ---------------------------------------------------------------------------
+
+class TestCurrentRepo:
+    def test_master_is_clean(self):
+        missing, _, unparseable = check_remote_routes()
+        assert missing == [], f"Expected clean but got missing: {missing}"
+        assert unparseable == 3
+
+    def test_at_least_twenty_literal_paths(self):
+        calls, _ = _parse_remote_calls(
+            (REPO_ROOT / "taosmd" / "remote.py").read_text(encoding="utf-8")
+        )
+        assert len(calls) >= 20


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #249: the gate's own test reads the lane's build worktree, which no longer exists

Autonomous build of board card tsk-hb2y7n.

The test at line 226 in tests/test_remote_routes_gate.py read
Path("/tmp/exec-tsk-bwgr26/taosmd/remote.py"), the lane's own build
worktree, which no longer exists. Read the repo's own taosmd/remote.py
via REPO_ROOT instead so the test passes in any environment, matching
the behaviour the gate is meant to enforce.

Carry forward the tsk-bwgr26 work via squash merge.

Files:
 .github/workflows/remote-routes-gate.yml |  35 +++++
 scripts/check_remote_routes.py           | 206 +++++++++++++++++++++++++++
 tests/test_remote_routes_gate.py         | 230 +++++++++++++++++++++++++++++++
 3 files changed, 471 insertions(+)