### PR TITLE
fix(merge-gate): check_bot_anchoring counts inline comments, not includesCreatedEdit

### DIFF
--- a/scripts/merge-gate/check_bot_anchoring.sh
+++ b/scripts/merge-gate/check_bot_anchoring.sh
@@ -37,7 +37,7 @@ for r in reviews:
     if commit_oid != head_oid:
         continue
     body = r.get('body') or ''
-    has_inline = r.get('includesCreatedEdit', False)
+    has_inline = (r.get('comments') or {}).get('totalCount', 0) > 0
     if body.strip() or has_inline:
         print('SUCCESS: anchored substantive bot review found')
         sys.exit(0)

--- a/tests/fixtures/merge_gate/pr_inline_only.json
+++ b/tests/fixtures/merge_gate/pr_inline_only.json
@@ -1,0 +1,15 @@
+{
+  "number": 218,
+  "headRefOid": "abc123def456",
+  "reviews": [
+    {
+      "author": {"login": "coderabbitai"},
+      "state": "COMMENTED",
+      "body": "",
+      "commit": {"oid": "abc123def456"},
+      "comments": {"totalCount": 3},
+      "includesCreatedEdit": false,
+      "submittedAt": "2026-07-28T12:21:45Z"
+    }
+  ]
+}

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -97,6 +97,43 @@ def test_human_only_fails(tmp_path):
     assert result.stdout.startswith("FAILED:")
 
 
+def test_inline_only_review_rejected_by_buggy_logic(tmp_path):
+    fixture = _read("pr_inline_only.json")
+    _make_fake_gh(str(tmp_path), pr=fixture)
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + ":" + env.get("PATH", "")
+
+    # Reconstruct the pre-fix logic that relied on includesCreatedEdit
+    with open(os.path.join("scripts", "merge-gate", "check_bot_anchoring.sh")) as f:
+        buggy_script = f.read().replace(
+            "has_inline = (r.get('comments') or {}).get('totalCount', 0) > 0",
+            "has_inline = r.get('includesCreatedEdit', False)",
+        )
+    buggy_path = os.path.join(str(tmp_path), "buggy.sh")
+    with open(buggy_path, "w") as f:
+        f.write(buggy_script)
+
+    result = subprocess.run(
+        ["bash", buggy_path, "218"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 10, result.stdout + result.stderr
+    assert result.stdout.startswith("FAILED:")
+
+
+def test_inline_only_review_accepted_by_fix(tmp_path):
+    result = _run(
+        "check_bot_anchoring.sh",
+        ["218"],
+        str(tmp_path),
+        pr=_read("pr_inline_only.json"),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.startswith("SUCCESS:")
+
+
 def test_rate_limited_fails(tmp_path):
     result = _run(
         "check_fake_green.sh",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix(merge-gate): check_bot_anchoring counts inline comments, not includesCreatedEdit

Autonomous build of board card tsk-e4cpto.

includesCreatedEdit means 'this review was edited', not 'has inline
comments', so inline-only bot reviews (CodeRabbit's normal shape) were
rejected by the anchoring gate. Use comments.totalCount > 0 instead.

Files:
 scripts/merge-gate/check_bot_anchoring.sh     |  2 +-
 tests/fixtures/merge_gate/pr_inline_only.json | 15 +++++++++++
 tests/test_merge_gate.py                      | 37 +++++++++++++++++++++++++++
 3 files changed, 53 insertions(+), 1 deletion(-)