### PR TITLE
Revise PR #305: the normalise_handle gate fires on @typing.overload and crashes on non-UTF-8 (its docstring says otherwise)

### DIFF
--- a/.github/workflows/normalise-handle-gate.yml
+++ b/.github/workflows/normalise-handle-gate.yml
@@ -1,0 +1,27 @@
+name: Normalise handle gate
+
+# Fails if any module under ``taosmd/`` contains more than one definition
+# of the internal helper ``_normalise_handle``.  Overload stubs decorated
+# with ``@typing.overload`` or ``@overload`` are excluded.  Files that
+# cannot be decoded as UTF-8 are skipped with a warning.
+#
+# See scripts/normalise_handle_gate.py for the implementation.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  normalise-handle-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Install deps
+        run: uv sync --python 3.12
+      - name: Check for duplicate _normalise_handle definitions
+        run: python scripts/normalise_handle_gate.py

--- a/changelog.d/tsk-vcda2i-normalise-handle-gate.md
+++ b/changelog.d/tsk-vcda2i-normalise-handle-gate.md
@@ -1,0 +1,3 @@
+### Fixed
+- Skip ``@typing.overload`` and ``@overload`` stubs when counting ``_normalise_handle`` definitions, so the gate no longer fails on legitimate typed overload pairs.
+- Catch ``UnicodeDecodeError`` in addition to ``OSError`` when reading files, so the gate no longer crashes on non-UTF-8 input its docstring already claimed it would survive.

