### PR TITLE
Collections: doc currency metadata on the hit envelope (Q7+Q10 of #210)

### DIFF
--- a/changelog.d/tsk-fogwh4-collection-doc-currency.md
+++ b/changelog.d/tsk-fogwh4-collection-doc-currency.md
@@ -1,0 +1,2 @@
+### Added
+- Front-matter parsing: markdown files with YAML front-matter now parse `doc_id`, `version`, and `review_by` keys at index time, storing them on every chunk's metadata. Collection search hits gain `doc_id`, `version`, `is_current` (always true on default path), `as_of` (indexing timestamp), and `is_past_review` (true when `review_by` exists and is before now). A assertion in `_format_hit` guards against metadata loss reverting to PR #195 behaviour.

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -425,6 +425,16 @@ def _format_hit(hit: dict) -> dict:
     underlying row's ``created_at`` / ``timestamp`` field.
     """
     md = hit.get("metadata", {}) or {}
+    # --- NEW: extract front-matter doc metadata before unwrapping ---
+    # We extract from the original md here because the unwrapping loop
+    # descends into nested metadata dicts, which would lose top-level keys
+    # like doc_id, version, review_by that are stored alongside a nested
+    # metadata key (as happens when chunks from ingest_folder carry them).
+    doc_id = md.get("doc_id") if isinstance(md, dict) else None
+    version = md.get("version") if isinstance(md, dict) else None
+    review_by = md.get("review_by") if isinstance(md, dict) else None
+    # --- end NEW ---
+
     # Unwrap to the innermost user metadata. Depending on the path a hit's
     # metadata is nested differently: the BM25 path passes the row metadata
     # (one ``metadata`` level for batch rows), while the full retrieval path
@@ -450,6 +460,12 @@ def _format_hit(hit: dict) -> dict:
         for key, value in preserved.items():
             user_md.setdefault(key, value)
 
+    # Assert that critical provenance keys survive the unwrapping
+    # (PR #195: deep-unwrap once stripped archive_span_id and blinded the claims gate).
+    for key in ("archive_span_id", "agent", "project"):
+        if key in (md or {}):
+            assert key in user_md, f"_format_hit lost critical key: {key} during metadata unwrap"
+
     confidence = (
         md.get("similarity")
         if isinstance(md, dict) and md.get("similarity") is not None
@@ -462,6 +478,41 @@ def _format_hit(hit: dict) -> dict:
         or (md.get("timestamp") if isinstance(md, dict) else None)
         or 0
     )
+
+    # --- NEW: add collection doc metadata to formatted hit ---
+    # is_current: always true on the default path (results are current by construction)
+    # as_of: the indexing timestamp of the row
+    # is_past_review: true when review_by exists and is before now
+    is_current = True
+    as_of = user_md.get("indexed_at") if isinstance(user_md, dict) else None
+    if as_of is None:
+        as_of = timestamp
+    has_review_by = review_by is not None
+    is_past_review = has_review_by and review_by < time.strftime("%Y-%m-%d")
+
+    # Base new metadata fields: always add is_current and as_of.
+    # Add is_past_review only when review_by is present (front-matter case).
+    # When review_by is absent, is_past_review is omitted per the spec:
+    # "Same file without front-matter -> none of those keys except is_current/as_of".
+    user_md["is_current"] = is_current
+    user_md["as_of"] = as_of
+    if has_review_by:
+        user_md["is_past_review"] = is_past_review
+    if doc_id is not None:
+        user_md["doc_id"] = doc_id
+    if version is not None:
+        user_md["version"] = version
+    if has_review_by:
+        user_md["review_by"] = review_by
+    # --- end NEW ---
+
+    # NOTE: superseded_by is ONLY included on rows from an explicit
+    # superseded/history query (not the default path), because default
+    # results are current by construction — superseded rows are hidden.
+    # The ``hidden_by`` marker on the row's metadata indicates it has
+    # been superseded; when present, carry forward the replacement info.
+    if "hidden_by" in (md or {}):
+        user_md["superseded_by"] = md["hidden_by"]
 
     return {
         "text": hit.get("text", ""),

--- a/taosmd/collections.py
+++ b/taosmd/collections.py
@@ -494,6 +494,55 @@ def _is_ignored(
     return ignored
 
 
+def _parse_front_matter(file_path: str) -> dict:
+    """Parse YAML front-matter from a markdown file (stdlib-only, no deps).
+
+    Looks for ``\\n---\\n`` at the start, extracts simple ``key: value`` pairs
+    from the block between the opening and closing ``---`` delimiters.
+    Returns a dict with doc_id (str), version (int), review_by (ISO date str)
+    when present; absent keys are omitted.
+    """
+    try:
+        text = Path(file_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    if not text.startswith("---\n") and not text.startswith("---"):
+        return {}
+    # Find the closing --- after the opening ---
+    rest = text[4:] if text.startswith("---\n") else text[3:]
+    close_idx = rest.find("\n---\n")
+    if close_idx < 0:
+        close_idx = rest.rfind("\n---")
+        if close_idx < 0:
+            return {}
+    fm_text = rest[:close_idx].strip()
+    if not fm_text:
+        return {}
+    result: dict = {}
+    for line in fm_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        # Strip surrounding quotes
+        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+            value = value[1:-1]
+        elif len(value) >= 2 and value[0] == "'" and value[-1] == "'":
+            value = value[1:-1]
+        # Try int for version
+        if key == "version":
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+        result[key] = value
+    return result
+
+
 def _loader_for(path: Path):
     """Return an instance of the loader that explicitly claims ``path``,
     or ``None`` when no registered loader does.
@@ -810,6 +859,10 @@ async def ingest_folder(
                         # vanished, and clients show the two separately.
                         emptied.add(rel)
                     continue
+                # Parse front-matter from markdown files at index time.
+                fm: dict = {}
+                if abs_path.suffix.lower() == ".md":
+                    fm = _parse_front_matter(str(abs_path))
                 # Hashing + chunking are CPU-bound; off-loop like the walk above.
                 file_hash, chunks = await asyncio.to_thread(
                     _hash_and_chunk, text, chunk_chars, prior.get(rel)
@@ -823,16 +876,22 @@ async def ingest_folder(
                     chunk_id = hashlib.sha256(
                         f"{collection_id}:{rel}:{file_hash}:{i}".encode("utf-8")
                     ).hexdigest()
+                    chunk_md: dict = {
+                        "collection_id": collection_id,
+                        "file_path": rel,
+                        "source": "collection",
+                        "chunk_index": i,
+                        "file_hash": file_hash,
+                        "indexed_at": time.time(),
+                    }
+                    # Add front-matter parsed fields when present.
+                    for key in ("doc_id", "version", "review_by"):
+                        if key in fm:
+                            chunk_md[key] = fm[key]
                     items.append({
                         "text": chunk,
                         "id": chunk_id,
-                        "metadata": {
-                            "collection_id": collection_id,
-                            "file_path": rel,
-                            "source": "collection",
-                            "chunk_index": i,
-                            "file_hash": file_hash,
-                        },
+                        "metadata": chunk_md,
                     })
                 indexed.append((rel, file_hash))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -190,7 +190,68 @@ def test_format_hit_prefers_similarity_over_source_score():
     assert formatted["confidence"] == 0.85
     assert formatted["source"] == "vector"
     assert formatted["timestamp"] == 1700000000
-    assert formatted["metadata"] == {"position": 7, "timestamp": 1700000000}
+    # New collection doc metadata fields are added alongside existing user keys.
+    assert formatted["metadata"]["position"] == 7
+    assert formatted["metadata"]["timestamp"] == 1700000000
+    assert formatted["metadata"]["as_of"] == 1700000000
+    assert formatted["metadata"]["is_current"] is True
+
+
+def test_format_hit_includes_front_matter_metadata():
+    """_format_hit passes through doc_id, version, review_by from user metadata."""
+    hit = {
+        "text": "test content",
+        "source": "vector",
+        "metadata": {
+            "doc_id": "doc-abc123",
+            "version": 5,
+            "review_by": "2024-12-31",
+            "metadata": {"file_path": "docs/intro.md"},
+            "collection_id": "col-xyz",
+        },
+    }
+    formatted = taosmd_api._format_hit(hit)
+    assert formatted["metadata"]["doc_id"] == "doc-abc123"
+    assert formatted["metadata"]["version"] == 5
+    assert formatted["metadata"]["is_current"] is True
+    assert formatted["metadata"]["is_past_review"] is True  # 2024-12-31 < now
+    assert formatted["metadata"]["as_of"] is not None
+    assert formatted["metadata"]["review_by"] == "2024-12-31"
+
+
+def test_format_hit_no_front_matter_no_doc_id():
+    """_format_hit without doc_id/version in metadata leaves those keys absent."""
+    hit = {
+        "text": "test content",
+        "source": "vector",
+        "metadata": {
+            "file_path": "docs/intro.md",
+        },
+    }
+    formatted = taosmd_api._format_hit(hit)
+    assert "doc_id" not in formatted["metadata"]
+    assert "version" not in formatted["metadata"]
+    assert "is_past_review" not in formatted["metadata"]
+    # is_current and as_of should always be present
+    assert formatted["metadata"]["is_current"] is True
+    assert formatted["metadata"]["as_of"] is not None
+
+
+def test_format_hit_review_by_in_future_is_not_past_review():
+    """_format_hit is_past_review is false when review_by is after today."""
+    import datetime
+    future_date = (datetime.date.today() + datetime.timedelta(days=365)).isoformat()
+    hit = {
+        "text": "test content",
+        "source": "vector",
+        "metadata": {
+            "doc_id": "doc-abc123",
+            "review_by": future_date,
+        },
+    }
+    formatted = taosmd_api._format_hit(hit)
+    assert formatted["metadata"]["is_past_review"] is False
+    assert formatted["metadata"]["review_by"] == future_date
 
 
 def test_format_hit_falls_back_to_source_score():


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Collections: doc currency metadata on the hit envelope (Q7+Q10 of #210)

Autonomous build of board card tsk-fogwh4.



Files:
 changelog.d/tsk-fogwh4-collection-doc-currency.md |  2 +
 taosmd/api.py                                     | 51 ++++++++++++++++
 taosmd/collections.py                             | 73 ++++++++++++++++++++---
 tests/test_api.py                                 | 63 ++++++++++++++++++-
 4 files changed, 181 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown document front matter now supports document IDs, versions, and review dates.
  * Indexed content and search results include document provenance and review-status metadata.
  * Search results now indicate whether content is current, its effective date, and whether review is overdue.
  * Indexed chunks include an indexing timestamp.

* **Bug Fixes**
  * Preserved critical document metadata when formatting search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->