### PR TITLE
deleted-symbols-gate does not catch a name removed from __all__ while its def survives

### DIFF
--- a/changelog.d/tsk-b5gfwg-export-gate.md
+++ b/changelog.d/tsk-b5gfwg-export-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- The `deleted-symbols-gate` CI check now also catches names silently dropped from a module `__all__` while their top-level `def`/`class` still exists, the shape a mechanical merge resolution produces when one side of a conflicted `__all__` block is taken wholesale.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -7,18 +7,32 @@ PR branch cut before hardening commits landed on dev would silently delete
 them when merged -- git reports "Automatic merge went well" with no conflict
 because the PR branch simply wins on files dev touched after the branch point.
 
+Two shapes of silent loss are detected:
+
+  1. A def/class present on the target branch but gone at HEAD (definition
+     removal).
+  2. A name removed from a module __all__ while its top-level def/class still
+     exists at HEAD (export removal). This is the shape a mechanical merge
+     resolution produces: one side of a conflicted __all__ block is taken
+     wholesale, dropping entries without touching the definitions.
+
 Algorithm:
   1. Extract all Python def/class symbols at two points: the target branch
      head and HEAD (the merge ref / PR head).
   2. A symbol is "deleted by the PR" if it exists at the target head but not
      at HEAD. The signal is that set.
-  3. Fail with an explicit list of the deleted symbols and the commits that
+  3. Also compare __all__ membership: an entry present at the target head but
+     absent at HEAD is a signal only when the corresponding top-level
+     def/class still exists at HEAD. A genuine deletion removes both the
+     definition and the __all__ entry, so it stays allowed.
+  4. Fail with an explicit list of the deleted symbols and the commits that
      added them.
-  4. A "Removes-Intentionally: <symbol>, ..." trailer in the PR body waives
+  5. A "Removes-Intentionally: <symbol>, ..." trailer in the PR body waives
      named symbols, making deliberate deletions a conscious, auditable act.
 
 Narrow by design: Python def/class names only (test functions are defs).
-No semantic analysis -- name-level matching catches every instance hit so far.
+Exports are compared via AST so continuation lines and indentation never
+matter.
 
 Usage:
     python scripts/check_deleted_symbols.py --base origin/master
@@ -45,6 +59,7 @@ TRAILER = "Removes-Intentionally:"
 class Violation:
     symbol: str
     added_by: str
+    kind: str = "deleted"
 
 
 def _run_git(args: list[str], cwd: str | Path | None = None) -> str:
@@ -84,6 +99,42 @@ def _extract_symbols(source: str, file_path: str) -> dict[str, str]:
     return symbols
 
 
+def _collect_all_names(value: ast.AST, file_path: str, exports: dict[str, str]) -> None:
+    """Collect string-literal names from an __all__ value expression."""
+    if isinstance(value, (ast.List, ast.Tuple)):
+        for elt in value.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                exports[f"{file_path}:{elt.value}"] = "export"
+
+
+def _extract_all_exports(source: str, file_path: str) -> dict[str, str]:
+    """Extract __all__ export names from Python source.
+
+    Returns a dict mapping "file_path:name" to "export". Uses AST (not
+    regex) so continuation lines and indentation never matter. Handles list
+    and tuple literals, including __all__ += [...] augmented assignment.
+    """
+    exports: dict[str, str] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return exports
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    _collect_all_names(node.value, file_path, exports)
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            _collect_all_names(node.value, file_path, exports)
+
+    return exports
+
+
 def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]:
     """Get all Python symbols at a given git ref using git archive."""
     result = subprocess.run(
@@ -101,6 +152,25 @@ def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]
             source = f.read().decode("utf-8", errors="ignore")
             symbols.update(_extract_symbols(source, member.name))
     return symbols
