### PR TITLE
Promote _normalise_handle to one shared identity-slug helper (blocks #233 and #241)

### DIFF
--- a/taosmd/mentions.py
+++ b/taosmd/mentions.py
@@ -1,0 +1,87 @@
+"""Mention index for the A2A bus.
+
+Stores @handle mentions extracted from A2A message bodies and the optional
+``recipient`` field, enabling the /a2a/mentions feed and thread-scoped
+visibility (anti-bypass rule from taOSmd #211).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+from taosmd import _db
+from taosmd.service import _normalise_handle
+
+_MENTION_RE = re.compile(r'@([a-zA-Z0-9_-]+)')
+
+
+class MentionStore:
+    """Append-only mention index keyed by (mentioned_handle, message_id, ts, thread)."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+
+    async def init(self) -> None:
+        self._conn = _db.connect(self._db_path)
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS mentions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mentioned_handle TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                ts REAL NOT NULL,
+                thread TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_mentions_handle_ts
+                ON mentions(mentioned_handle, ts);
+        """)
+        self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    async def record_mentions(
+        self,
+        message_id: int,
+        body: str,
+        thread: str,
+        ts: float,
+        recipient: str | None = None,
+    ) -> None:
+        handles: set[str] = set()
+        for m in _MENTION_RE.finditer(body or ''):
+            handles.add(_normalise_handle(m.group(1), mint_strip=True))
+        if recipient:
+            handles.add(_normalise_handle(recipient, mint_strip=True))
+
+        for handle in handles:
+            self._conn.execute(
+                "INSERT INTO mentions (mentioned_handle, message_id, ts, thread) VALUES (?, ?, ?, ?)",
+                (handle, message_id, ts, thread),
+            )
+        if handles:
+            self._conn.commit()
+
+    async def get_mentioned_message_ids(
+        self, reader: str, since: float | None = None, limit: int = 50
+    ) -> list[dict]:
+        reader = _normalise_handle(reader, mint_strip=True)
+        query = "SELECT message_id, ts FROM mentions WHERE mentioned_handle = ?"
+        params: list = [reader]
+        if since is not None:
+            query += " AND ts > ?"
+            params.append(since)
+        query += " ORDER BY ts ASC LIMIT ?"
+        params.append(limit)
+        rows = self._conn.execute(query, params).fetchall()
+        return [{"message_id": r[0], "ts": r[1]} for r in rows]
+
+    async def get_mention_recipients(self, message_id: int) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT mentioned_handle FROM mentions WHERE message_id = ?",
+            (message_id,),
+        ).fetchall()
+        return [r[0] for r in rows]

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -66,12 +66,16 @@ def authorize_sender(token: str, claimed_from: str, *, public_key: str,
       * ``sub`` must equal the message ``from`` (no impersonation);
       * ``sub`` must not be in the registry revocation set;
       * when ``expected_iss`` is set, ``iss`` must match it (issuer pinning).
+
+    Identity comparison uses :func:`taosmd.service._normalise_handle` so
+    ``@``-prefixed and bare handles compare equal case-insensitively.
     """
+    from .service import _normalise_handle  # noqa: PLC0415
     claims = decode_and_verify(token, public_key)
     sub = claims.get("sub")
     if not sub:
         raise AuthError("token has no 'sub' (canonical_id) claim")
-    if sub != claimed_from:
+    if _normalise_handle(sub) != _normalise_handle(claimed_from):
         raise AuthError(f"token sub {sub!r} does not match from {claimed_from!r}")
     if sub in revoked:
         raise AuthError(f"canonical_id {sub!r} is revoked")

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -28,12 +28,35 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 
 from . import api as _api
 from . import config as _config
 from .archive import EVENT_A2A
 
 logger = logging.getLogger(__name__)
+
+
+def _normalise_handle(handle: str, *, mint_strip: bool = False) -> str:
+    """Slug-match helper for identity comparison on the A2A bus.
+
+    This is a slug match, NOT an identity check: two distinct agents that
+    share a stem will unify under this function. Do not use it for
+    authorisation decisions that require distinguishing between same-stem
+    identities.
+
+    Strips any leading ``@``, casefolds, and optionally strips a timestamp
+    mint stamp (``-YYYYMMDD`` or ``-YYYYMMDD-HHMMSS`` suffix) when
+    ``mint_strip=True``. The default is ``mint_strip=False`` because the
+    ``from`` field on bus messages does not carry bare-or-@ twins for the
+    same canonical, and stripping would collapse install discriminators
+    such as ``@taOS-agent-1a2b3c4d``.
+    """
+    handle = handle.lstrip("@").casefold()
+    if mint_strip:
+        handle = re.sub(r"-\d{8}(-\d{6})?$", "", handle)
+    return handle
+
 
 # Cache of RemoteClient instances keyed by (base_url, token) so we don't
 # create a fresh object on every call.  Access from async coroutines is safe

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,80 @@
+"""Tests for taosmd.mentions.MentionStore.
+
+Verifies that the store uses the shared _normalise_handle helper on both
+the write path (record_mentions) and the read path (get_mentioned_message_ids)
+so the index and query never disagree on handle spelling.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from taosmd.mentions import MentionStore
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "mentions.db")
+
+
+@pytest.fixture()
+def store(db_path: str) -> MentionStore:
+    s = MentionStore(db_path)
+    asyncio.run(s.init())
+    yield s
+    asyncio.run(s.close())
+
+
+class TestMentionStore:
+    def test_record_and_retrieve_bare_slug(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @bob", "general", 1000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("bob"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_record_and_retrieve_at_prefixed_reader(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @bob", "general", 1000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("@bob"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_record_and_retrieve_case_insensitive(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @BOB", "general", 1000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("bob"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_record_with_recipient(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hello", "general", 1000.0, recipient="@alice"))
+        rows = asyncio.run(store.get_mentioned_message_ids("alice"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_mint_strip_matches_canonical_reader(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @hermes", "general", 1000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("hermes-20260727-001415"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_install_discriminator_survives(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @taOS-agent-1a2b3c4d", "general", 1000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("taOS-agent-1a2b3c4d"))
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_since_filter(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @bob", "general", 1000.0))
+        asyncio.run(store.record_mentions(2, "hey @bob", "general", 2000.0))
+        rows = asyncio.run(store.get_mentioned_message_ids("bob", since=1500.0))
+        assert [r["message_id"] for r in rows] == [2]
+
+    def test_limit(self, store: MentionStore):
+        for i in range(5):
+            asyncio.run(store.record_mentions(i, f"hey @bob {i}", "general", float(i * 1000)))
+        rows = asyncio.run(store.get_mentioned_message_ids("bob", limit=2))
+        assert len(rows) == 2
+
+    def test_no_mentions_returns_empty(self, store: MentionStore):
+        rows = asyncio.run(store.get_mentioned_message_ids("nobody"))
+        assert rows == []
+
+    def test_get_mention_recipients(self, store: MentionStore):
+        asyncio.run(store.record_mentions(1, "hey @bob", "general", 1000.0))
+        recipients = asyncio.run(store.get_mention_recipients(1))
+        assert recipients == ["bob"]

--- a/tests/test_service_normalise.py
+++ b/tests/test_service_normalise.py
@@ -1,0 +1,41 @@
+"""Tests for taosmd.service._normalise_handle.
+
+The helper is a slug match, not an identity check: it strips any leading
+``@``, casefolds, and optionally strips a timestamp mint stamp. Two
+distinct agents that share a stem will unify under it.
+"""
+from __future__ import annotations
+
+from taosmd.service import _normalise_handle
+
+
+class TestNormaliseHandle:
+    def test_strips_leading_at(self):
+        assert _normalise_handle("@bob") == "bob"
+
+    def test_casefolds(self):
+        assert _normalise_handle("TaOSmd") == "taosmd"
+
+    def test_bare_slug_unchanged(self):
+        assert _normalise_handle("bob") == "bob"
+
+    def test_at_plus_casefold(self):
+        assert _normalise_handle("@TaOSmd-dev") == "taosmd-dev"
+
+    def test_mint_strip_default_false(self):
+        assert _normalise_handle("hermes-20260727-001415") == "hermes-20260727-001415"
+
+    def test_mint_strip_true_strips_date_suffix(self):
+        assert _normalise_handle("hermes-20260727-001415", mint_strip=True) == "hermes"
+
+    def test_mint_strip_true_strips_date_only_suffix(self):
+        assert _normalise_handle("taOSmd-20260609", mint_strip=True) == "taosmd"
+
+    def test_install_discriminator_survives_mint_strip(self):
+        assert _normalise_handle("@taOS-agent-1a2b3c4d", mint_strip=True) == "taos-agent-1a2b3c4d"
+
+    def test_install_discriminator_survives_without_mint_strip(self):
+        assert _normalise_handle("@taOS-agent-1a2b3c4d") == "taos-agent-1a2b3c4d"
+
+    def test_slug_match_not_identity_check(self):
+        assert _normalise_handle("bob") == _normalise_handle("@BOB")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Promote _normalise_handle to one shared identity-slug helper (blocks #233 and #241)

Autonomous build of board card tsk-pgtl4b.

Add _normalise_handle to taosmd.service with explicit mint_strip parameter
(default False). Use it in registry_auth.authorize_sender so @-prefixed
and bare handles compare equal case-insensitively. Create taosmd.mentions
with MentionStore that applies _normalise_handle on both write and read
paths so the index and query agree on handle spelling. Add tests for slug
match semantics and install discriminator survival.

Files:
 taosmd/mentions.py              | 87 +++++++++++++++++++++++++++++++++++++++++
 taosmd/registry_auth.py         |  6 ++-
 taosmd/service.py               | 23 +++++++++++
 tests/test_mentions.py          | 80 +++++++++++++++++++++++++++++++++++++
 tests/test_service_normalise.py | 41 +++++++++++++++++++
 5 files changed, 236 insertions(+), 1 deletion(-)