### PR TITLE
FIX-FORWARD PR #284: register the archive source_uid migration, add fresh-install + upgrade + import tests

### DIFF
--- a/changelog.d/tsk-sgoilz-upgrade-and-import.md
+++ b/changelog.d/tsk-sgoilz-upgrade-and-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Revised PR #230: fixed upgrade path broken on every existing install by removing source/source_id from INDEX_SCHEMA and changing migration guard from has_column to index_exists; also added _get_remote branch to a2a_import so remote-configured installs don't silently write history to local archive

--- a/changelog.d/tsk-uyznqh-register-source-uid-migration.md
+++ b/changelog.d/tsk-uyznqh-register-source-uid-migration.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Registered the `archive_index_source_uid` migration (step 3) in `_ARCHIVE_INDEX` so the `source`/`source_id` columns and `idx_archive_source_uid` partial unique index are created on fresh installs and applied on upgrade; also extended `ArchiveStore.record()` to accept `source` and `source_id` so `a2a_import` can write tagged rows

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -179,8 +179,16 @@ class ArchiveStore:
         app_id: str | None = None,
         summary: str = "",
         project: str | None = None,
+        timestamp: float | None = None,
     ) -> int:
-        """Record an event to the archive. Returns the index row ID."""
+        """Record an event to the archive. Returns the index row ID.
+
+        ``timestamp`` overrides the wall-clock time when provided (used by the
+        A2A batch importer to preserve historical timestamps, #211). ``source``
+        and ``source_id`` tag imported A2A messages for idempotent re-import;
+        when both are non-null the unique index ``idx_archive_source_uid``
+        enforces (source, source_id) uniqueness.
+        """
         # Skip user activity events if tracking is disabled
         if event_type in USER_ACTIVITY_EVENTS and not self._user_tracking_enabled:
             return -1
@@ -192,7 +200,7 @@ class ArchiveStore:
             if key in data and isinstance(data[key], str):
                 data[key], _ = redact_secrets(data[key])
 
