### PR TITLE
fix(merge-gate): check_bot_anchoring counts inline comments, not includesCreatedEdit

### DIFF
--- a/scripts/merge-gate/check_bot_anchoring.sh
+++ b/scripts/merge-gate/check_bot_anchoring.sh
@@ -37,7 +37,7 @@ for r in reviews:
     if commit_oid != head_oid:
         continue
     body = r.get('body') or ''
-    has_inline = r.get('includesCreatedEdit', False)
+    has_inline = (r.get('comments') or {}).get('totalCount', 0) > 0
     if body.strip() or has_inline:
         print('SUCCESS: anchored substantive bot review found')
         sys.exit(0)

--- a/tests/fixtures/merge_gate/pr_inline_only.json
+++ b/tests/fixtures/merge_gate/pr_inline_only.json
@@ -1,0 +1,15 @@
+{
+  "number": 218,
+  "headRefOid": "abc123def456",
+  "reviews": [
+    {
+      "author": {"login": "coderabbitai"},
+      "state": "COMMENTED",
+      "body": "",
+      "commit": {"oid": "abc123def456"},
+      "includesCreatedEdit": false,
+      "comments": {"totalCount": 3},
+      "submittedAt": "2026-07-28T12:21:45Z"
+    }
+  ]
+}

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -126,6 +126,100 @@ def test_bare_ack_fails(tmp_path):
     assert result.stdout.startswith("FAILED:")
 
 
+def _write_old_anchoring_script(tmpdir):
+    """Write a copy of check_bot_anchoring.sh using the OLD includesCreatedEdit logic,
+    so we can prove the bug existed before the fix."""
+    script = os.path.join(tmpdir, "old_check_bot_anchoring.sh")
+    with open(script, "w") as f:
+        f.write("""#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "FAILED: usage: check_bot_anchoring.sh <pr-number>"
+    exit 2
+fi
+
+PR_NUMBER="$1"
+
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,headRefOid,reviews 2>/dev/null) || {
+    echo "FAILED: gh/network error"
+    exit 3
+}
+
+python3 - "$PR_JSON" << 'PYEOF'
+import json, sys
+
+try:
+    data = json.loads(sys.argv[1])
+except json.JSONDecodeError:
+    print('FAILED: could not parse PR data')
+    sys.exit(3)
+
+head_oid = data.get('headRefOid', '')
+reviews = data.get('reviews', [])
+bot_authors = {'coderabbitai', 'qodo-code-review', 'kilo-code-bot'}
+
+for r in reviews:
+    author = (r.get('author') or {}).get('login', '')
+    if author not in bot_authors:
+        continue
+    state = r.get('state', '')
+    if state not in ('COMMENTED', 'APPROVED', 'CHANGES_REQUESTED'):
+        continue
+    commit_oid = (r.get('commit') or {}).get('oid', '')
+    if commit_oid != head_oid:
+        continue
+    body = r.get('body') or ''
+    has_inline = r.get('includesCreatedEdit', False)
+    if body.strip() or has_inline:
+        print('SUCCESS: anchored substantive bot review found')
+        sys.exit(0)
+
+print('FAILED: no anchored substantive bot review found')
+sys.exit(10)
+PYEOF
+exit $?
+""")
+    os.chmod(script, stat.S_IRWXU)
+    return script
+
+
+def test_inline_only_review_fix(tmp_path):
+    """An inline-only bot review (empty body, comments.totalCount > 0,
+    includesCreatedEdit=false) must be rejected by the old logic and
+    accepted by the fix."""
+    fixture = _read("pr_inline_only.json")
+
+    fake_gh = _make_fake_gh(str(tmp_path), pr=fixture)
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + ":" + env.get("PATH", "")
+
+    # --- Fixed code accepts (exit 0) ---
+    script_path = os.path.abspath(
+        os.path.join("scripts", "merge-gate", "check_bot_anchoring.sh")
+    )
+    result = subprocess.run(
+        ["bash", script_path, "218"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.startswith("SUCCESS:")
+
+    # --- Old code rejects (exit 10) - proves the bug existed ---
+    old_script = _write_old_anchoring_script(str(tmp_path))
+    old_result = subprocess.run(
+        ["bash", old_script, "218"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert old_result.returncode == 10, old_result.stdout + old_result.stderr
+    assert old_result.stdout.startswith("FAILED:")
+    assert "no anchored substantive bot review found" in old_result.stdout
+
+
 def test_red_first_usage_error():
     result = subprocess.run(
         ["bash", "scripts/merge-gate/red_first.sh"],


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix(merge-gate): check_bot_anchoring counts inline comments, not includesCreatedEdit

Autonomous build of board card tsk-e4cpto.

includesCreatedEdit means 'review was edited', not 'has inline comments'.
Inline-only bot reviews (empty body with inline comments, like CodeRabbit's
normal shape) were wrongly rejected because includesCreatedEdit is false
essentially everywhere. Derive the inline signal from comments.totalCount > 0
instead, keeping the anchoring check separate.

Files:
 scripts/merge-gate/check_bot_anchoring.sh     |  2 +-
 tests/fixtures/merge_gate/pr_inline_only.json | 15 +++++
 tests/test_merge_gate.py                      | 94 +++++++++++++++++++++++++++
 3 files changed, 110 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-gate detection for bot reviews containing only inline comments.
  * Inline-only reviews are now correctly recognized as anchored, even without a review body or edit marker.

* **Tests**
  * Added regression coverage for inline-only review scenarios to prevent future anchoring issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->