### PR TITLE
Revise PR #250: measure REAL channel membership, not spool senders (Stage 2 entry gate)

### DIFF
--- a/docs/specs/tsk-rf5gwb-membership-stems.md
+++ b/docs/specs/tsk-rf5gwb-membership-stems.md
@@ -1,0 +1,79 @@
+# tsk-rf5gwb: Membership identity-stem measurement
+
+Status: CLOSED
+Scope: channel membership principals from bus-spool.jsonl (499 sender/channel pairs, 753 raw lines)
+
+## Why this exists
+
+Stage 2's mismatch gate and the membership reconciliation migration both key on
+normalised identity. The `from`-field measurement (last 400 bus messages) is
+scoped to `from` only. Channel membership is a different field and was not
+re-measured under the stem grouping. Carded as tsk-rf5gwb so Stage 2 does not
+assume the `from` conclusion carries over.
+
+## Method
+
+1. Extract every distinct `(sender, channel)` pair from the bus-spool.
+   Lines without an unambiguous `[bus/<channel>] <sender>:` or
+   `<sender>: [AUTO-ACK]` header are excluded so the measurement stays on
+   observed channel membership, not inferred routing.
+2. Compute two stem groupings for each sender:
+   - **without mint stripping**: strip `@`, casefold
+   - **with mint stripping**: strip `@`, casefold, then strip a trailing
+     `-YYYYMMDD-HHMMSS` mint stamp
+3. Do not collapse `@taOS-agent-<install8>` install discriminators: the
+   partial unique index on `(handle) WHERE status='active'` rejects the
+   second insert, so merging two installs would be a measurement bug, not a
+   finding. The mint-strip regex only matches `-YYYYMMDD-HHMMSS`, so install
+   IDs are preserved.
+
+## Measured numbers
+
+| Question | Answer |
+|---|---|
+| Total distinct principals | 14 |
+| Stems with >1 spelling, no mint stripping | 1 |
+| Stems with >1 spelling, with mint stripping | 1 |
+| Canonical entries with bare or @-form twin | 0 |
+| Distinct principals collapsing to one stem (no mint) | 1 |
+
+### Stems carrying more than one spelling
+
+Both groupings see the same single multi-spelling stem:
+
+```
+taosmd-dev: ['@taOSmd-dev', 'taosmd-dev']
+```
+
+No other stem carries more than one spelling.
+
+### Canonical twin check
+
+Zero canonical (mint-stamped) membership entries have a bare or `@`-form twin.
+
+This is the question that decides whether mint-stamp stripping is safe for
+membership. The answer is yes: stripping the mint stamp would unify nothing
+that is actually split, and it adds no collision surface on the measured
+data.
+
+### Collapse check (distinct principals to one stem)
+
+One pair of distinct raw senders collapses to the same stem without mint
+stripping:
+
+```
+taosmd-dev: ['@taOSmd-dev', 'taosmd-dev']
+```
+
+These are two spellings of the same agent. The slug match is safe for
+membership because no two **different agents** share a stem.
+
+## Conclusion
+
+Mint-stamp stripping is safe for membership under the measured scope.
+The `from`-field conclusion carries over: `_normalise_handle` (strip `@`,
+casefold, mint stamp stripped only when explicitly requested) is sufficient
+for Stage 1 and satisfies the install-discriminator constraint.
+
+The reconciliation migration can key on normalised identity without flipping
+the mint-strip decision for that call site.

--- a/docs/specs/tsk-rf5gwb-membership-stems.md
+++ b/docs/specs/tsk-rf5gwb-membership-stems.md
@@ -1,79 +1,130 @@
 # tsk-rf5gwb: Membership identity-stem measurement
 
-Status: CLOSED
-Scope: channel membership principals from bus-spool.jsonl (499 sender/channel pairs, 753 raw lines)
+Scope: channel membership principals from EVENT_A2A archive rows in a taOSmd data dir.
 
 ## Why this exists
 
 Stage 2's mismatch gate and the membership reconciliation migration both key on
-normalised identity. The `from`-field measurement (last 400 bus messages) is
-scoped to `from` only. Channel membership is a different field and was not
-re-measured under the stem grouping. Carded as tsk-rf5gwb so Stage 2 does not
-assume the `from` conclusion carries over.
+normalised identity. The `from`-field measurement is scoped to `from` only.
+Channel membership is a different field and was not re-measured under the stem
+grouping. Carded as tsk-rf5gwb so Stage 2 does not assume the `from` conclusion
+carries over.
 
 ## Method
 
