### PR TITLE
live_embed_backend: a truncated model.onnx still fails instead of skipping

### DIFF
--- a/changelog.d/tsk-rm57pj-skip-truncated-onnx-model.md
+++ b/changelog.d/tsk-rm57pj-skip-truncated-onnx-model.md
@@ -1,0 +1,8 @@
+### Fixed
+
+The `live_embed_backend` test guard now verifies an ONNX embed backend by
+loading the model with ONNX Runtime instead of only checking that
+`model.onnx` exists, so a truncated or empty model file (for example left by
+an interrupted `scripts/setup.sh`) makes the guarded tests SKIP instead of
+failing at embed time. The QMD service probe result is cached for the process
+so a filtered (rather than refused) port is only waited on once per run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ explicitly still wins.
 """
 from __future__ import annotations
 
+import functools
 import json
 import os
 import urllib.request
@@ -22,26 +23,73 @@ from pathlib import Path
 
 import pytest
 
+_NO_BACKEND_SKIP_MSG = (
+    "No live embed backend available. "
+    "Install an ONNX model (run scripts/setup.sh or set TAOSMD_ONNX_PATH) "
+    "or start the QMD service (qmd serve on http://localhost:7832)."
+)
+
+
+def _resolve_onnx_model_file() -> Path | None:
+    """Return the ``model.onnx`` path for a discoverable ONNX backend, else None.
+
+    Honours ``$TAOSMD_ONNX_PATH`` and the default install locations
+    (``~/.taosmd/models/minilm-onnx`` and ``$TAOSMD_DIR/models/minilm-onnx``),
+    accepting either a root ``model.onnx`` or an ``onnx/model.onnx`` layout.
+    Existence is necessary but not sufficient: :func:`_has_onnx_model` loads the
+    file before a backend is considered available.
+    """
+    env = os.environ.get("TAOSMD_ONNX_PATH")
+    roots = [Path(env)] if env else []
+    roots.extend(
+        [
+            Path("~/.taosmd/models/minilm-onnx").expanduser(),
+            Path(os.environ.get("TAOSMD_DIR", "~/taosmd")).expanduser() / "models" / "minilm-onnx",
+        ]
+    )
+    for root in roots:
+        for rel in ("model.onnx", "onnx/model.onnx"):
+            candidate = root / rel
+            if candidate.is_file():
+                return candidate
+    return None
+
 
 def _has_onnx_model() -> bool:
-    """True if an ONNX embedding model is available on disk."""
-    env = os.environ.get("TAOSMD_ONNX_PATH")
-    if env:
-        p = Path(env)
-        if (p / "model.onnx").exists() or (p / "onnx" / "model.onnx").exists():
-            return True
-    candidates = [
-        Path("~/.taosmd/models/minilm-onnx").expanduser(),
-        Path(os.environ.get("TAOSMD_DIR", "~/taosmd")).expanduser() / "models" / "minilm-onnx",
-    ]
-    for candidate in candidates:
-        if (candidate / "model.onnx").exists() or (candidate / "onnx" / "model.onnx").exists():
-            return True
-    return False
+    """True if an ONNX embedding backend can actually load and embed.
+
+    Loads the model with ONNX Runtime rather than merely checking that a
+    ``model.onnx`` file exists, so a truncated or empty file left by an
+    interrupted ``scripts/setup.sh`` is treated as "no backend" and the
+    guarded tests SKIP instead of failing at embed time.
+    """
+    model_file = _resolve_onnx_model_file()
+    if model_file is None:
+        return False
+    try:
+        import onnxruntime as ort
+
+        options = ort.SessionOptions()
+        options.log_severity_level = 4  # silence the load diagnostics on bad files
+        options.intra_op_num_threads = 1
+        ort.InferenceSession(
+            str(model_file),
+            options,
+            providers=["CPUExecutionProvider"],
+        )
+        return True
+    except Exception:
+        return False
 
 
+@functools.lru_cache(maxsize=1)
 def _has_qmd_service() -> bool:
-    """True if the QMD embed service is reachable at the default URL."""
+    """True if the QMD embed service is reachable at the default URL.
+
+    Cached for the process lifetime: the cached value is itself a real probe
+    response from this session, and a filtered (rather than refused) port would
+    otherwise block for the full timeout on every function-scoped fixture call.
+    """
     try:
         data = json.dumps({"text": "probe"}).encode()
         req = urllib.request.Request(
@@ -54,6 +102,11 @@ def _has_qmd_service() -> bool:
             return resp.status == 200
     except Exception:
         return False
+
+
+def _live_backend_available() -> bool:
+    """True if a live ONNX or QMD embed backend is actually usable."""
+    return _has_onnx_model() or _has_qmd_service()
 
 
 @pytest.fixture(autouse=True)
@@ -76,13 +129,13 @@ def _no_reranker_network(monkeypatch):
 def live_embed_backend():
     """Skip unless a live embed backend (ONNX model or QMD service) is available.
 
