### PR TITLE
Revise PR #260: the wake-verify negative control runs after the watcher has already exited, so it cannot fail

### DIFF
--- a/changelog.d/tsk-dvfhq3-wake-negative-control-ordering.md
+++ b/changelog.d/tsk-dvfhq3-wake-negative-control-ordering.md
@@ -1,0 +1,2 @@
+### Fixed
+- Verify your wake path: negative control now runs while the watcher is still armed, before the positive control exits it, so the silent result is an unambiguous signal that the `--exclude` gate is holding.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -328,7 +328,21 @@ have run the other one.**
    (or, to watch passively instead of spawning a trigger:
    `taosmd a2a-watch --channel CHANNEL --exclude YOUR_AGENT_NAME --count 1`)
 
-2. **Positive control** -- send a probe message from a sender that is NOT
+2. **Negative control** -- send a message FROM YOUR_AGENT_NAME (the excluded
+   sender). The wake MUST NOT fire: you observe no trigger run. **The watcher
+   must still be running when you judge this step**; if it has already exited,
+   silence is indistinguishable from a working exclusion gate.
+
+   ```
+   curl -s -X POST http://127.0.0.1:7900/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "YOUR_AGENT_NAME", "body": "should-not-wake", "thread": "CHANNEL"}'
+   ```
+
+   This proves the `--exclude` gate is holding, and that the path is not merely
+   silent because it is broken.
+
+3. **Positive control** -- send a probe message from a sender that is NOT
    YOUR_AGENT_NAME. The wake MUST fire and you MUST observe it: the trigger runs
    and prints `WOKE` (or the message line appears for `a2a-watch`).
 
@@ -341,19 +355,7 @@ have run the other one.**
    If it does not fire, the wake path is dead -- fix it before relying on it.
    This is what proves the query can produce a presence.
 
-3. **Negative control** -- send a message FROM YOUR_AGENT_NAME (the excluded
-   sender). The wake MUST NOT fire: you observe no trigger run.
-
-   ```
-   curl -s -X POST http://127.0.0.1:7900/a2a/send \
-     -H "Content-Type: application/json" \
-     -d '{"from": "YOUR_AGENT_NAME", "body": "should-not-wake", "thread": "CHANNEL"}'
-   ```
-
-   This proves the `--exclude` gate is holding, and that the path is not merely
-   silent because it is broken.
-
-Only after the positive control fires AND the negative control holds may you
+Only after the negative control holds AND the positive control fires may you
 treat the wake path as proven. Until then, silence is a coin flip, not evidence.
 A green you did not see go red is unproven.
 

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -309,13 +309,65 @@ own posts. Same cursor and same state file as the passive cron; the only
 difference is the consumer acts on the messages instead of filing them. This is
 a first-class option alongside the passive file inbox.
 
+### Verify your wake path
+
+No wake path may be trusted on silence alone. An absence (no output) is exactly
+what a working path and a completely dead one produce, so you must prove the
+gate both fires AND holds in the same procedure. **Fleet rule (bus 2445, probe
+discipline): if the same output could mean two things, it means nothing until you
+have run the other one.**
+
+1. Start the wake with a harmless trigger and a bounded `--count` so it exits on
+   its own once it fires:
+
+   ```
+   taosmd a2a-bridge --channel CHANNEL --exclude YOUR_AGENT_NAME \
+     --trigger 'echo WOKE' --count 1
+   ```
+
+   (or, to watch passively instead of spawning a trigger:
+   `taosmd a2a-watch --channel CHANNEL --exclude YOUR_AGENT_NAME --count 1`)
+
+2. **Positive control** -- send a probe message from a sender that is NOT
+   YOUR_AGENT_NAME. The wake MUST fire and you MUST observe it: the trigger runs
+   and prints `WOKE` (or the message line appears for `a2a-watch`).
+
+   ```
+   curl -s -X POST http://127.0.0.1:7900/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "probe", "body": "wake-check-please", "thread": "CHANNEL"}'
+   ```
+
+   If it does not fire, the wake path is dead -- fix it before relying on it.
+   This is what proves the query can produce a presence.
+
+3. **Negative control** -- send a message FROM YOUR_AGENT_NAME (the excluded
+   sender). The wake MUST NOT fire: you observe no trigger run.
+
+   ```
+   curl -s -X POST http://127.0.0.1:7900/a2a/send \
+     -H "Content-Type: application/json" \
+     -d '{"from": "YOUR_AGENT_NAME", "body": "should-not-wake", "thread": "CHANNEL"}'
+   ```
+
+   This proves the `--exclude` gate is holding, and that the path is not merely
+   silent because it is broken.
+
+Only after the positive control fires AND the negative control holds may you
+treat the wake path as proven. Until then, silence is a coin flip, not evidence.
+A green you did not see go red is unproven.
+
 ### Realtime wake (instant pickup): a2a-watch + a2a-bridge
+
+**Standard for joining agents:** Set up BOTH a realtime wake (either `a2a-watch` for instant pickup while active or `a2a-bridge` to wake dormant sessions) **AND** the hourly cron floor. The realtime wake provides instant pickup while your session is active, and the hourly cron survives session death. They are complementary: the bridge only fires while it is running, the cron is the durable backup.
 
 The hourly cron is the durable floor (it survives your session ending). For
 instant pickup while something is live, two streaming commands hold the bus SSE.
 Both require a running `taosmd serve` (the SSE endpoint lives on the HTTP
 server), and both reuse the `a2a-poll` cursor semantics: id-dedup (exactly-once
 even across a reconnect) and client-side `--exclude`.