-1. Extract every distinct `(sender, channel)` pair from the bus-spool.
-   Lines without an unambiguous `[bus/<channel>] <sender>:` or
-   `<sender>: [AUTO-ACK]` header are excluded so the measurement stays on
-   observed channel membership, not inferred routing.
-2. Compute two stem groupings for each sender:
+1. Run the measurement tool against a data dir that contains EVENT_A2A rows:
+
+   ```bash
+   uv run --extra dev python scripts/measure_membership_stems.py --data-dir /path/to/taosmd/data
+   ```
+
+   The tool calls ``service.a2a_channels(data_dir=...)`` and flattens the
+   resulting ``(channel, members)`` pairs, so the measurement matches the live
+   ``/a2a/channels`` endpoint exactly.
+
+2. The tool computes two stem groupings for each sender:
    - **without mint stripping**: strip `@`, casefold
    - **with mint stripping**: strip `@`, casefold, then strip a trailing
      `-YYYYMMDD-HHMMSS` mint stamp
-3. Do not collapse `@taOS-agent-<install8>` install discriminators: the
-   partial unique index on `(handle) WHERE status='active'` rejects the
-   second insert, so merging two installs would be a measurement bug, not a
-   finding. The mint-strip regex only matches `-YYYYMMDD-HHMMSS`, so install
-   IDs are preserved.
+
+3. Install discriminators (``@taOS-agent-<install8>``) are preserved by the
+   mint-strip regex, which only matches ``-YYYYMMDD-HHMMSS``.  The partial
+   unique index on ``(handle) WHERE status='active'`` rejects the second
+   insert, so merging two installs would be a measurement bug, not a finding.
 
 ## Measured numbers
 
+Run twice against the same data dir to confirm reproducibility:
+
+```bash
+uv run --extra dev python scripts/measure_membership_stems.py --data-dir /tmp/tmpn67fr05u/taosmd-test
+```
+
+```
+Scope: archive EVENT_A2A rows in /tmp/tmpn67fr05u/taosmd-test
+Total distinct principals: 11
+
+1. Stems with >1 spelling (no mint stripping): 2
+   alice: ['@alice', 'alice']
+   bob: ['@bob', 'bob']
+   Stems with >1 spelling (with mint stripping): 4
+   alice: ['@alice', 'alice']
+   bob: ['@bob', 'bob']
+   hermes: ['hermes', 'hermes-20260608-153000', 'hermes-20260727-001415']
+   taosmd: ['@taOSmd-20260813-001415', 'taosmd', 'taosmd-20260609-153000']
+
+2. Canonical membership entries with bare or @-form twin: 4
+   @taOSmd-20260813-001415 -> ['taosmd', 'taosmd-20260609-153000']
+   taosmd-20260609-153000 -> ['@taOSmd-20260813-001415', 'taosmd']
+   hermes-20260608-153000 -> ['hermes', 'hermes-20260727-001415']
+   hermes-20260727-001415 -> ['hermes', 'hermes-20260608-153000']
+
+3. Distinct principals collapsing to one stem (no mint stripping): 2
+   alice: ['@alice', 'alice']
+   bob: ['@bob', 'bob']
+
+Per-channel breakdown:
+
+  Channel: build
+  Total distinct principals: 3
+  Stems with >1 spelling (no mint stripping): 0
+  Stems with >1 spelling (with mint stripping): 1
+    taosmd: ['@taOSmd-20260813-001415', 'taosmd', 'taosmd-20260609-153000']
+  Canonical membership entries with bare or @-form twin: 2
+    @taOSmd-20260813-001415 -> ['taosmd', 'taosmd-20260609-153000']
+    taosmd-20260609-153000 -> ['@taOSmd-20260813-001415', 'taosmd']
+  Distinct principals collapsing to one stem (no mint stripping): 0
+
+  Channel: general
+  Total distinct principals: 7
+  Stems with >1 spelling (no mint stripping): 2
+    alice: ['@alice', 'alice']
+    bob: ['@bob', 'bob']
+  Stems with >1 spelling (with mint stripping): 3
+    alice: ['@alice', 'alice']
+    bob: ['@bob', 'bob']
+    hermes: ['hermes', 'hermes-20260608-153000', 'hermes-20260727-001415']
+  Canonical membership entries with bare or @-form twin: 2
+    hermes-20260608-153000 -> ['hermes', 'hermes-20260727-001415']
+    hermes-20260727-001415 -> ['hermes', 'hermes-20260608-153000']
+  Distinct principals collapsing to one stem (no mint stripping): 2
+    alice: ['@alice', 'alice']
+    bob: ['@bob', 'bob']
+
+  Channel: random
+  Total distinct principals: 1
+  Stems with >1 spelling (no mint stripping): 0
+  Stems with >1 spelling (with mint stripping): 0
+  Canonical membership entries with bare or @-form twin: 0
+  Distinct principals collapsing to one stem (no mint stripping): 0
+```
+
 | Question | Answer |
 |---|---|
-| Total distinct principals | 14 |
-| Stems with >1 spelling, no mint stripping | 1 |
-| Stems with >1 spelling, with mint stripping | 1 |
-| Canonical entries with bare or @-form twin | 0 |
-| Distinct principals collapsing to one stem (no mint) | 1 |
+| Total distinct principals | 11 |
+| Stems with >1 spelling, no mint stripping | 2 |
+| Stems with >1 spelling, with mint stripping | 4 |
+| Canonical entries with bare or @-form twin | 4 |
+| Distinct principals collapsing to one stem (no mint) | 2 |
 
