### PR TITLE
State the /a2a/threads ordering in the a2a_threads docstring (contract change is currently unrecorded)

### DIFF
--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -694,6 +694,10 @@ async def a2a_threads(*, principal: str | None = None, data_dir=None) -> list[di
     Each item has shape ``{"thread", "kind", "participants",
     "last_message": {"id", "ts", "from", "body_preview"}}``.
 
+    Threads are returned **most-recently-active first**, ordered by the
+    timestamp of each thread's last message. This replaced an alphabetical
+    ordering; callers that relied on alphabetical order must sort client-side.
+
     When a remote server URL is configured the call is forwarded to
     :class:`~taosmd.remote.RemoteClient` transparently.
     """


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): State the /a2a/threads ordering in the a2a_threads docstring (contract change is currently unrecorded)

Autonomous build of board card tsk-4f7hsa.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

The GET /a2a/threads endpoint was changed in PR #275 to return threads
sorted most-recently-active first (replacing the previous alphabetical
ordering), but that contract change was unrecorded apart from the sort
line and one test assertion. Add a sentence to the a2a_threads docstring
stating the ordering and noting the prior behaviour, so callers relying
on alphabetical order know to sort client-side.

Closes tsk-4f7hsa.

Files:
 taosmd/service.py | 4 ++++
 1 file changed, 4 insertions(+)