### PR TITLE
taosmd config setters: a positional bool before a path silently clears the key you meant to set

### DIFF
--- a/changelog.d/tsk-tnz4zs-keyword-only-clear.md
+++ b/changelog.d/tsk-tnz4zs-keyword-only-clear.md
@@ -1,0 +1,2 @@
+### Fixed
+- Config setters with a `clear` bool before `data_dir` now make `clear` keyword-only, preventing silent data loss when a path is passed positionally.

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -113,7 +113,7 @@ def get_memory_model(data_dir=None) -> str | None:
     return None
 
 
-def set_memory_model(model: str, clear: bool = False, data_dir=None) -> None:
+def set_memory_model(model: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the global memory model.
 
     Args:
@@ -142,7 +142,7 @@ def get_generator_profile(data_dir=None) -> str | None:
     return None
 
 
-def set_generator_profile(profile_id: str, clear: bool = False, data_dir=None) -> None:
+def set_generator_profile(profile_id: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the active global generator-profile id.
 
     Args:
@@ -171,7 +171,7 @@ def get_default_recipe(data_dir=None) -> str | None:
     return None
 
 
-def set_default_recipe(recipe_id: str, clear: bool = False, data_dir=None) -> None:
+def set_default_recipe(recipe_id: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the global default recipe id (or clear it).
 
     Args:
@@ -309,7 +309,7 @@ def get_server_url(data_dir=None) -> str | None:
     return None
 
 
-def set_server_url(url: str, clear: bool = False, data_dir=None) -> None:
+def set_server_url(url: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the remote server URL.
 
     Args:
@@ -356,7 +356,7 @@ def get_registry_url(data_dir=None) -> str | None:
     return None
 
 
-def set_registry_url(url: str, clear: bool = False, data_dir=None) -> None:
+def set_registry_url(url: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the agent-registry base URL (or clear it).
 
     Args:
@@ -399,7 +399,7 @@ def get_registry_token(data_dir=None) -> str | None:
     return None
 
 
-def set_registry_token(token: str, clear: bool = False, data_dir=None) -> None:
+def set_registry_token(token: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the registry auth token (or clear it).
 
     Args:
@@ -442,7 +442,7 @@ def get_files_url(data_dir=None) -> str | None:
     return None
 
 
-def set_files_url(url: str, clear: bool = False, data_dir=None) -> None:
+def set_files_url(url: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the taOS Files base URL (or clear it).
 
     Args:
@@ -488,7 +488,7 @@ def get_server_token(data_dir=None) -> str | None:
     return None
 
 
-def set_server_token(token: str, clear: bool = False, data_dir=None) -> None:
+def set_server_token(token: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the remote server bearer token.
 
     Args:
@@ -533,7 +533,7 @@ def get_admin_token(data_dir=None) -> str | None:
     return None
 
 
-def set_admin_token(token: str, clear: bool = False, data_dir=None) -> None:
+def set_admin_token(token: str, *, clear: bool = False, data_dir=None) -> None:
     """Persist the admin bearer token.
 
     Args:
@@ -676,7 +676,7 @@ def get_human_principal_ids(data_dir=None) -> list[str]:
     return []
 
 
-def set_human_principal_ids(ids, clear: bool = False, data_dir=None) -> None:
+def set_human_principal_ids(ids, *, clear: bool = False, data_dir=None) -> None:
     """Persist the human principal IDs list (or clear it).
 
     Args:
@@ -738,7 +738,7 @@ def get_collections_allowed_roots(data_dir=None) -> list[str]:
     return [r.strip() for r in roots if isinstance(r, str) and r.strip()]
 
 
-def set_collections_allowed_roots(roots, clear: bool = False, data_dir=None) -> None:
+def set_collections_allowed_roots(roots, *, clear: bool = False, data_dir=None) -> None:
     """Persist the collections allowed-roots list (or clear it).
 
     Args:

--- a/tests/test_config_registry_token.py
+++ b/tests/test_config_registry_token.py
@@ -42,3 +42,13 @@ def test_clear_returns_none(data_dir):
 def test_set_empty_string_raises(data_dir):
     with pytest.raises(ValueError):
         config.set_registry_token("", data_dir=data_dir)
+
+
+def test_positional_path_raises_typeerror(data_dir):
+    with pytest.raises(TypeError):
+        config.set_registry_token("tok", "/tmp/probe-datadir")
+
+
+def test_keyword_data_dir_still_writes_value(data_dir):
+    config.set_registry_token("tok", data_dir=data_dir)
+    assert config.get_registry_token(data_dir) == "tok"

--- a/tests/test_config_registry_url.py
+++ b/tests/test_config_registry_url.py
@@ -40,3 +40,13 @@ def test_clear_returns_none(data_dir):
 def test_set_empty_string_raises(data_dir):
     with pytest.raises(ValueError):
         config.set_registry_url("", data_dir=data_dir)
+
+
+def test_positional_path_raises_typeerror(data_dir):
+    with pytest.raises(TypeError):
+        config.set_registry_url("https://x", "/tmp/probe-datadir")
+
+
+def test_keyword_data_dir_still_writes_value(data_dir):
+    config.set_registry_url("https://x", data_dir=data_dir)
+    assert config.get_registry_url(data_dir) == "https://x"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taosmd config setters: a positional bool before a path silently clears the key you meant to set

Autonomous build of board card tsk-tnz4zs.

The clear bool parameter before data_dir allowed positional path binding,
causing silent data loss. Adding * makes clear keyword-only so
set_registry_url("https://x", "/tmp/probe-datadir") now raises
TypeError instead of clearing the key.

Changed: set_memory_model, set_generator_profile, set_default_recipe,
set_server_url, set_registry_url, set_registry_token, set_files_url,
set_server_token, set_admin_token, set_human_principal_ids,
set_collections_allowed_roots.

Left alone: set_managed_by (no bool before path), set_serve_dashboard
and set_a2a_auth_enforce (bool is the persisted value, not a clear flag).

Files:
 changelog.d/tsk-tnz4zs-keyword-only-clear.md |  2 ++
 taosmd/config.py                             | 22 +++++++++++-----------
 tests/test_config_registry_token.py          | 10 ++++++++++
 tests/test_config_registry_url.py            | 10 ++++++++++
 4 files changed, 33 insertions(+), 11 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration setters now require the `clear` option to be specified by keyword, preventing accidental data-directory values from triggering unintended clearing.
  - Existing configuration persistence and retrieval behavior remains supported when `data_dir` is passed by keyword.

- **Tests**
  - Added coverage confirming invalid positional arguments are rejected and valid keyword-based configuration updates continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->