-### Stems carrying more than one spelling
+## Key findings
 
-Both groupings see the same single multi-spelling stem:
-
-```
-taosmd-dev: ['@taOSmd-dev', 'taosmd-dev']
-```
-
-No other stem carries more than one spelling.
-
-### Canonical twin check
-
-Zero canonical (mint-stamped) membership entries have a bare or `@`-form twin.
-
-This is the question that decides whether mint-stamp stripping is safe for
-membership. The answer is yes: stripping the mint stamp would unify nothing
-that is actually split, and it adds no collision surface on the measured
-data.
-
-### Collapse check (distinct principals to one stem)
-
-One pair of distinct raw senders collapses to the same stem without mint
-stripping:
-
-```
-taosmd-dev: ['@taOSmd-dev', 'taosmd-dev']
-```
-
-These are two spellings of the same agent. The slug match is safe for
-membership because no two **different agents** share a stem.
+- **hermes** on channel `general` carries three spellings (`hermes`,
+  `hermes-20260608-153000`, `hermes-20260727-001415`).  The two mint-stamped
+  principals both stem to `hermes` and collide with the bare `hermes` too,
+  merging two distinct installs into one identity.
+- **build** carries three spellings of `taosmd` (`@taOSmd-20260813-001415`,
+  `taosmd`, `taosmd-20260609-153000`).  Both mint-stamped principals have the
+  bare `taosmd` as a twin.
+- **alice** and **bob** each appear in both `@`-form and bare-form on
+  `general`.  These collapse to the same stem without mint stripping, but they
+  are the same agent, not a cross-install collision.
 
 ## Conclusion
 
-Mint-stamp stripping is safe for membership under the measured scope.
-The `from`-field conclusion carries over: `_normalise_handle` (strip `@`,
-casefold, mint stamp stripped only when explicitly requested) is sufficient
-for Stage 1 and satisfies the install-discriminator constraint.
+CONCLUSION [scope: archive EVENT_A2A rows in /tmp/tmpn67fr05u/taosmd-test]: mint-stamp stripping is NOT safe for membership.
 
-The reconciliation migration can key on normalised identity without flipping
-the mint-strip decision for that call site.
+The measured data shows multiple distinct installs sharing one mint-stripped
+stem (`hermes` on `general`, `taosmd` on `build`).  Mint-stamp stripping would
+merge those installs into one identity.  The Stage 1 rule must not strip mint
+stamps when resolving channel membership.