-        ts = time.time()
+        ts = timestamp if timestamp is not None else time.time()
         event = {
             "timestamp": ts,
             "event_type": event_type,
@@ -341,6 +349,35 @@ class ArchiveStore:
         except (json.JSONDecodeError, TypeError):
             result["data"] = {}
         return result
+
+    async def find_source_ids(
+        self, source: str, event_type: str = EVENT_A2A
+    ) -> dict[str, int]:
+        """Return ``{source_id: archive_id}`` for all events tagged with ``source``.
+
+        Backs idempotent A2A batch import (#211): lets the importer skip rows whose
+        ``(source, source_id)`` already exists and resolve ``reply_to_source_id``
+        to the archive row id of the originally imported message. Only rows with a
+        non-null ``source_id`` are considered.
+        """
+        rows = self._conn.execute(
+            "SELECT source_id, id FROM archive_index "
+            "WHERE source = ? AND source_id IS NOT NULL AND event_type = ?",
+            (source, event_type),
+        ).fetchall()
+        return {row["source_id"]: row["id"] for row in rows}
+
+    async def find_reply_target(
+        self, source: str, source_id: str, event_type: str = EVENT_A2A
+    ) -> int | None:
+        """Return the archive row id for a ``(source, source_id)`` pair, or None."""
+        row = self._conn.execute(
+            "SELECT id FROM archive_index "
+            "WHERE source = ? AND source_id = ? AND event_type = ? "
+            "ORDER BY id ASC LIMIT 1",
+            (source, source_id, event_type),
+        ).fetchone()
+        return row["id"] if row else None
 
     async def count(
         self,

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -180,6 +180,8 @@ class ArchiveStore:
         summary: str = "",
         project: str | None = None,
         timestamp: float | None = None,
+        source: str | None = None,
+        source_id: str | None = None,
     ) -> int:
         """Record an event to the archive. Returns the index row ID.
 
@@ -240,9 +242,9 @@ class ArchiveStore:
         # Index for fast lookup
         cursor = self._conn.execute(
             """INSERT INTO archive_index
-               (timestamp, event_type, agent_name, app_id, project, summary, file_path, line_number, data_json)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (ts, event_type, agent_name, app_id, project, summary, file_path, line_count, json.dumps(data, default=str)),
+               (timestamp, event_type, agent_name, app_id, project, summary, file_path, line_number, data_json, source, source_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (ts, event_type, agent_name, app_id, project, summary, file_path, line_count, json.dumps(data, default=str), source, source_id),
         )
 
         # Index in FTS for full-text search

--- a/taosmd/capabilities.py
+++ b/taosmd/capabilities.py
@@ -84,9 +84,10 @@ CAPABILITY_PROBES: tuple[CapabilityProbe, ...] = (
     CapabilityProbe(
         name="a2a.v1",
         module="taosmd.service",
-        symbols=("a2a_send", "a2a_feed", "a2a_channels", "a2a_members"),
+        symbols=("a2a_send", "a2a_import", "a2a_feed", "a2a_channels", "a2a_members"),
         route_markers=(
             '"/a2a/send"',
+            '"/a2a/import"',
             '"/a2a/messages"',
             '"/a2a/stream"',
             '"/a2a/channels"',

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -105,10 +105,17 @@ Endpoints
 ``POST /a2a/send``         ``{"from", "body", "thread"?, "reply_to"?, "refs"?, "blocks"?}`` -> send receipt
                             ``refs``: optional list (<=8) of ``{"kind": doc|report|spec|log, "title", "uri", "sha256"?, "doc_id"?, "version"?, "for"?, "summary"?}``
                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
+<<<<<<< HEAD
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream); ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400
 ``GET  /a2a/threads``      ``?principal=``                  -> ``{"threads": [...]}`` thread list for the principal, ordered by latest activity desc; each entry has ``thread``, ``kind``, ``participants``, ``last_message: {id, ts, from, body_preview}`` (see notes below)
 ``GET  /a2a/threads/{thread}/messages`` ``?before=&after=&limit=`` -> ``{"thread", "messages": [...]}`` cursor-paginated message envelope, oldest-first
+=======
+``POST /a2a/import``      (admin) ``{"source": str, "defer_index"?: bool, "messages": [{"from": str, "thread": str, "body": str, "ts": float, "source_id": str, "reply_to_source_id"?: str|null, "blocks"?: [...], "refs"?: [...]}]}`` -> ``{"imported": n, "skipped": n, "first_id": int|null, "last_id": int|null}``
+                            Batch-import historical chat history onto the bus (taOSmd #211 Q3a). Idempotent on ``(source, source_id)``: re-runs skip existing rows. ``ts`` is preserved as the archive timestamp, not import time. ``reply_to_source_id`` resolves to the imported archive id of the referenced message (same source); unresolvable -> 400, no write. ``defer_index=true`` archives only and defers vector embedding; run ``taosmd reindex --agent <from>`` afterwards to back-fill vectors from the archive.
+``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line)
+``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream)
+>>>>>>> 04e6b07af77bb30d797e0867a2647196c18b7c28
 ``GET  /a2a/channels``                                     -> ``{"channels": [...]}``
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 ``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
@@ -830,6 +837,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 "/a2a/admin/delete-channel",
                 "/a2a/admin/rename-channel",
                 "/a2a/admin/supersede-message",
+                "/a2a/import",
             )
 
         def _check_admin_token(self) -> bool:
@@ -1029,6 +1037,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_pending_resolve()
                 elif method == "POST" and path == "/a2a/send":
                     self._handle_a2a_send()
+                elif method == "POST" and path == "/a2a/import":
+                    self._handle_a2a_import()
                 elif method == "GET" and path == "/a2a/channels":
                     self._handle_a2a_channels()
                 elif method == "GET" and path == "/a2a/members":
@@ -1604,6 +1614,26 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     thread=thread, reply_to=reply_to,
                     refs=refs, blocks=blocks,
                     data_dir=data_dir,
+                )
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_import(self) -> None:
+            if not self._check_admin_token():
+                return
+            body = self._read_json_body()
+            source = body.get("source")
+            defer_index = body.get("defer_index", False)
+            messages = body.get("messages")
+            if not isinstance(source, str) or not source:
+                raise _BadRequest("'source' (non-empty string) is required")
+            if not isinstance(messages, list) or not messages:
+                raise _BadRequest("'messages' (non-empty list) is required")
+            if not isinstance(defer_index, bool):
+                raise _BadRequest("'defer_index' must be a boolean when provided")
+            result = runner.run(
+                service.a2a_import(
+                    source, messages, defer_index=defer_index, data_dir=data_dir,
                 )
             )
             self._send_json(200, result)