+
+
+def _get_all_exports_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    """Get all __all__ exports at a given git ref using git archive."""
+    result = subprocess.run(
+        ["git", "archive", ref],
+        cwd=repo_root, capture_output=True, check=True,
+    )
+    exports: dict[str, str] = {}
+    with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+        for member in tar.getmembers():
+            if not member.name.startswith("taosmd/") or not member.name.endswith(".py"):
+                continue
+            f = tar.extractfile(member)
+            if f is None:
+                continue
+            source = f.read().decode("utf-8", errors="ignore")
+            exports.update(_extract_all_exports(source, member.name))
+    return exports
 
 
 def _find_adding_commit(
@@ -160,6 +230,22 @@ def find_signal_symbols(
     return {k: base_symbols[k] for k in signal_keys}
 
 
+def find_removed_all_entries(
+    base_exports: dict[str, str],
+    head_exports: dict[str, str],
+    head_symbols: dict[str, str],
+) -> dict[str, str]:
+    """Find __all__ entries removed at HEAD while their def/class still exists.
+
+    An entry in base __all__ that is absent from head __all__ is a signal only
+    when the corresponding top-level def/class still exists at HEAD. A genuine
+    deletion removes both the definition and the __all__ entry, so it does not
+    appear here -- it is caught by find_signal_symbols instead.
+    """
+    removed = set(base_exports) - set(head_exports)
+    return {k: head_symbols[k] for k in removed if k in head_symbols}
+
+
 def check_deleted_symbols(
     base_ref: str,
     repo_root: Path = REPO_ROOT,
@@ -177,6 +263,10 @@ def check_deleted_symbols(
 
     signal = find_signal_symbols(base_symbols, head_symbols)
 
+    base_exports = _get_all_exports_at_ref(base_ref, repo_root)
+    head_exports = _get_all_exports_at_ref("HEAD", repo_root)
+    export_signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+
     waived_set: set[str] = set()
     if waived:
         waived_set.update(waived)
@@ -190,7 +280,15 @@ def check_deleted_symbols(
             continue
         file_path, name = symbol.rsplit(":", 1)
         added_by = _find_adding_commit(file_path, name, kind, base_ref, repo_root)
-        violations.append(Violation(symbol=symbol, added_by=added_by))
+        violations.append(Violation(symbol=symbol, added_by=added_by, kind="deleted"))
+
+    for symbol, kind in sorted(export_signal.items()):
+        if symbol in waived_set:
+            waived_in_signal.add(symbol)
+            continue
+        file_path, name = symbol.rsplit(":", 1)
+        added_by = _find_adding_commit(file_path, name, kind, base_ref, repo_root)
+        violations.append(Violation(symbol=symbol, added_by=added_by, kind="export-removed"))
 
     return violations, waived_in_signal
 
@@ -220,12 +318,24 @@ def main(argv: list[str] | None = None) -> int:
             print(f"deleted-symbols-guard: waived via Removes-Intentionally: {sym}")
 
     if violations:
-        print(
-            f"DELETED-SYMBOLS FAIL: this PR deletes {len(violations)} symbol(s) that "
-            f"exist on the base branch but are missing from the merge result:"
-        )
-        for v in violations:
-            print(f"  - {v.symbol} (added by {v.added_by})")
+        deleted = [v for v in violations if v.kind == "deleted"]
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+
+        if deleted:
+            print(
+                f"DELETED-SYMBOLS FAIL: this PR deletes {len(deleted)} symbol(s) that "
+                f"exist on the base branch but are missing from the merge result:"
+            )
+            for v in deleted:
+                print(f"  - {v.symbol} (added by {v.added_by})")
+
+        if export_removed:
+            print(
+                f"DELETED-SYMBOLS FAIL: this PR removes {len(export_removed)} symbol(s) "
+                f"from __all__ while the definition still exists at HEAD:"
+            )
+            for v in export_removed:
+                print(f"  - {v.symbol} (added by {v.added_by})")
 
         print()
         print(

--- a/tests/test_deleted_symbols.py
+++ b/tests/test_deleted_symbols.py
@@ -17,11 +17,13 @@ import scripts.check_deleted_symbols as cds
 from scripts.check_deleted_symbols import (
     TRAILER,
     Violation,
+    _extract_all_exports,
     _extract_symbols,
     _find_adding_commit,
     _get_symbols_at_ref,
     _run_git,
     check_deleted_symbols,
+    find_removed_all_entries,
     find_signal_symbols,
     main,
     parse_waived_symbols,
@@ -62,6 +64,53 @@ class TestExtractSymbols:
         assert syms == {}
 
 
+class TestExtractAllExports:
+    def test_single_line_all(self):
+        src = 'def foo():\n    pass\n\ndef bar():\n    pass\n\n__all__ = ["foo", "bar"]\n'
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert "pkg/mod.py:foo" in exports
+        assert "pkg/mod.py:bar" in exports
+        assert len(exports) == 2
+
+    def test_multi_line_all(self):
+        src = (
+            'def foo():\n    pass\n\n'
+            'def bar():\n    pass\n\n'
+            '__all__ = ["foo",\n    "bar"]\n'
+        )
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert "pkg/mod.py:foo" in exports
+        assert "pkg/mod.py:bar" in exports
+
+    def test_tuple_all(self):
+        src = '__all__ = ("foo", "bar")\n'
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert "pkg/mod.py:foo" in exports
+        assert "pkg/mod.py:bar" in exports
+
+    def test_continuation_at_column_zero(self):
+        src = '__all__ = ["foo", "bar",\n"baz"]\n'
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert "pkg/mod.py:foo" in exports
+        assert "pkg/mod.py:bar" in exports
+        assert "pkg/mod.py:baz" in exports
+
+    def test_no_all(self):
+        src = "def foo():\n    pass\n"
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert exports == {}
+
+    def test_syntax_error_returns_empty(self):
+        exports = _extract_all_exports("def foo(\n", "pkg/mod.py")
+        assert exports == {}
+
+    def test_augmented_all(self):
+        src = '__all__ = ["foo"]\n__all__ += ["bar"]\n'
+        exports = _extract_all_exports(src, "pkg/mod.py")
+        assert "pkg/mod.py:foo" in exports
+        assert "pkg/mod.py:bar" in exports
+
+
 class TestFindSignalSymbols:
     def test_deleted_symbol_detected(self):
         base = {"taosmd/foo.py:bar": "def"}
@@ -79,6 +128,43 @@ class TestFindSignalSymbols:
         base = {"taosmd/foo.py:bar": "def"}
         head = {"taosmd/foo.py:bar": "def"}
         signal = find_signal_symbols(base, head)
+        assert signal == {}
+
+
+class TestFindRemovedAllEntries:
+    def test_removed_all_but_def_survives(self):
+        base_exports = {"pkg/mod.py:foo": "export", "pkg/mod.py:bar": "export"}
+        head_exports = {"pkg/mod.py:foo": "export"}
+        head_symbols = {"pkg/mod.py:foo": "def", "pkg/mod.py:bar": "def"}
+        signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+        assert signal == {"pkg/mod.py:bar": "def"}
+
+    def test_removed_all_and_def_removed_is_not_signal(self):
+        base_exports = {"pkg/mod.py:foo": "export", "pkg/mod.py:bar": "export"}
+        head_exports = {"pkg/mod.py:foo": "export"}
+        head_symbols = {"pkg/mod.py:foo": "def"}
+        signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+        assert signal == {}
+
+    def test_no_removal(self):
+        base_exports = {"pkg/mod.py:foo": "export"}
+        head_exports = {"pkg/mod.py:foo": "export"}
+        head_symbols = {"pkg/mod.py:foo": "def"}
+        signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+        assert signal == {}
+
+    def test_added_to_all_is_not_signal(self):
+        base_exports = {"pkg/mod.py:foo": "export"}
+        head_exports = {"pkg/mod.py:foo": "export", "pkg/mod.py:bar": "export"}
+        head_symbols = {"pkg/mod.py:foo": "def", "pkg/mod.py:bar": "def"}
+        signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+        assert signal == {}
+
+    def test_removed_export_no_def_is_not_signal(self):
+        base_exports = {"pkg/mod.py:bar": "export"}
+        head_exports = {}
+        head_symbols = {}
+        signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
         assert signal == {}
 
 
@@ -314,3 +400,181 @@ class TestDeletedSymbolsIntegration:
         waived = "Removes-Intentionally: taosmd/service.py:s0, taosmd/service.py:s1, taosmd/service.py:s2"
         rc = main(["--base", "HEAD~1", "--pr-body", waived])
         assert rc == 1
+
+
+# ----------------------------------------------------------------------
+# __all__ export-removal: a name dropped from __all__ while its def survives
+# ----------------------------------------------------------------------
+
+def _init_repo_all_removed(tmp_path):
+    """A name is removed from __all__ while its def survives at HEAD."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    base_file = tmp_path / "taosmd" / "service.py"
+    base_file.parent.mkdir(parents=True, exist_ok=True)
+    base_file.write_text(
+        'def func_a():\n    pass\n\n'
+        'def func_b():\n    pass\n\n'
+        '__all__ = ["func_a", "func_b"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    head_file = tmp_path / "taosmd" / "service.py"
+    head_file.write_text(
+        'def func_a():\n    pass\n\n'
+        'def func_b():\n    pass\n\n'
+        '__all__ = ["func_a"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+def _init_repo_legitimate_deletion(tmp_path):
+    """A name is removed from both __all__ and the file (legitimate deletion)."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    base_file = tmp_path / "taosmd" / "service.py"
+    base_file.parent.mkdir(parents=True, exist_ok=True)
+    base_file.write_text(
+        'def func_a():\n    pass\n\n'
+        'def func_b():\n    pass\n\n'
+        '__all__ = ["func_a", "func_b"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    head_file = tmp_path / "taosmd" / "service.py"
+    head_file.write_text(
+        'def func_a():\n    pass\n\n'
+        '__all__ = ["func_a"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+def _init_repo_noop(tmp_path):
+    """A PR that touches neither symbols nor __all__."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    base_file = tmp_path / "taosmd" / "service.py"
+    base_file.parent.mkdir(parents=True, exist_ok=True)
+    base_file.write_text(
+        'def func_a():\n    pass\n\n'
+        '__all__ = ["func_a"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    head_file = tmp_path / "taosmd" / "service.py"
+    head_file.write_text(
+        '# harmless comment\n'
+        'def func_a():\n    pass\n\n'
+        '__all__ = ["func_a"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+class TestAllRemovalIntegration:
+    def test_all_removal_fails_when_def_survives(self, tmp_path, monkeypatch):
+        repo = _init_repo_all_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        assert len(violations) == 1
+        assert violations[0].symbol == "taosmd/service.py:func_b"
+        assert violations[0].kind == "export-removed"
+        assert waived == set()
+
+    def test_all_removal_exits_nonzero(self, tmp_path, monkeypatch):
+        repo = _init_repo_all_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 1
+
+    def test_all_removal_passes_with_waiver(self, tmp_path, monkeypatch):
+        repo = _init_repo_all_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main([
+            "--base", "HEAD~1",
+            "--pr-body", "Removes-Intentionally: taosmd/service.py:func_b",
+        ])
+        assert rc == 0
+
+    def test_all_removal_prints_violation_details(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo_all_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "DELETED-SYMBOLS FAIL" in captured.out
+        assert "from __all__" in captured.out
+        assert "taosmd/service.py:func_b" in captured.out
+
+
+class TestAllRemovalControl:
+    def test_legitimate_deletion_has_no_export_violation(self, tmp_path, monkeypatch):
+        """A name removed from both __all__ and the file is a legitimate deletion.
+        The existing def-deletion check catches it; the __all__ check must not."""
+        repo = _init_repo_legitimate_deletion(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        deleted = [v for v in violations if v.kind == "deleted"]
+        assert len(deleted) == 1
+        assert deleted[0].symbol == "taosmd/service.py:func_b"
+        assert waived == set()
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        assert export_removed == []
+
+    def test_legitimate_deletion_passes_with_def_waiver(self, tmp_path, monkeypatch):
+        """With the def-deletion waived, the full gate is clean."""
+        repo = _init_repo_legitimate_deletion(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main([
+            "--base", "HEAD~1",
+            "--pr-body", "Removes-Intentionally: taosmd/service.py:func_b",
+        ])
+        assert rc == 0
+
+    def test_noop_change_is_clean(self, tmp_path, monkeypatch):
+        """A PR that touches neither symbols nor __all__ stays green."""
+        repo = _init_repo_noop(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 0


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deleted-symbols-gate does not catch a name removed from __all__ while its def survives

Autonomous build of board card tsk-b5gfwg.

The deleted-symbols-gate compared def/class definitions between base and
HEAD, but missed names silently dropped from __all__ while their definitions
remained -- the shape a mechanical merge produces when one side of a
conflicted __all__ block is taken wholesale.

Extend the gate to compare __all__ membership via AST walk, not regex, so
continuation lines and column-0 indentation never matter. An entry in base
__all__ absent from head __all__ is a violation only when the corresponding
top-level def/class still exists at HEAD. A genuine deletion removes both
the definition and the __all__ entry, and stays allowed: it is caught by
the existing definition-removal check.

Violation objects gain a kind field ("deleted" or "export-removed") so
the output distinguishes the two shapes. The Removes-Intentionally trailer
waiver covers both kinds uniformly.

Files:
 changelog.d/tsk-b5gfwg-export-gate.md |   2 +
 scripts/check_deleted_symbols.py      | 130 +++++++++++++++--
 tests/test_deleted_symbols.py         | 264 ++++++++++++++++++++++++++++++++++
 3 files changed, 386 insertions(+), 10 deletions(-)