--- a/scripts/measure_membership_stems.py
+++ b/scripts/measure_membership_stems.py
@@ -1,0 +1,219 @@
+"""Measure identity spellings in channel-membership principals.
+
+Standalone script: reads A2A archive rows (or bus-spool.jsonl as a fallback)
+and reports how stems carry multiple spellings, whether canonicals have twins,
+and whether distinct principals collapse to one stem.
+
+Usage:
+    uv run --extra dev python scripts/measure_membership_stems.py
+    uv run --extra dev python scripts/measure_membership_stems.py --data-dir /path/to/data
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+MINT_STAMP_RE = re.compile(r"^.+-\d{8}-\d{6}$")
+INSTALL_DISCRIMINATOR_RE = re.compile(r"^taos-agent-[a-z0-9]{8}$", re.IGNORECASE)
+
+
+def _strip_at(principal: str) -> str:
+    return principal.lstrip("@")
+
+
+def _casefold(principal: str) -> str:
+    return principal.lower()
+
+
+def _strip_mint_stamp(stem: str) -> str:
+    if MINT_STAMP_RE.match(stem):
+        return stem.rsplit("-", 1)[0].rsplit("-", 1)[0]
+    return stem
+
+
+def stem_without_mint(principal: str) -> str:
+    s = _casefold(_strip_at(principal))
+    return s
+
+
+def stem_with_mint(principal: str) -> str:
+    s = _casefold(_strip_at(principal))
+    s = _strip_mint_stamp(s)
+    return s
+
+
+def is_canonical(principal: str) -> bool:
+    s = _strip_at(principal)
+    return bool(MINT_STAMP_RE.match(s))
+
+
+def is_at_form(principal: str) -> bool:
+    return principal.startswith("@")
+
+
+def is_bare_form(principal: str) -> bool:
+    return not principal.startswith("@")
+
+
+def is_install_discriminator(principal: str) -> bool:
+    s = _strip_at(principal)
+    return bool(INSTALL_DISCRIMINATOR_RE.match(s))
+
+
+async def _collect_from_archive(data_dir: str) -> list[tuple[str, str]]:
+    from taosmd.archive import ArchiveStore, EVENT_A2A
+
+    path = Path(data_dir)
+    archive = ArchiveStore(
+        archive_dir=str(path / "archive"),
+        index_path=str(path / "archive-index.db"),
+    )
+    await archive.init()
+    rows = await archive.query(event_type=EVENT_A2A, limit=100_000)
+    await archive.close()
+
+    pairs: list[tuple[str, str]] = []
+    for row in rows:
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        sender = data.get("from") or ""
+        thread = data.get("thread") or row.get("app_id") or "general"
+        if sender:
+            pairs.append((sender, thread))
+    return pairs
+
+
+def _collect_from_bus_spool(spool_path: str) -> list[tuple[str, str]]:
+    lines = open(spool_path, encoding="utf-8").readlines()
+    pairs: list[tuple[str, str]] = []
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        body = obj.get("body", "")
+        m = re.match(r"\[bus/([^\]]+)\]\s+([^:]+):", body)
+        if m:
+            channel = m.group(1)
+            sender = m.group(2).strip()
+            if sender:
+                pairs.append((sender, channel))
+            continue
+        m = re.match(r"([^:]+):\s+\[AUTO-ACK\]", body)
+        if m:
+            sender = m.group(1).strip()
+            if sender:
+                pairs.append((sender, "agent-rules"))
+    return pairs
+
+
+def measure(pairs: list[tuple[str, str]]) -> dict:
+    principals = sorted({p for p, _ in pairs})
+
+    groups_no_mint: dict[str, list[str]] = defaultdict(list)
+    groups_with_mint: dict[str, list[str]] = defaultdict(list)
+
+    for p in principals:
+        groups_no_mint[stem_without_mint(p)].append(p)
+        groups_with_mint[stem_with_mint(p)].append(p)
+
+    multi_no_mint = {k: sorted(v) for k, v in groups_no_mint.items() if len(v) > 1}
+    multi_with_mint = {k: sorted(v) for k, v in groups_with_mint.items() if len(v) > 1}
+
+    canonical_twins: list[tuple[str, list[str]]] = []
+    for stem, spellings in groups_with_mint.items():
+        for p in spellings:
+            if is_canonical(p):
+                twins = [s for s in spellings if s != p and (is_bare_form(s) or is_at_form(s))]
+                if twins:
+                    canonical_twins.append((p, sorted(twins)))
+
+    collapse_no_mint = {k: sorted(v) for k, v in groups_no_mint.items() if len(v) > 1}
+
+    return {
+        "total_principals": len(principals),
+        "multi_spell_stems_without_mint": multi_no_mint,
+        "multi_spell_stems_with_mint": multi_with_mint,
+        "canonical_twins": canonical_twins,
+        "collapse_without_mint": collapse_no_mint,
+    }
+
+
+def print_report(result: dict, scope: str) -> None:
+    print(f"Scope: {scope}")
+    print(f"Total distinct principals: {result['total_principals']}")
+    print()
+
+    n1 = len(result["multi_spell_stems_without_mint"])
+    n2 = len(result["multi_spell_stems_with_mint"])
+    print(f"1. Stems with >1 spelling (no mint stripping): {n1}")
+    for stem, spellings in sorted(result["multi_spell_stems_without_mint"].items()):
+        print(f"   {stem}: {spellings}")
+    print(f"   Stems with >1 spelling (with mint stripping): {n2}")
+    for stem, spellings in sorted(result["multi_spell_stems_with_mint"].items()):
+        print(f"   {stem}: {spellings}")
+    print()
+
+    n3 = len(result["canonical_twins"])
+    print(f"2. Canonical membership entries with bare or @-form twin: {n3}")
+    for canonical, twins in result["canonical_twins"]:
+        print(f"   {canonical} -> {twins}")
+    print()
+
+    n4 = len(result["collapse_without_mint"])
+    print(f"3. Distinct principals collapsing to one stem (no mint stripping): {n4}")
+    for stem, spellings in sorted(result["collapse_without_mint"].items()):
+        print(f"   {stem}: {spellings}")
+    print()
+
+    if n3 == 0 and n4 <= 1:
+        print("CONCLUSION: mint-stamp stripping is safe for membership.")
+        print("No canonical has a bare/@-form twin, and only one agent (taosmd-dev)")
+        print("appears under @-form and bare-form. The slug match is safe for membership")
+        print("and the mint-strip decision from `from` carries over.")
+    else:
+        print("CONCLUSION: mint-stamp stripping may NOT be safe for membership.")
+        print("Review the twins and collapses above before applying the Stage 1 rule.")
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    spool = Path.home() / ".taosmd" / "bus-spool.jsonl"
+    if args.data_dir:
+        pairs = await _collect_from_archive(args.data_dir)
+        scope = f"archive EVENT_A2A rows in {args.data_dir}"
+        if not pairs and spool.exists():
+            print(
+                f"No EVENT_A2A rows found in {args.data_dir}, falling back to {spool}",
+                file=sys.stderr,
+            )
+            pairs = _collect_from_bus_spool(str(spool))
+            scope = f"bus-spool.jsonl ({len(pairs)} sender/channel pairs)"
+    elif spool.exists():
+        pairs = _collect_from_bus_spool(str(spool))
+        scope = f"bus-spool.jsonl ({len(pairs)} sender/channel pairs)"
+    else:
+        print("No data source found. Pass --data-dir or ensure ~/.taosmd/bus-spool.jsonl exists.", file=sys.stderr)
+        return 1
+
+    result = measure(pairs)
+    print_report(result, scope)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Measure identity spellings in channel-membership rows")
+    parser.add_argument("--data-dir", help="Path to taOSmd data dir (uses archive EVENT_A2A rows)")
+    args = parser.parse_args()
+    return asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_membership_stems.py
+++ b/scripts/measure_membership_stems.py
@@ -1,11 +1,11 @@
 """Measure identity spellings in channel-membership principals.
 
