### PR TITLE
benchmarks: realworld_llm_benchmark exits 0 when the model is missing (last site of the issue #205 class)

### DIFF
--- a/benchmarks/realworld_llm_benchmark.py
+++ b/benchmarks/realworld_llm_benchmark.py
@@ -297,7 +297,7 @@ async def run_benchmark(limit: int = 500, top_k: int = 5):
         print(f"\nERROR: {LLM_MODEL} not available in Ollama")
         print(f"Available models: {models}")
         print(f"Run: ollama pull {LLM_MODEL}")
-        return
+        sys.exit(1)
 
     print(f"Ollama OK — {LLM_MODEL} available")
 

--- a/changelog.d/tsk-xykcf2-realworld-llm-benchmark.md
+++ b/changelog.d/tsk-xykcf2-realworld-llm-benchmark.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `benchmarks/realworld_llm_benchmark.py:300`: Changed bare `return` to `sys.exit(1)` when the LLM model is not available in Ollama, so that automated benchmark chains detect the refusal as a non-zero exit code instead of treating it as a clean run.

--- a/tests/test_realworld_llm_benchmark_exit.py
+++ b/tests/test_realworld_llm_benchmark_exit.py
@@ -1,0 +1,19 @@
+"""Test that realworld_llm_benchmark exits with non-zero code when LLM model is missing."""
+
+import pytest
+from benchmarks.realworld_llm_benchmark import run_benchmark
+
+
+@pytest.mark.asyncio
+async def test_exit_code_non_zero_when_model_missing():
+    """Verify sys.exit(1) is called when LLM model is not available in Ollama.
+
+    This mirrors the test pattern from PR #290 (eventqa_runner.py): catch
+    SystemExit and assert the exit code is non-zero, rather than using a bare
+    pytest.raises(SystemExit) which would pass on sys.exit(0).
+    """
+    with pytest.raises(SystemExit) as exc:
+        await run_benchmark(limit=1, top_k=1)
+    assert exc.value.code != 0, (
+        f"Expected non-zero exit code, got {exc.value.code}"
+    )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): benchmarks: realworld_llm_benchmark exits 0 when the model is missing (last site of the issue #205 class)

Autonomous build of board card tsk-xykcf2.

- benchmarks/realworld_llm_benchmark.py:300: change bare return to sys.exit(1)
- tests/test_realworld_llm_benchmark_exit.py: add exit-code non-zero test
- changelog.d/tsk-xykcf2-realworld-llm-benchmark.md: record the fix

Files:
 benchmarks/realworld_llm_benchmark.py             |  2 +-
 changelog.d/tsk-xykcf2-realworld-llm-benchmark.md |  3 +++
 tests/test_realworld_llm_benchmark_exit.py        | 19 +++++++++++++++++++
 3 files changed, 23 insertions(+), 1 deletion(-)