--- a/scripts/normalise_handle_gate.py
+++ b/scripts/normalise_handle_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Normalise handle gate.
+
+Scans ``taosmd/`` for duplicate definitions of the internal helper
+``_normalise_handle`` and fails if any module contains more than one.
+``@typing.overload`` stubs are excluded: they are not rival copies.
+
+Files that cannot be decoded as UTF-8 are skipped with a warning rather
+than allowed to crash the gate.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _has_overload_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in node.decorator_list:
+        if isinstance(decorator, ast.Name):
+            if decorator.id == "overload":
+                return True
+        elif isinstance(decorator, ast.Attribute):
+            if decorator.attr == "overload":
+                return True
+        elif isinstance(decorator, ast.Call):
+            func = decorator.func
+            if isinstance(func, ast.Name) and func.id == "overload":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "overload":
+                return True
+    return False
+
+
+def _count_definitions(file_path: Path) -> int:
+    try:
+        source = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        print(
+            f"normalise-handle-gate: skipping {file_path}: unreadable",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return 0
+
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == "_normalise_handle" and not _has_overload_decorator(node):
+                count += 1
+    return count
+
+
+def main(argv: list[str] | None = None) -> int:
+    failures: list[tuple[str, int]] = []
+    for file_path in sorted(REPO_ROOT.glob("taosmd/**/*.py")):
+        count = _count_definitions(file_path)
+        if count > 1:
+            rel = file_path.relative_to(REPO_ROOT)
+            failures.append((str(rel), count))
+
+    if failures:
+        print("NORMALISE_HANDLE GATE FAIL:")
+        for path, count in failures:
+            print(
+                f"  {path}: found {count} definitions; at most 1 is allowed"
+            )
+        return 1
+
+    print("normalise-handle-gate: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_normalise_handle_gate.py
+++ b/tests/test_normalise_handle_gate.py
@@ -1,0 +1,172 @@
+"""Tests for scripts/normalise_handle_gate.py.
+
+Proves both directions:
+- A single _normalise_handle definition lets the gate pass.
+- Two rival definitions cause the gate to fail with an explicit count.
+- @typing.overload stubs are excluded from the count.
+- try/except ImportError fallback must leave the gate silent.
+- Files that cannot be decoded as UTF-8 are skipped with a warning.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import scripts.normalise_handle_gate as nhg
+from scripts.normalise_handle_gate import (
+    _count_definitions,
+    _has_overload_decorator,
+    main,
+)
+
+
+# ----------------------------------------------------------------------
+# unit tests for pure helpers
+# ----------------------------------------------------------------------
+
+class TestHasOverloadDecorator:
+    def test_name_overload(self):
+        src = "@overload\ndef _normalise_handle(handle: str) -> str: ...\n"
+        tree = __import__('ast').parse(src)
+        funcs = [n for n in __import__('ast').walk(tree) if isinstance(n, __import__('ast').FunctionDef)]
+        assert _has_overload_decorator(funcs[0]) is True
+
+    def test_typing_overload(self):
+        src = "import typing\n@typing.overload\ndef _normalise_handle(handle: str) -> str: ...\n"
+        tree = __import__('ast').parse(src)
+        funcs = [n for n in __import__('ast').walk(tree) if isinstance(n, __import__('ast').FunctionDef)]
+        assert _has_overload_decorator(funcs[0]) is True
+
+    def test_no_overload(self):
+        src = "def _normalise_handle(handle: str) -> str:\n    return handle\n"
+        tree = __import__('ast').parse(src)
+        funcs = [n for n in __import__('ast').walk(tree) if isinstance(n, __import__('ast').FunctionDef)]
+        assert _has_overload_decorator(funcs[0]) is False
+
+
+class TestCountDefinitions:
+    def test_single_def_returns_one(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("def _normalise_handle(handle):\n    pass\n")
+        assert _count_definitions(f) == 1
+
+    def test_no_def_returns_zero(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("def other():\n    pass\n")
+        assert _count_definitions(f) == 0
+
+    def test_two_defs_return_two(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def _normalise_handle(a):\n    pass\n"
+            "def _normalise_handle(b):\n    pass\n"
+        )
+        assert _count_definitions(f) == 2
+
+    def test_overload_stubs_ignored(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "import typing\n\n"
+            "@typing.overload\n"
+            "def _normalise_handle(handle: str) -> str: ...\n"
+            "\n"
+            "def _normalise_handle(handle):\n    pass\n"
+        )
+        assert _count_definitions(f) == 1
+
+    def test_name_overload_ignored(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "from typing import overload\n\n"
+            "@overload\n"
+            "def _normalise_handle(handle: str) -> str: ...\n"
+            "\n"
+            "def _normalise_handle(handle):\n    pass\n"
+        )
+        assert _count_definitions(f) == 1
+
+    def test_try_except_import_error_fallback_is_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    from typing import overload\n"
+            "except ImportError:\n"
+            "    pass\n"
+            "\n"
+            "def _normalise_handle(handle):\n    pass\n"
+        )
+        assert _count_definitions(f) == 1
+
+    def test_non_utf8_file_skipped(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_bytes(b"def _normalise_handle():\n    pass\n\xff\xfe\n")
+        assert _count_definitions(f) == 0
+
+    def test_unreadable_file_skipped(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("def _normalise_handle():\n    pass\n")
+        f.chmod(0o000)
+        try:
+            assert _count_definitions(f) == 0
+        finally:
+            f.chmod(0o644)
+
+
+# ----------------------------------------------------------------------
+# integration tests with a temporary repo
+# ----------------------------------------------------------------------
+
+def _init_repo(tmp_path, single_def=True):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    taosmd_dir = repo / "taosmd"
+    taosmd_dir.mkdir()
+    (taosmd_dir / "__init__.py").write_text("")
+
+    mod = taosmd_dir / "service.py"
+    if single_def:
+        mod.write_text("def _normalise_handle(handle):\n    pass\n")
+    else:
+        mod.write_text(
+            "def _normalise_handle(a):\n    pass\n"
+            "def _normalise_handle(b):\n    pass\n"
+        )
+    return repo
+
+
+class TestNormaliseHandleGateIntegration:
+    def test_single_def_passes(self, tmp_path, monkeypatch):
+        repo = _init_repo(tmp_path, single_def=True)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(nhg, "REPO_ROOT", repo)
+        rc = main([])
+        assert rc == 0
+
+    def test_two_defs_fail_with_count(self, tmp_path, monkeypatch):
+        repo = _init_repo(tmp_path, single_def=False)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(nhg, "REPO_ROOT", repo)
+        rc = main([])
+        assert rc == 1
+
+    def test_main_prints_duplicate_count(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path, single_def=False)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(nhg, "REPO_ROOT", repo)
+        rc = main([])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "NORMALISE_HANDLE GATE FAIL" in captured.out
+        assert "found 2 definitions" in captured.out
+
+    def test_main_prints_clean_when_single(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path, single_def=True)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(nhg, "REPO_ROOT", repo)
+        rc = main([])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "normalise-handle-gate: clean" in captured.out


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #305: the normalise_handle gate fires on @typing.overload and crashes on non-UTF-8 (its docstring says otherwise)

Autonomous build of board card tsk-vcda2i.



Files:
 .github/workflows/normalise-handle-gate.yml     |  27 ++++
 changelog.d/tsk-vcda2i-normalise-handle-gate.md |   3 +
 scripts/normalise_handle_gate.py                |  81 +++++++++++
 tests/test_normalise_handle_gate.py             | 172 ++++++++++++++++++++++++
 4 files changed, 283 insertions(+)