### PR TITLE
verify-merged-assertions.md and the blocks_without_body docstring quote the HTTP handler's error string as the service layer's

### DIFF
--- a/changelog.d/tsk-cwzaab-fix-quoted-error-strings.md
+++ b/changelog.d/tsk-cwzaab-fix-quoted-error-strings.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Corrected quoted error strings in `docs/verify-merged-assertions.md` and
+  `tests/test_a2a.py` for the `test_http_a2a_blocks_without_body_returns_400`
+  test. The service-layer `ValueError` message is `body must be a
+  non-empty string` (from `taosmd/service.py:436`), not the HTTP handler's
+  `'body' (non-empty string) is required` (from `taosmd/http_server.py:1546`).

--- a/docs/verify-merged-assertions.md
+++ b/docs/verify-merged-assertions.md
@@ -141,7 +141,8 @@ its load-bearing surface is narrower than the other seven.
 Its docstring now states: the `assert status == 400` half is **duplicated** at
 the service layer -- `service.a2a_send` raises `ValueError` for an empty body
 independently. Disabling R8 still returns 400 (from the service-layer ValueError);
-the only thing that changes is the error text. The test asserts
+the only thing that changes is the error message: `body must be a non-empty string`.
+The test asserts
 `"blocks" in body["error"]`, which is the **message** assertion -- the only
 check that is unique to the HTTP-level invariant. The status-code assertion
 cannot fail without the service layer also failing, so a future "tidying" change

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -851,7 +851,7 @@ def test_http_a2a_blocks_without_body_returns_400(live_server):
     status code assertion red -- the service layer still returns 400. What
     does turn red is the **message** assertion: the HTTP-level check produces
     an error mentioning ``blocks``, whereas the service-layer ``ValueError``
-    yields the generic text ``'body' (non-empty string) is required``.
+    yields the generic text ``body must be a non-empty string``.
 
     In other words, ``assert "blocks" in body["error"]`` is the load-bearing
     assertion. A future "tidying" change to ``assert status == 400`` would


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): verify-merged-assertions.md and the blocks_without_body docstring quote the HTTP handler's error string as the service layer's

Autonomous build of board card tsk-cwzaab.



Files:
 changelog.d/tsk-cwzaab-fix-quoted-error-strings.md | 7 +++++++
 docs/verify-merged-assertions.md                   | 3 ++-
 tests/test_a2a.py                                  | 2 +-
 3 files changed, 10 insertions(+), 2 deletions(-)