@@ -2232,7 +2262,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     print("Endpoints: GET /health, GET /version, POST /ingest, POST /ingest/batch, GET|POST /search, "
           "GET /projects, GET /shelves, "
           "GET /pending, POST /pending/resolve, "
-          "POST /a2a/send, GET /a2a/messages, GET /a2a/stream, "
+          "POST /a2a/send, POST /a2a/import, GET /a2a/messages, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
           "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
           "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove, "
@@ -2244,7 +2274,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "POST /shelves, POST /shelves/{id}/archive, "
           "POST /shelves/{id}/unarchive, "
           "POST /a2a/admin/delete-channel, POST /a2a/admin/rename-channel, "
-          "POST /a2a/admin/supersede-message")
+          "POST /a2a/admin/supersede-message, POST /a2a/import")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -199,6 +199,24 @@ def _archive_index_project(conn: sqlite3.Connection) -> None:
     add_column(conn, "archive_index", "project", "TEXT")
 
 
+def _archive_index_source_uid(conn: sqlite3.Connection) -> None:
+    """Add source/source_id columns for idempotent A2A batch import (#211).
+
+    ``source`` and ``source_id`` tag each imported A2A message with the
+    external origin and its stable per-source id, so a re-import can skip
+    rows already present without relying on the JSON payload alone. The
+    partial unique index enforces (source, source_id) uniqueness at the
+    database level as a safety net against duplicate writes.
+    """
+    add_column(conn, "archive_index", "source", "TEXT")
+    add_column(conn, "archive_index", "source_id", "TEXT")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_source_uid "
+        "ON archive_index (source, source_id) "
+        "WHERE source IS NOT NULL AND source_id IS NOT NULL"
+    )
+
+
 _ARCHIVE_INDEX: tuple[Migration, ...] = (
     Migration(
         1, "archive_index_baseline", _archive_index_baseline,

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -226,6 +226,11 @@ _ARCHIVE_INDEX: tuple[Migration, ...] = (
         2, "archive_index_project", _archive_index_project,
         lambda c: has_column(c, "archive_index", "project"),
     ),
+    Migration(
+        3, "archive_index_source_uid", _archive_index_source_uid,
+        lambda c: has_column(c, "archive_index", "source_id")
+        and index_exists(c, "idx_archive_source_uid"),
+    ),
 )
 
 

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -228,6 +228,24 @@ class RemoteClient:
             payload["blocks"] = blocks
         return await self._run("POST", "/a2a/send", payload)
 
+    async def a2a_import(
+        self,
+        source: str,
+        messages: list[dict],
+        *,
+        defer_index: bool = False,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/import: admin batch-import historical messages onto the remote bus.
+
+        Returns ``{"imported", "skipped", "first_id", "last_id"}`` (taOSmd #211 Q3a).
+        Uses the client's bearer token, which must be an admin token.
+        """
+        payload: dict = {"source": source, "messages": messages}
+        if defer_index:
+            payload["defer_index"] = True
+        return await self._run("POST", "/a2a/import", payload)
+
     async def a2a_feed(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 
 from . import api as _api
 from . import config as _config
@@ -854,6 +855,186 @@ async def a2a_thread_messages(
     limit_i = max(1, min(limit, 200))
     messages = messages[:limit_i]
     return {"thread": thread, "messages": messages}
+async def a2a_import(
+    source: str,
+    messages: list[dict],
+    *,
+    defer_index: bool = False,
+    data_dir=None,
+) -> dict:
+    """Admin batch-import historical chat messages onto the A2A bus.
+
+    Writes each message as an append-only :data:`~taosmd.archive.EVENT_A2A`
+    archive event, preserving the caller-supplied historical ``ts`` rather than
+    the wall-clock import time (taOSmd #211 Q3a).  Designed for the taOS chat
+    history migration: existing conversations become ordinary bus messages with
+    their original timestamps intact, so thread ordering survives in the archive.
+
+    The whole batch is validated and pre-checked *before any write*; a missing
+    required field or an unresolvable ``reply_to_source_id`` refuses the entire
+    batch with a ``ValueError`` (which the HTTP layer maps to 400) and leaves the
+    archive untouched (fail-loud, zero partial writes).
+
+    Rules:
+
+    * **Idempotent** -- uniqueness is on ``(source, source_id)``.  Messages whose
+      ``source_id`` already exists for this ``source`` (in the archive or earlier
+      in the same batch) are skipped and counted in ``skipped``, never duplicated.
+    * **TS preserved** -- the archive row carries the historical ``ts``.  Within a
+      batch, rows are inserted in ascending ``(ts, position-in-batch)`` order so
+      the auto-increment row-id ordering matches ts ordering (thread ordering
+      survives equal timestamps via the stable sort).
+    * **reply_to resolution** -- ``reply_to_source_id`` is resolved to the archive
+      row id of the matching message (same ``source``); an unresolvable id
+      refuses the batch.
+    * **defer_index** -- when ``True``, messages are archived but NOT embedded
+      into the vector store.  Run ``taosmd reindex --agent <from>`` afterwards to
+      back-fill vector entries from the archive.  When ``False`` (default) each
+      message body is embedded immediately so imported history is searchable.
+
+    Returns ``{"imported": n, "skipped": n, "first_id": int|None, "last_id": int|None}``.
+    ``first_id`` / ``last_id`` are the archive row ids of the first and last newly
+    imported messages in ts order (both ``None`` when every message was skipped).
+    """
+    if not isinstance(source, str) or not source:
+        raise ValueError("source (non-empty string) is required")
+    if not isinstance(messages, list):
+        raise ValueError("messages must be a list")
+    if not messages:
+        raise ValueError("messages must be a non-empty list")
+
+    # --- Remote import branch: forward to remote server if configured -----
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_import(source, messages, defer_index=defer_index)
+
+    # --- Fail-loud validation: every field checked before any write --------
+    seen_source_ids: set[str] = set()
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            raise ValueError(f"messages[{i}] must be an object")
+        for field in ("from", "thread", "body", "source_id"):
+            val = msg.get(field)
+            if not isinstance(val, str) or not val:
+                raise ValueError(
+                    f"messages[{i}].{field} (non-empty string) is required"
+                )
+        ts = msg.get("ts")
+        if not isinstance(ts, (int, float)) or isinstance(ts, bool) or not math.isfinite(ts):
+            raise ValueError(f"messages[{i}].ts (finite float) is required")
+        rti = msg.get("reply_to_source_id")
+        if rti is not None and not isinstance(rti, str):
+            raise ValueError(f"messages[{i}].reply_to_source_id must be a string or null")
+        sid = msg["source_id"]
+        if sid in seen_source_ids:
+            raise ValueError(
+                f"messages[{i}].source_id {sid!r} is duplicated within the batch"
+            )
+        seen_source_ids.add(sid)
+
+    # --- Idempotency + reply_to pre-check (archive is source of truth) ---
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    existing = await archive.find_source_ids(source)
+    # Every reply_to_source_id must resolve to an already-imported message
+    # (in the archive, or earlier in this same batch by source_id presence).
+    batch_ids = {msg["source_id"] for msg in messages}
+    for i, msg in enumerate(messages):
+        rti = msg.get("reply_to_source_id")
+        if rti is not None and rti not in existing and rti not in batch_ids:
+            raise ValueError(
+                f"messages[{i}].reply_to_source_id {rti!r} does not match any "
+                f"imported message in source {source!r}"
+            )
+
+    # --- Insert in ts order so auto-increment id order == ts order ----------
+    # Stable sort on (ts, original position): equal timestamps keep their
+    # in-batch order, so thread ordering survives.
+    order = sorted(
+        range(len(messages)),
+        key=lambda p: (messages[p]["ts"], p),
+    )
+
+    id_map: dict[str, int] = dict(existing)
+    imported = 0
+    skipped = 0
+    first_id: int | None = None
+    last_id: int | None = None
+
+    for pos in order:
+        msg = messages[pos]
+        sid = msg["source_id"]
+        if sid in id_map:
+            skipped += 1
+            continue
+
+        # Resolve reply_to_source_id to the archive row id of the referenced
+        # message (already imported in the archive or earlier in this batch in
+        # ts order).  A forward reference (target comes later in the batch)
+        # leaves reply_to=None but keeps reply_to_source_id for traceability.
+        rti = msg.get("reply_to_source_id")
+        reply_to: str | None = None
+        if rti is not None:
+            target = id_map.get(rti)
+            if target is not None:
+                reply_to = str(target)
+
+        data: dict = {
+            "from": msg["from"],
+            "body": msg["body"],
+            "thread": msg["thread"],
+            "reply_to": reply_to,
+            "source": source,
+            "source_id": sid,
+        }
+        if rti is not None:
+            data["reply_to_source_id"] = rti
+        if msg.get("refs") is not None:
+            data["refs"] = msg["refs"]
+        if msg.get("blocks") is not None:
+            data["blocks"] = msg["blocks"]
+
+        row_id = await archive.record(
+            event_type=EVENT_A2A,
+            data=data,
+            agent_name=msg["from"],
+            app_id=msg["thread"],
+            summary=msg["body"][:200],
+            source=source,
+            source_id=sid,
+            timestamp=msg["ts"],
+        )
+        id_map[sid] = row_id
+        if first_id is None:
+            first_id = row_id
+        last_id = row_id
+        imported += 1
+
+        # Optional vector embedding (skipped when deferring).
+        if not defer_index:
+            meta: dict = {
+                "agent": msg["from"],
+                "source": source,
+                "source_id": sid,
+                "ts": msg["ts"],
+            }
+            if isinstance(row_id, int) and row_id >= 0:
+                meta["archive_span_id"] = row_id
+            try:
+                await stores["vector"].add(msg["body"], metadata=meta)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "a2a_import: vector embed failed for source_id %r; "
+                    "message is archived and recoverable",
+                    sid,
+                )
+
+    return {
+        "imported": imported,
+        "skipped": skipped,
+        "first_id": first_id,
+"last_id": last_id,
+    }
 
 
 async def task_create(
@@ -1262,8 +1443,7 @@ async def collections_archive(collection_id: str, *, data_dir=None) -> dict:
 
 
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
-           "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_members",
-           "a2a_threads", "a2a_thread_messages",
+"supersede", "a2a_send", "a2a_import", "a2a_feed", "a2a_channels", "a2a_members",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -214,6 +214,37 @@ def test_a2a_reply_to_field_preserved(isolated_data_dir):
     assert msgs[1]["reply_to"] == str(r1["id"])
 
 
+def test_a2a_import_preserves_historical_ts(isolated_data_dir):
+    """a2a_import stores each message with its caller-supplied ts."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    historical_ts = 1_700_000_000.0
+    messages = [
+        {"from": "alice", "thread": "hist", "body": "first", "source_id": "h1", "ts": historical_ts},
+        {"from": "alice", "thread": "hist", "body": "second", "source_id": "h2", "ts": historical_ts + 10.0},
+    ]
+
+    result = asyncio.run(service.a2a_import("bus", messages, data_dir=dd))
+    assert result["imported"] == 2
+    assert result["skipped"] == 0
+    assert result["first_id"] is not None
+    assert result["last_id"] is not None
+    assert result["first_id"] < result["last_id"]
+
+    msgs = asyncio.run(service.a2a_feed(thread="hist", data_dir=dd))
+    assert len(msgs) == 2
+    assert msgs[0]["ts"] == historical_ts
+    assert msgs[0]["body"] == "first"
+    assert msgs[1]["ts"] == historical_ts + 10.0
+    assert msgs[1]["body"] == "second"
+
+    # Idempotency: re-importing the same batch skips both rows.
+    retry = asyncio.run(service.a2a_import("bus", messages, data_dir=dd))
+    assert retry["imported"] == 0
+    assert retry["skipped"] == 2
+
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -120,6 +120,17 @@ def test_legacy_modern_archive_index_is_stamped_without_reapplying(tmp_path):
     conn = _db.connect(path)
     conn.executescript(INDEX_SCHEMA)  # modern shape, includes `project`
     conn.execute(
+        "ALTER TABLE archive_index ADD COLUMN source TEXT"
+    )
+    conn.execute(
+        "ALTER TABLE archive_index ADD COLUMN source_id TEXT"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_source_uid "
+        "ON archive_index (source, source_id) "
+        "WHERE source IS NOT NULL AND source_id IS NOT NULL"
+    )
+    conn.execute(
         "INSERT INTO archive_index "
         "(timestamp, event_type, agent_name, app_id, project, summary,"
         " file_path, line_number, data_json) "
@@ -421,7 +432,7 @@ def test_status_reports_pending_for_an_unstamped_legacy_store(tmp_path):
     # The baseline is already present, so it is reported as detected rather
     # than as a step that would run.
     assert st["detected_baseline"] == 1
-    assert st["pending"] == ["archive_index_project"]
+    assert st["pending"] == ["archive_index_project", "archive_index_source_uid"]
 
     migrations.migrate(conn, "archive_index")
     st = migrations.status(conn, "archive_index")
@@ -436,6 +447,13 @@ def test_status_of_a_complete_legacy_store_reports_stamp_only_work(tmp_path):
 
     conn = _db.connect(tmp_path / "archive-index.db")
     conn.executescript(INDEX_SCHEMA)
+    conn.execute("ALTER TABLE archive_index ADD COLUMN source TEXT")
+    conn.execute("ALTER TABLE archive_index ADD COLUMN source_id TEXT")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_source_uid "
+        "ON archive_index (source, source_id) "
+        "WHERE source IS NOT NULL AND source_id IS NOT NULL"
+    )
     conn.commit()
 
     st = migrations.status(conn, "archive_index")
@@ -487,6 +505,82 @@ async def test_archive_store_open_stamps_the_database(tmp_path):
     assert _user_version(conn) == migrations.latest_version("archive_index")
     assert "project" in _columns(conn, "archive_index")
     conn.close()
+
+
+@pytest.mark.asyncio
+async def test_archive_store_fresh_install_has_source_uid_migration(tmp_path):
+    """A brand-new DB has source/source_id columns and the partial unique index."""
+    from taosmd.archive import ArchiveStore
+
+    store = ArchiveStore(archive_dir=tmp_path / "archive",
+                         index_path=tmp_path / "archive-index.db")
+    await store.init()
+    await store.close()
+
+    conn = sqlite3.connect(tmp_path / "archive-index.db")
+    try:
+        assert _user_version(conn) == migrations.latest_version("archive_index")
+        cols = _columns(conn, "archive_index")
+        assert "source" in cols, "fresh install must have source column"
+        assert "source_id" in cols, "fresh install must have source_id column"
+        assert "project" in cols, "positive control: project column must also be present"
+        idx_rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_archive_source_uid'"
+        ).fetchall()
+        assert idx_rows, "fresh install must have idx_archive_source_uid"
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_archive_store_upgrades_legacy_index_to_source_uid(tmp_path):
+    """A pre-source_uid DB gains the columns and index on open."""
+    from taosmd.archive import ArchiveStore
+
+    path = tmp_path / "archive-index.db"
+    conn = _db.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE archive_index (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            event_type TEXT NOT NULL,
+            agent_name TEXT,
+            app_id TEXT,
+            project TEXT,
+            summary TEXT NOT NULL DEFAULT '',
+            file_path TEXT NOT NULL,
+            line_number INTEGER NOT NULL,
+            data_json TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE TABLE archive_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        """
+    )
+    conn.execute(
+        "INSERT INTO archive_index (timestamp, event_type, summary, file_path, line_number)"
+        " VALUES (1.0, 'turn', 'legacy', 'f.jsonl', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = ArchiveStore(archive_dir=tmp_path / "archive", index_path=path)
+    await store.init()
+    await store.close()
+
+    conn = sqlite3.connect(path)
+    try:
+        assert _user_version(conn) == migrations.latest_version("archive_index")
+        cols = _columns(conn, "archive_index")
+        assert "source" in cols
+        assert "source_id" in cols
+        idx_rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_archive_source_uid'"
+        ).fetchall()
+        assert idx_rows
+        row = conn.execute("SELECT summary FROM archive_index").fetchone()
+        assert row[0] == "legacy"
+    finally:
+        conn.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): FIX-FORWARD PR #284: register the archive source_uid migration, add fresh-install + upgrade + import tests

Autonomous build of board card tsk-uyznqh.



Files:
 taosmd/capabilities.py                             |   3 +-
 taosmd/http_server.py                              |  34 +++-
 taosmd/migrations.py                               |  23 +++
 taosmd/remote.py                                   |  18 ++
 taosmd/service.py                                  | 184 ++++++++++++++++++++-
 tests/test_a2a.py                                  |  31 ++++
 tests/test_migrations.py                           |  96 ++++++++++-
 10 files changed, 433 insertions(+), 11 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only API for importing historical A2A messages in batches.
  * Preserves original timestamps, reply relationships, and source identifiers.
  * Supports idempotent imports, duplicate skipping, and deferred indexing.
  * Added remote-client support for initiating imports.

* **Bug Fixes**
  * Improved upgrade and migration handling for imported message metadata.
  * Added validation for import requests and historical timestamps.

* **Documentation**
  * Updated endpoint and changelog documentation for A2A imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->