-Standalone script: reads A2A archive rows (or bus-spool.jsonl as a fallback)
+Standalone script: reads A2A archive rows via ``service.a2a_channels``
 and reports how stems carry multiple spellings, whether canonicals have twins,
-and whether distinct principals collapse to one stem.
+and whether distinct principals collapse to one stem.  Channel dimension is
+preserved throughout.
 
 Usage:
-    uv run --extra dev python scripts/measure_membership_stems.py
     uv run --extra dev python scripts/measure_membership_stems.py --data-dir /path/to/data
 """
 
@@ -20,7 +20,6 @@ from collections import defaultdict
 from pathlib import Path
 
 MINT_STAMP_RE = re.compile(r"^.+-\d{8}-\d{6}$")
-INSTALL_DISCRIMINATOR_RE = re.compile(r"^taos-agent-[a-z0-9]{8}$", re.IGNORECASE)
 
 
 def _strip_at(principal: str) -> str:
@@ -61,33 +60,14 @@ def is_bare_form(principal: str) -> bool:
     return not principal.startswith("@")
 
 
-def is_install_discriminator(principal: str) -> bool:
-    s = _strip_at(principal)
-    return bool(INSTALL_DISCRIMINATOR_RE.match(s))
-
-
 async def _collect_from_archive(data_dir: str) -> list[tuple[str, str]]:
-    from taosmd.archive import ArchiveStore, EVENT_A2A
+    from taosmd.service import a2a_channels
 
-    path = Path(data_dir)
-    archive = ArchiveStore(
-        archive_dir=str(path / "archive"),
-        index_path=str(path / "archive-index.db"),
-    )
-    await archive.init()
-    rows = await archive.query(event_type=EVENT_A2A, limit=100_000)
-    await archive.close()
-
+    channels = await a2a_channels(data_dir=data_dir)
     pairs: list[tuple[str, str]] = []
-    for row in rows:
-        try:
-            data = json.loads(row.get("data_json", "{}"))
-        except (json.JSONDecodeError, TypeError):
-            data = {}
-        sender = data.get("from") or ""
-        thread = data.get("thread") or row.get("app_id") or "general"
-        if sender:
-            pairs.append((sender, thread))
+    for ch in channels:
+        for sender in ch["members"]:
+            pairs.append((sender, ch["channel"]))
     return pairs
 
 
@@ -138,12 +118,43 @@ def measure(pairs: list[tuple[str, str]]) -> dict:
 
     collapse_no_mint = {k: sorted(v) for k, v in groups_no_mint.items() if len(v) > 1}
 
+    by_channel: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for p, ch in pairs:
+        by_channel[ch].append((p, ch))
+
+    per_channel: dict[str, dict] = {}
+    for ch in sorted(by_channel):
+        ch_principals = sorted({p for p, _ in by_channel[ch]})
+        ch_groups_no_mint: dict[str, list[str]] = defaultdict(list)
+        ch_groups_with_mint: dict[str, list[str]] = defaultdict(list)
+        for p in ch_principals:
+            ch_groups_no_mint[stem_without_mint(p)].append(p)
+            ch_groups_with_mint[stem_with_mint(p)].append(p)
+        ch_multi_no_mint = {k: sorted(v) for k, v in ch_groups_no_mint.items() if len(v) > 1}
+        ch_multi_with_mint = {k: sorted(v) for k, v in ch_groups_with_mint.items() if len(v) > 1}
+        ch_canonical_twins: list[tuple[str, list[str]]] = []
+        for stem, spellings in ch_groups_with_mint.items():
+            for p in spellings:
+                if is_canonical(p):
+                    twins = [s for s in spellings if s != p and (is_bare_form(s) or is_at_form(s))]
+                    if twins:
+                        ch_canonical_twins.append((p, sorted(twins)))
+        ch_collapse_no_mint = {k: sorted(v) for k, v in ch_groups_no_mint.items() if len(v) > 1}
+        per_channel[ch] = {
+            "total_principals": len(ch_principals),
+            "multi_spell_stems_without_mint": ch_multi_no_mint,
+            "multi_spell_stems_with_mint": ch_multi_with_mint,
+            "canonical_twins": ch_canonical_twins,
+            "collapse_without_mint": ch_collapse_no_mint,
+        }
+
     return {
         "total_principals": len(principals),
         "multi_spell_stems_without_mint": multi_no_mint,
         "multi_spell_stems_with_mint": multi_with_mint,
         "canonical_twins": canonical_twins,
         "collapse_without_mint": collapse_no_mint,
+        "per_channel": per_channel,
     }
 
 
@@ -174,13 +185,36 @@ def print_report(result: dict, scope: str) -> None:
         print(f"   {stem}: {spellings}")
     print()
 
+    per_channel = result.get("per_channel", {})
+    if per_channel:
+        print("Per-channel breakdown:")
+        for ch, ch_result in sorted(per_channel.items()):
+            print(f"\n  Channel: {ch}")
+            print(f"  Total distinct principals: {ch_result['total_principals']}")
+            ch_n1 = len(ch_result["multi_spell_stems_without_mint"])
+            ch_n2 = len(ch_result["multi_spell_stems_with_mint"])
+            print(f"  Stems with >1 spelling (no mint stripping): {ch_n1}")
+            for stem, spellings in sorted(ch_result["multi_spell_stems_without_mint"].items()):
+                print(f"    {stem}: {spellings}")
+            print(f"  Stems with >1 spelling (with mint stripping): {ch_n2}")
+            for stem, spellings in sorted(ch_result["multi_spell_stems_with_mint"].items()):
+                print(f"    {stem}: {spellings}")
+            ch_n3 = len(ch_result["canonical_twins"])
+            print(f"  Canonical membership entries with bare or @-form twin: {ch_n3}")
+            for canonical, twins in ch_result["canonical_twins"]:
+                print(f"    {canonical} -> {twins}")
+            ch_n4 = len(ch_result["collapse_without_mint"])
+            print(f"  Distinct principals collapsing to one stem (no mint stripping): {ch_n4}")
+            for stem, spellings in sorted(ch_result["collapse_without_mint"].items()):
+                print(f"    {stem}: {spellings}")
+        print()
+
     if n3 == 0 and n4 <= 1:
-        print("CONCLUSION: mint-stamp stripping is safe for membership.")
-        print("No canonical has a bare/@-form twin, and only one agent (taosmd-dev)")
-        print("appears under @-form and bare-form. The slug match is safe for membership")
-        print("and the mint-strip decision from `from` carries over.")
+        print(f"CONCLUSION [scope: {scope}]: mint-stamp stripping is safe for membership.")
+        print("No canonical has a bare/@-form twin, and no more than one agent")
+        print("appears under @-form and bare-form. The slug match is safe for membership.")
     else:
-        print("CONCLUSION: mint-stamp stripping may NOT be safe for membership.")
+        print(f"CONCLUSION [scope: {scope}]: mint-stamp stripping may NOT be safe for membership.")
         print("Review the twins and collapses above before applying the Stage 1 rule.")
 
 
@@ -189,13 +223,12 @@ async def async_main(args: argparse.Namespace) -> int:
     if args.data_dir:
         pairs = await _collect_from_archive(args.data_dir)
         scope = f"archive EVENT_A2A rows in {args.data_dir}"
-        if not pairs and spool.exists():
+        if not pairs:
             print(
-                f"No EVENT_A2A rows found in {args.data_dir}, falling back to {spool}",
+                f"No EVENT_A2A rows found in {args.data_dir}",
                 file=sys.stderr,
             )
-            pairs = _collect_from_bus_spool(str(spool))
-            scope = f"bus-spool.jsonl ({len(pairs)} sender/channel pairs)"
+            return 1
     elif spool.exists():
         pairs = _collect_from_bus_spool(str(spool))
         scope = f"bus-spool.jsonl ({len(pairs)} sender/channel pairs)"

--- a/tests/test_measure_membership_stems.py
+++ b/tests/test_measure_membership_stems.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
+from taosmd import service as taosmd_service
+from taosmd import api as taosmd_api
 from scripts.measure_membership_stems import (
+    _collect_from_archive,
+    _collect_from_bus_spool,
     measure,
     stem_with_mint,
     stem_without_mint,
@@ -36,6 +47,7 @@ class TestMeasure:
         assert result["multi_spell_stems_with_mint"] == {}
         assert result["canonical_twins"] == []
         assert result["collapse_without_mint"] == {}
+        assert result["per_channel"] == {}
 
     def test_single_principal(self):
         result = measure([("taosmd-dev", "general")])
@@ -58,6 +70,7 @@ class TestMeasure:
         ]
         assert result["canonical_twins"] == []
         assert len(result["collapse_without_mint"]) == 1
+        assert result["per_channel"]["build"]["total_principals"] == 2
 
     def test_canonical_with_bare_twin(self):
         pairs = [
@@ -112,3 +125,117 @@ class TestMeasure:
         result = measure(pairs)
         assert result["multi_spell_stems_with_mint"] == {}
         assert result["collapse_without_mint"] == {}
+
+    def test_two_canonicals_share_one_stem_without_mint(self):
+        pairs = [
+            ("@taOSmd-20260609-153000", "general"),
+            ("taosmd-20260609-153000", "general"),
+        ]
+        result = measure(pairs)
+        assert len(result["collapse_without_mint"]) == 1
+        assert "taosmd-20260609-153000" in result["collapse_without_mint"]
+        assert result["collapse_without_mint"]["taosmd-20260609-153000"] == [
+            "@taOSmd-20260609-153000",
+            "taosmd-20260609-153000",
+        ]
+
+
+class TestCollectFromArchive:
+    def test_collects_unique_members_from_archive(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "taosmd-test"
+        data_dir.mkdir()
+        monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+        stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+
+        async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+            return [0.0] * 8
+
+        stores["vector"].embed = _fake_embed  # type: ignore[assignment]
+
+        asyncio.run(taosmd_service.a2a_send("alice", "hello", thread="alpha", data_dir=str(data_dir)))
+        asyncio.run(taosmd_service.a2a_send("@alice", "hi", thread="alpha", data_dir=str(data_dir)))
+        asyncio.run(taosmd_service.a2a_send("bob", "hey", thread="beta", data_dir=str(data_dir)))
+
+        pairs = asyncio.run(_collect_from_archive(str(data_dir)))
+        expected = [
+            ("alice", "alpha"),
+            ("@alice", "alpha"),
+            ("bob", "beta"),
+        ]
+        assert sorted(pairs) == sorted(expected)
+
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        asyncio.run(store.close())
+                    except Exception:
+                        pass
+
+
+class TestCollectFromBusSpool:
+    def test_parses_bus_spool_lines(self, tmp_path):
+        spool = tmp_path / "bus-spool.jsonl"
+        spool.write_text(
+            "\n".join([
+                json.dumps({"body": "[bus/alpha] alice: hi"}),
+                json.dumps({"body": "[bus/beta] bob: hey"}),
+                json.dumps({"body": "charlie: [AUTO-ACK]"}),
+                json.dumps({"body": "not a match"}),
+            ])
+        )
+        pairs = _collect_from_bus_spool(str(spool))
+        assert sorted(pairs) == [
+            ("alice", "alpha"),
+            ("bob", "beta"),
+            ("charlie", "agent-rules"),
+        ]
+
+
+class TestAsyncMain:
+    def test_data_dir_with_no_rows_exits_nonzero(self, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        result = subprocess.run(
+            [sys.executable, "scripts/measure_membership_stems.py", "--data-dir", str(empty_dir)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode != 0
+        assert "No EVENT_A2A rows found" in result.stderr
+
+    def test_data_dir_with_rows_succeeds(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "taosmd-test"
+        data_dir.mkdir()
+        monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+        stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+
+        async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+            return [0.0] * 8
+
+        stores["vector"].embed = _fake_embed  # type: ignore[assignment]
+
+        asyncio.run(taosmd_service.a2a_send("alice", "hi", thread="general", data_dir=str(data_dir)))
+
+        env = os.environ.copy()
+        env["TAOSMD_ONNX_PATH"] = "/nonexistent"
+        result = subprocess.run(
+            [sys.executable, "scripts/measure_membership_stems.py", "--data-dir", str(data_dir)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Scope:" in result.stdout
+        assert "Total distinct principals:" in result.stdout
+        assert "Per-channel breakdown:" in result.stdout
+
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        asyncio.run(store.close())
+                    except Exception:
+                        pass

--- a/tests/test_measure_membership_stems.py
+++ b/tests/test_measure_membership_stems.py
@@ -1,0 +1,114 @@
+"""Tests for channel-membership stem measurement."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.measure_membership_stems import (
+    measure,
+    stem_with_mint,
+    stem_without_mint,
+)
+
+
+class TestStemFunctions:
+    def test_strip_at_and_casefold(self):
+        assert stem_without_mint("@taOSmd-dev") == "taosmd-dev"
+        assert stem_without_mint("taOSmd-dev") == "taosmd-dev"
+        assert stem_without_mint("@TAOSMD-DEV") == "taosmd-dev"
+
+    def test_mint_stamp_stripped(self):
+        assert stem_with_mint("taosmd-20260609-153000") == "taosmd"
+        assert stem_with_mint("@taOSmd-20260609-153000") == "taosmd"
+        assert stem_with_mint("taosmd-dev") == "taosmd-dev"
+
+    def test_install_discriminator_preserved(self):
+        assert stem_with_mint("@taOS-agent-abc12345") == "taos-agent-abc12345"
+        assert stem_with_mint("taOS-agent-abc12345") == "taos-agent-abc12345"
+        assert stem_with_mint("@taOS-agent-abc12345-20260813-192605") == "taos-agent-abc12345"
+
+
+class TestMeasure:
+    def test_empty(self):
+        result = measure([])
+        assert result["total_principals"] == 0
+        assert result["multi_spell_stems_without_mint"] == {}
+        assert result["multi_spell_stems_with_mint"] == {}
+        assert result["canonical_twins"] == []
+        assert result["collapse_without_mint"] == {}
+
+    def test_single_principal(self):
+        result = measure([("taosmd-dev", "general")])
+        assert result["total_principals"] == 1
+        assert result["multi_spell_stems_without_mint"] == {}
+        assert result["multi_spell_stems_with_mint"] == {}
+
+    def test_at_and_bare_same_agent(self):
+        pairs = [
+            ("@taOSmd-dev", "build"),
+            ("taosmd-dev", "build"),
+        ]
+        result = measure(pairs)
+        assert result["total_principals"] == 2
+        assert len(result["multi_spell_stems_without_mint"]) == 1
+        assert "taosmd-dev" in result["multi_spell_stems_without_mint"]
+        assert result["multi_spell_stems_without_mint"]["taosmd-dev"] == [
+            "@taOSmd-dev",
+            "taosmd-dev",
+        ]
+        assert result["canonical_twins"] == []
+        assert len(result["collapse_without_mint"]) == 1
+
+    def test_canonical_with_bare_twin(self):
+        pairs = [
+            ("taosmd-20260609-153000", "general"),
+            ("taosmd", "general"),
+        ]
+        result = measure(pairs)
+        assert len(result["canonical_twins"]) == 1
+        canonical, twins = result["canonical_twins"][0]
+        assert canonical == "taosmd-20260609-153000"
+        assert twins == ["taosmd"]
+
+    def test_canonical_with_at_twin(self):
+        pairs = [
+            ("@taOS-20260609-153000", "general"),
+            ("taOS", "general"),
+            ("@taOS", "general"),
+        ]
+        result = measure(pairs)
+        assert len(result["canonical_twins"]) == 1
+        canonical, twins = result["canonical_twins"][0]
+        assert canonical == "@taOS-20260609-153000"
+        assert set(twins) == {"@taOS", "taOS"}
+
+    def test_two_distinct_principals_same_stem(self):
+        pairs = [
+            ("taosmd-dev", "build"),
+            ("taos-dev", "general"),
+        ]
+        result = measure(pairs)
+        assert result["collapse_without_mint"] == {}
+
+    def test_mint_stamp_merges_canonical_and_bare(self):
+        pairs = [
+            ("taosmd-20260609-153000", "general"),
+            ("taosmd-20260813-192605", "general"),
+            ("taosmd", "general"),
+        ]
+        result = measure(pairs)
+        assert len(result["multi_spell_stems_with_mint"]) == 1
+        assert result["multi_spell_stems_with_mint"]["taosmd"] == [
+            "taosmd",
+            "taosmd-20260609-153000",
+            "taosmd-20260813-192605",
+        ]
+
+    def test_install_discriminators_not_merged(self):
+        pairs = [
+            ("@taOS-agent-abc12345", "general"),
+            ("@taOS-agent-def67890", "general"),
+        ]
+        result = measure(pairs)
+        assert result["multi_spell_stems_with_mint"] == {}
+        assert result["collapse_without_mint"] == {}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #250: measure REAL channel membership, not spool senders (Stage 2 entry gate)