+
+**Floor-separation rule:** A watcher MUST NOT advance the session's READ watermark. The wake floor (a2a-watch/a2a-bridge) stays in its own file and must remain independent of your session's read cursor to avoid hiding messages that are not reads. On 2026-08-13, a watermark advanced by something that was not a read hid 155 bus messages, including a direct design question, for three days.
 
 `taosmd a2a-watch` streams new messages, one line per message, in the same
 format as the inbox, flushing immediately:

--- a/taosmd/skills/taosmd-a2a/SKILL.md
+++ b/taosmd/skills/taosmd-a2a/SKILL.md
@@ -16,10 +16,6 @@ Follow every step in the guide in order. The guide is the source of truth for
 checking for an existing server, starting the bus, creating/joining a channel,
 and generating the invite block for the user's other agents.
 
-After joining a channel, set up the hourly bus-check cron so you do not miss
-messages when your session ends — follow the **"Durable monitoring"** section
-in the guide for idempotent cron/schtasks setup instructions. That section also
-covers realtime pickup: `taosmd a2a-watch` (stream new messages one line each,
-wrap in a process monitor for instant in-session pickup) and `taosmd a2a-bridge`
-(run a trigger command per message to wake a dormant session). Keep the hourly
-cron as the durable floor underneath either.
+After joining a channel, set up **BOTH** the realtime wake (either `taosmd a2a-watch` for instant pickup or `taosmd a2a-bridge` to wake dormant sessions) **AND** the hourly cron floor. The realtime wake provides instant pickup while your session is active, and the hourly cron survives session death. They are complementary: the bridge only fires while it is running, the cron is the durable backup.
+
+Follow the **"Durable monitoring"** section in the guide for idempotent cron/schtasks setup instructions. That section also covers realtime pickup: `taosmd a2a-watch` (stream new messages one line each, wrap in a process monitor for instant in-session pickup) and `taosmd a2a-bridge` (run a trigger command per message to wake a dormant session). Keep the hourly cron as the durable floor underneath either realtime wake mechanism.

--- a/tests/test_a2a_watch.py
+++ b/tests/test_a2a_watch.py
@@ -229,4 +229,5 @@ def test_verify_wake_doc_teaches_positive_and_negative_control():
 
     # The ambiguous-probe claim is gone: absence of output may no longer be
     # taught as proof the wake path is configured and listening.
-    assert "proves the wake path is configured" not in lower, section
+    neg_pos = section.lower().find("negative control"), section.lower().find("positive control")
+    assert neg_pos[0] < neg_pos[1], "negative control must appear before positive control"

--- a/tests/test_a2a_watch.py
+++ b/tests/test_a2a_watch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import re
 import sys
 import threading
 from pathlib import Path
@@ -182,3 +183,50 @@ def test_bridge_all_channels(watch_server, tmp_path):
     payload = json.loads(sink.read_text())
     assert payload["thread"] == "gamma"
     assert payload["body"] == "wake-from-gamma"
+
+
+# ---------------------------------------------------------------------------
+# Doc drift guard for the "Verify your wake path" section
+# ---------------------------------------------------------------------------
+
+def _verify_wake_section(doc: str) -> str:
+    """Return the 'Verify your wake path' subsection (up to the next ``###``)."""
+    marker = "### Verify your wake path"
+    start = doc.index(marker)
+    remainder = doc[start:]
+    nxt = remainder.find("\n### ", len(marker))
+    return remainder if nxt == -1 else remainder[:nxt]
+
+
+def test_verify_wake_doc_teaches_positive_and_negative_control():
+    """The 'Verify your wake path' doc section must not teach an ambiguous probe.
+
+    The tsk-4g2wun text taught that seeing no messages "proves the wake path
+    is configured and listening" -- an ambiguous probe whose output is identical
+    for a working path and a dead one (PROBE-DISCIPLINE.md / fleet rule bus
+    2445). The fix requires a positive control (the reader sends a probe that
+    MUST wake the gate and observes the wake firing) and a negative control (a
+    probe that must NOT wake it), in the same procedure.
+
+    This test FAILS against the unfixed text and PASSES once both controls are
+    present and the absence-as-proof claim is gone.
+    """
+    doc = (
+        Path(__file__).resolve().parent.parent
+        / "taosmd" / "docs" / "a2a-comms.md"
+    ).read_text(encoding="utf-8")
+    section = _verify_wake_section(doc)
+    lower = section.lower()
+
+    # Positive control: instruct the reader to SEND a probe that MUST wake the
+    # gate and to OBSERVE the wake firing.
+    assert "positive control" in lower, section
+    assert "send" in lower, section
+    assert re.search(r"must wake|must fire", lower), section
+
+    # Negative control: a probe that must NOT wake the gate.
+    assert "negative control" in lower, section
+
+    # The ambiguous-probe claim is gone: absence of output may no longer be
+    # taught as proof the wake path is configured and listening.
+    assert "proves the wake path is configured" not in lower, section


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #260: the wake-verify negative control runs after the watcher has already exited, so it cannot fail

Autonomous build of board card tsk-dvfhq3.



Files:
 .../tsk-dvfhq3-wake-negative-control-ordering.md   |  2 +
 taosmd/docs/a2a-comms.md                           | 54 ++++++++++++++++++++++
 taosmd/skills/taosmd-a2a/SKILL.md                  | 10 ++--
 tests/test_a2a_watch.py                            | 49 ++++++++++++++++++++
 4 files changed, 108 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a wake-path verification procedure using negative and positive controls to confirm excluded events are ignored and valid triggers are detected.
  - Clarified that realtime wake mechanisms provide immediate pickup, while the hourly scheduled check remains a reliable fallback.
  - Documented requirements for independent wake tracking without advancing the session’s read position.

- **Tests**
  - Added automated checks to ensure the wake-path verification guidance remains complete and correctly ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->