-    Configure an ONNX model with ``scripts/setup.sh`` or ``TAOSMD_ONNX_PATH``.
-    Start the QMD service with ``qmd serve`` (default http://localhost:7832).
+    The ONNX path is verified by loading the model (not just checking that the
+    file exists), so a truncated or empty ``model.onnx`` from an interrupted
+    ``scripts/setup.sh`` SKIPs here instead of producing confusing embed
+    failures later. Configure with ``scripts/setup.sh`` or
+    ``TAOSMD_ONNX_PATH``; start the QMD service with ``qmd serve`` on the
+    default http://localhost:7832.
     """
-    if _has_onnx_model() or _has_qmd_service():
+    if _live_backend_available():
         return True
-    pytest.skip(
-        "No live embed backend available. "
-        "Install an ONNX model (run scripts/setup.sh or set TAOSMD_ONNX_PATH) "
-        "or start the QMD service (qmd serve on http://localhost:7832)."
-    )
+    pytest.skip(_NO_BACKEND_SKIP_MSG)

--- a/tests/test_live_embed_backend.py
+++ b/tests/test_live_embed_backend.py
@@ -1,0 +1,191 @@
+"""Tests for the ``live_embed_backend`` skip guard and its ONNX/QMD probes.
+
+Regression coverage for tsk-rm57pj: a truncated or empty ``model.onnx`` (the
+remnant of an interrupted ``scripts/setup.sh``) must make the guard SKIP
+instead of letting an unusable model through to fail at embed time. The QMD
+probe already verifies a live response (not mere reachability); the ONNX probe
+must do the same in spirit by loading the model, not just checking existence.
+"""
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests import conftest
+
+
+def _onnx_dir(tmp_path: Path, name: str = "minilm-onnx", layout: str = "root") -> Path:
+    d = tmp_path / name
+    if layout == "onnx_subdir":
+        (d / "onnx").mkdir(parents=True)
+    else:
+        d.mkdir(parents=True)
+    return d
+
+
+def _placeholder(d: Path) -> None:
+    (d / "model.onnx").write_bytes(b"placeholder")
+
+
+def _neutralize_default_candidates(tmp_path, monkeypatch):
+    """Redirect '~' expansion so the install-location candidates resolve to a
+    fake home under tmp_path (where no model exists), making backend probes
+    depend solely on ``TAOSMD_ONNX_PATH``."""
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+
+    def fake_expanduser(p):
+        if p.startswith("~"):
+            rel = p.lstrip("~").lstrip("/")
+            return str(fake_home / rel)
+        return p
+
+    monkeypatch.setattr("os.path.expanduser", fake_expanduser)
+
+
+# --- resolution ---------------------------------------------------------------
+
+
+def test_resolve_finds_root_model(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path, "root-layout")
+    _placeholder(d)
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._resolve_onnx_model_file() == d / "model.onnx"
+
+
+def test_resolve_finds_onnx_subdir_model(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path, "arctic-embed-s", layout="onnx_subdir")
+    (d / "onnx" / "model.onnx").write_bytes(b"placeholder")
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._resolve_onnx_model_file() == d / "onnx" / "model.onnx"
+
+
+def test_resolve_returns_none_when_absent(tmp_path, monkeypatch):
+    _neutralize_default_candidates(tmp_path, monkeypatch)
+    d = tmp_path / "empty"
+    d.mkdir()
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._resolve_onnx_model_file() is None
+
+
+# --- the defect: a truncated / empty model.onnx is NOT a working backend ------
+
+
+def test_empty_model_onnx_is_not_a_backend(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    (d / "model.onnx").write_bytes(b"")
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._has_onnx_model() is False
+
+
+def test_truncated_model_onnx_is_not_a_backend(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    (d / "model.onnx").write_bytes(b"\x08\x01\x02 not a real onnx graph")
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._has_onnx_model() is False
+
+
+def test_truncated_model_under_onnx_subdir_is_not_a_backend(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path, "arctic-embed-s", layout="onnx_subdir")
+    (d / "onnx" / "model.onnx").write_bytes(b"")
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    assert conftest._has_onnx_model() is False
+
+
+# --- positive control: a model that loads IS a working backend ----------------
+# A real 90MB ONNX model is not available in CI, so only the narrow ONNX
+# session constructor is mocked. Without this test the skip-only negative tests
+# would be indistinguishable from a guard pinned to always-skip -- the
+# "fixed into always skipping" regression the card warns against.
+
+
+def test_working_onnx_model_is_detected(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    _placeholder(d)
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    with patch("onnxruntime.InferenceSession") as sess:
+        sess.return_value = MagicMock()
+        assert conftest._has_onnx_model() is True
+
+
+def test_onnx_load_failure_is_not_a_working_backend(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    _placeholder(d)
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    with patch("onnxruntime.InferenceSession", side_effect=RuntimeError("unloadable")):
+        assert conftest._has_onnx_model() is False
+
+
+# --- combined decision --------------------------------------------------------
+
+
+def test_live_backend_available_false_when_truncated(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    (d / "model.onnx").write_bytes(b"")
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    monkeypatch.setattr(conftest, "_has_qmd_service", lambda: False)
+    assert conftest._live_backend_available() is False
+
+
+def test_live_backend_available_true_when_onnx_works(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    _placeholder(d)
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    monkeypatch.setattr(conftest, "_has_qmd_service", lambda: False)
+    with patch("onnxruntime.InferenceSession") as sess:
+        sess.return_value = MagicMock()
+        assert conftest._live_backend_available() is True
+
+
+# --- fixture end-to-end: skip vs run ------------------------------------------
+
+
+def test_fixture_skips_when_no_backend(monkeypatch):
+    monkeypatch.setattr(conftest, "_has_onnx_model", lambda: False)
+    monkeypatch.setattr(conftest, "_has_qmd_service", lambda: False)
+    with pytest.raises(pytest.skip.Exception, match="No live embed backend"):
+        conftest.live_embed_backend.__wrapped__()
+
+
+def test_fixture_runs_when_backend_works(tmp_path, monkeypatch):
+    d = _onnx_dir(tmp_path)
+    _placeholder(d)
+    monkeypatch.setenv("TAOSMD_ONNX_PATH", str(d))
+    monkeypatch.setattr(conftest, "_has_qmd_service", lambda: False)
+    with patch("onnxruntime.InferenceSession") as sess:
+        sess.return_value = MagicMock()
+        assert conftest.live_embed_backend.__wrapped__() is True
+
+
+# --- QMD probe: caches its result so a filtered port is probed once -----------
+
+
+def test_qmd_probe_caches_result(monkeypatch):
+    conftest._has_qmd_service.cache_clear()
+    counter = {"n": 0}
+    fake_resp = MagicMock()
+    fake_resp.__enter__.return_value.status = 200
+
+    def fake_urlopen(*args, **kwargs):
+        counter["n"] += 1
+        return fake_resp
+
+    try:
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        assert conftest._has_qmd_service() is True
+        assert conftest._has_qmd_service() is True
+        assert counter["n"] == 1
+    finally:
+        conftest._has_qmd_service.cache_clear()
+
+
+def test_qmd_probe_refused_is_false(monkeypatch):
+    conftest._has_qmd_service.cache_clear()
+    try:
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            assert conftest._has_qmd_service() is False
+    finally:
+        conftest._has_qmd_service.cache_clear()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): live_embed_backend: a truncated model.onnx still fails instead of skipping

Autonomous build of board card tsk-rm57pj.

`_has_onnx_model` only checked that `model.onnx` existed, so a truncated or
empty file (e.g. from an interrupted `scripts/setup.sh`) satisfied the guard,
the live-embed tests ran, and VectorMemory fell back to QMD into empty
embeddings, producing failures instead of skips.

Load the model with ONNX Runtime inside the guard so an unloadable
`model.onnx` is treated as "no backend". Mirror that on the QMD path, which
already probes a live response, and cache `_has_qmd_service` with lru_cache so
a filtered port is only waited on once per process instead of per test.

Adds tests/test_live_embed_backend.py covering empty/truncated models (skip),
the positive control where a load succeeds (run), and the QMD cache. Adds
changelog.d/tsk-rm57pj-skip-truncated-onnx-model.md.

Files:
 .../tsk-rm57pj-skip-truncated-onnx-model.md        |   8 +
 tests/conftest.py                                  |  99 ++++++++---
 tests/test_live_embed_backend.py                   | 191 +++++++++++++++++++++
 3 files changed, 275 insertions(+), 23 deletions(-)