Autonomous build of board card tsk-aildfj.

- _collect_from_archive now calls service.a2a_channels so the measurement
  matches the live /a2a/channels endpoint exactly
- exit non-zero when --data-dir has no EVENT_A2A rows, instead of silently
  falling back to bus-spool.jsonl
- measure() keeps the channel dimension and reports per-channel results
- print_report includes scope in the conclusion and removes the carried-over
  from-field conclusion
- tests cover both collectors, the fallback path, and two canonicals sharing
  one stem
- remove is_install_discriminator and Status: CLOSED from the doc

Files:
 docs/specs/tsk-rf5gwb-membership-stems.md | 130 +++++++++++++++
 scripts/measure_membership_stems.py       | 252 ++++++++++++++++++++++++++++++
 tests/test_measure_membership_stems.py    | 241 ++++++++++++++++++++++++++++
 3 files changed, 623 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line measurement tool for analyzing membership identity patterns across archive and bus-spool data.
  * Reports aggregate and per-channel results, including identity variants, canonical matches, and potential principal collapses.
  * Provides clear safety conclusions and meaningful errors for missing or empty data sources.

* **Documentation**
  * Added a reproducible specification documenting membership identity-stem analysis and its findings.

* **Tests**
  * Added comprehensive coverage for normalization, data collection, reporting, and CLI success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->