### PR TITLE
deleted-symbols-gate is blind to a re-export dropped from a package __init__.py

### DIFF
--- a/changelog.d/tsk-cssuku-reexport-gate.md
+++ b/changelog.d/tsk-cssuku-reexport-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- The `deleted-symbols-gate` CI check now also catches re-exported names silently dropped from a package `__all__` (e.g. an entry in `taosmd/__init__.py` that is backed by `from .x import Name`) when the underlying `def`/`class` still exists at HEAD. Previously only same-file definitions were guarded, leaving the package's top-level public API invisible to the gate.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -14,17 +14,22 @@ Two shapes of silent loss are detected:
   2. A name removed from a module __all__ while its top-level def/class still
      exists at HEAD (export removal). This is the shape a mechanical merge
      resolution produces: one side of a conflicted __all__ block is taken
-     wholesale, dropping entries without touching the definitions.
+     wholesale, dropping entries without touching the definitions. Re-exports
+     are included: when the removed entry is a re-exported name (imported, not
+     defined, in the file holding __all__), the gate resolves it through the
+     file's from-import statements and checks whether the target def/class
+     survives anywhere at HEAD.
 
 Algorithm:
   1. Extract all Python def/class symbols at two points: the target branch
      head and HEAD (the merge ref / PR head).
   2. A symbol is "deleted by the PR" if it exists at the target head but not
      at HEAD. The signal is that set.
-  3. Also compare __all__ membership: an entry present at the target head but
-     absent at HEAD is a signal only when the corresponding top-level
-     def/class still exists at HEAD. A genuine deletion removes both the
-     definition and the __all__ entry, so it stays allowed.
+  3. Compare __all__ membership: an entry present at the target head but absent
+     at HEAD is a signal only when the corresponding top-level def/class still
+     exists at HEAD (or, for re-exports, the definition it names survives at
+     HEAD). A genuine deletion removes both the definition and the __all__
+     entry, so it stays allowed.
   4. Fail with an explicit list of the deleted symbols and the commits that
      added them.
   5. A "Removes-Intentionally: <symbol>, ..." trailer in the PR body waives
@@ -32,7 +37,7 @@ Algorithm:
 
 Narrow by design: Python def/class names only (test functions are defs).
 Exports are compared via AST so continuation lines and indentation never
-matter.
+matter. Import resolution for re-exports also uses AST.
 
 Usage:
     python scripts/check_deleted_symbols.py --base origin/master
@@ -173,6 +178,85 @@ def _get_all_exports_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, 
     return exports
 
 
+def _resolve_import_parts(node: ast.ImportFrom, pkg_dir: str) -> list[str] | None:
+    """Resolve an ImportFrom node to dotted package parts.
+
+    Handles relative imports (``from .x import Y``, ``from ..x.y import Z``)
+    using *pkg_dir* (the directory of the importing file) and the import
+    ``level``.  Absolute imports (``from taosmd.x import Y``) are returned as-is.
+    ``from . import X`` (``module`` is None) returns None: the local name
+    refers to a module, not a def/class, so it cannot back an __all__ entry.
+    """
+    if node.module is None:
+        return None
+    if node.level == 0:
+        return node.module.split(".")
+    pkg_parts = pkg_dir.split("/") if pkg_dir else []
+    up = node.level - 1
+    if up > 0:
+        pkg_parts = pkg_parts[: max(0, len(pkg_parts) - up)]
+    return pkg_parts + node.module.split(".")
+
+
+def _extract_imports(source: str, file_path: str) -> dict[str, list[str]]:
+    """Extract from-import bindings that could back __all__ re-exports.
+
+    Returns a dict mapping each local name bound by a
+    ``from .x import Name`` or ``from .x import Name as Alias``
+    to candidate definition keys of the form ``"<file>:<name>"``.
+    Both ``<x>.py`` and ``<x>/__init__.py`` file forms are produced so the
+    caller can match against the symbol table regardless of whether the
+    target is a module file or a package.
+    """
+    imports: dict[str, list[str]] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return imports
+
+    pkg_dir = os.path.dirname(file_path)
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        parts = _resolve_import_parts(node, pkg_dir)
+        if parts is None:
+            continue
+        module_path = "/".join(parts)
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            original = alias.name
+            local = alias.asname if alias.asname else alias.name
+            imports.setdefault(local, []).extend([
+                f"{module_path}.py:{original}",
+                f"{module_path}/__init__.py:{original}",
+            ])
+    return imports
+
+
+def _get_imports_at_ref(
+    ref: str, repo_root: Path = REPO_ROOT
+) -> dict[str, dict[str, list[str]]]:
+    """Get import bindings for all Python files at a given git ref."""
+    result = subprocess.run(
+        ["git", "archive", ref],
+        cwd=repo_root, capture_output=True, check=True,
+    )
+    imports: dict[str, dict[str, list[str]]] = {}
+    with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+        for member in tar.getmembers():
+            if not member.name.startswith("taosmd/") or not member.name.endswith(".py"):
+                continue
+            f = tar.extractfile(member)
+            if f is None:
+                continue
+            source = f.read().decode("utf-8", errors="ignore")
+            file_imports = _extract_imports(source, member.name)
+            if file_imports:
+                imports[member.name] = file_imports
+    return imports
+
+
 def _find_adding_commit(
     file_path: str,
     name: str,
@@ -234,6 +318,7 @@ def find_removed_all_entries(
     base_exports: dict[str, str],
     head_exports: dict[str, str],
     head_symbols: dict[str, str],
+    base_imports: dict[str, dict[str, list[str]]] | None = None,
 ) -> dict[str, str]:
     """Find __all__ entries removed at HEAD while their def/class still exists.
 
@@ -241,9 +326,44 @@ def find_removed_all_entries(
     when the corresponding top-level def/class still exists at HEAD. A genuine
     deletion removes both the definition and the __all__ entry, so it does not
     appear here -- it is caught by find_signal_symbols instead.
+
+    Re-exports are resolved through the base file's import statements: when the
+    entry has no same-file definition, the gate follows the from-import that
+    supplied the name and checks whether the target def/class survives at HEAD.
     """
     removed = set(base_exports) - set(head_exports)
-    return {k: head_symbols[k] for k in removed if k in head_symbols}
+    base_imports = base_imports or {}
+    result: dict[str, str] = {}
+    for k in removed:
+        if k in head_symbols:
+            result[k] = head_symbols[k]
+            continue
+        file_path, name = k.rsplit(":", 1)
+        for candidate in base_imports.get(file_path, {}).get(name, []):
+            if candidate in head_symbols:
+                result[k] = head_symbols[candidate]
+                break
+    return result
+
+
+def _resolve_export_key(
+    symbol: str,
+    base_imports: dict[str, dict[str, list[str]]],
+    head_symbols: dict[str, str],
+) -> str:
+    """Resolve an __all__ entry key to the definition key it is backed by.
+
+    For same-file def/class entries this is a no-op. For re-exports the entry
+    is resolved through the base file's import statements. Falls back to the
+    original symbol when no backing definition is found.
+    """
+    if symbol in head_symbols:
+        return symbol
+    file_path, name = symbol.rsplit(":", 1)
+    for candidate in base_imports.get(file_path, {}).get(name, []):
+        if candidate in head_symbols:
+            return candidate
+    return symbol
 
 
 def check_deleted_symbols(
@@ -265,7 +385,10 @@ def check_deleted_symbols(
 
     base_exports = _get_all_exports_at_ref(base_ref, repo_root)
     head_exports = _get_all_exports_at_ref("HEAD", repo_root)
-    export_signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
+    base_imports = _get_imports_at_ref(base_ref, repo_root)
+    export_signal = find_removed_all_entries(
+        base_exports, head_exports, head_symbols, base_imports
+    )
 
     waived_set: set[str] = set()
     if waived:
@@ -286,7 +409,8 @@ def check_deleted_symbols(
         if symbol in waived_set:
             waived_in_signal.add(symbol)
             continue
-        file_path, name = symbol.rsplit(":", 1)
+        resolved = _resolve_export_key(symbol, base_imports, head_symbols)
+        file_path, name = resolved.rsplit(":", 1)
         added_by = _find_adding_commit(file_path, name, kind, base_ref, repo_root)
         violations.append(Violation(symbol=symbol, added_by=added_by, kind="export-removed"))
 

--- a/tests/test_deleted_symbols.py
+++ b/tests/test_deleted_symbols.py
@@ -18,9 +18,12 @@ from scripts.check_deleted_symbols import (
     TRAILER,
     Violation,
     _extract_all_exports,
+    _extract_imports,
     _extract_symbols,
     _find_adding_commit,
+    _get_imports_at_ref,
     _get_symbols_at_ref,
+    _resolve_export_key,
     _run_git,
     check_deleted_symbols,
     find_removed_all_entries,
@@ -111,6 +114,60 @@ class TestExtractAllExports:
         assert "pkg/mod.py:bar" in exports
 
 
+class TestExtractImports:
+    def test_relative_import(self):
+        src = 'from .sub import Thing\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert "Thing" in imp
+        assert "pkg/sub.py:Thing" in imp["Thing"]
+
+    def test_relative_import_with_alias(self):
+        src = 'from .sub import RealName as Alias\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert "Alias" in imp
+        assert "pkg/sub.py:RealName" in imp["Alias"]
+
+    def test_multiple_names(self):
+        src = 'from .sub import A, B\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert "pkg/sub.py:A" in imp["A"]
+        assert "pkg/sub.py:B" in imp["B"]
+
+    def test_package_form_candidate(self):
+        src = 'from .sub import Thing\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert "pkg/sub/__init__.py:Thing" in imp["Thing"]
+
+    def test_from_import_module_skipped(self):
+        src = 'from . import submodule\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert imp == {}
+
+    def test_absolute_import(self):
+        src = 'from pkg.sub import Thing\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert "pkg/sub.py:Thing" in imp["Thing"]
+
+    def test_star_import_skipped(self):
+        src = 'from .sub import *\n'
+        imp = _extract_imports(src, "pkg/__init__.py")
+        assert imp == {}
+
+    def test_plain_import_skipped(self):
+        src = 'import os\nimport sys as system\n'
+        imp = _extract_imports(src, "pkg/mod.py")
+        assert imp == {}
+
+    def test_nested_relative(self):
+        src = 'from ..parent import Thing\n'
+        imp = _extract_imports(src, "pkg/sub/__init__.py")
+        assert "pkg/parent.py:Thing" in imp["Thing"]
+
+    def test_syntax_error_returns_empty(self):
+        imp = _extract_imports("from .\n", "pkg/mod.py")
+        assert imp == {}
+
+
 class TestFindSignalSymbols:
     def test_deleted_symbol_detected(self):
         base = {"taosmd/foo.py:bar": "def"}
@@ -166,6 +223,52 @@ class TestFindRemovedAllEntries:
         head_symbols = {}
         signal = find_removed_all_entries(base_exports, head_exports, head_symbols)
         assert signal == {}
+
+    def test_removed_reexport_def_survives_is_signal(self):
+        base_exports = {"pkg/__init__.py:Thing": "export"}
+        head_exports = {}
+        head_symbols = {"pkg/sub.py:Thing": "class"}
+        base_imports = {
+            "pkg/__init__.py": {"Thing": ["pkg/sub.py:Thing", "pkg/sub/__init__.py:Thing"]},
+        }
+        signal = find_removed_all_entries(
+            base_exports, head_exports, head_symbols, base_imports
+        )
+        assert signal == {"pkg/__init__.py:Thing": "class"}
+
+    def test_removed_reexport_aliased_def_survives_is_signal(self):
+        base_exports = {"pkg/__init__.py:Alias": "export"}
+        head_exports = {}
+        head_symbols = {"pkg/sub.py:Real": "def"}
+        base_imports = {
+            "pkg/__init__.py": {"Alias": ["pkg/sub.py:Real", "pkg/sub/__init__.py:Real"]},
+        }
+        signal = find_removed_all_entries(
+            base_exports, head_exports, head_symbols, base_imports
+        )
+        assert signal == {"pkg/__init__.py:Alias": "def"}
+
+    def test_removed_reexport_def_also_removed_is_not_signal(self):
+        base_exports = {"pkg/__init__.py:Thing": "export"}
+        head_exports = {}
+        head_symbols = {}
+        base_imports = {
+            "pkg/__init__.py": {"Thing": ["pkg/sub.py:Thing", "pkg/sub/__init__.py:Thing"]},
+        }
+        signal = find_removed_all_entries(
+            base_exports, head_exports, head_symbols, base_imports
+        )
+        assert signal == {}
+
+    def test_same_file_still_works_with_imports(self):
+        base_exports = {"pkg/mod.py:foo": "export", "pkg/mod.py:bar": "export"}
+        head_exports = {"pkg/mod.py:foo": "export"}
+        head_symbols = {"pkg/mod.py:foo": "def", "pkg/mod.py:bar": "def"}
+        base_imports = {}
+        signal = find_removed_all_entries(
+            base_exports, head_exports, head_symbols, base_imports
+        )
+        assert signal == {"pkg/mod.py:bar": "def"}
 
 
 class TestParseWaivedSymbols:
@@ -573,6 +676,263 @@ class TestAllRemovalControl:
     def test_noop_change_is_clean(self, tmp_path, monkeypatch):
         """A PR that touches neither symbols nor __all__ stays green."""
         repo = _init_repo_noop(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 0
+
+
+# ----------------------------------------------------------------------
+# __all__ re-export removal: a name dropped from __all__ while its def
+# survives elsewhere (imported, not defined, in the __all__ file)
+# ----------------------------------------------------------------------
+
+
+def _init_repo_reexport_removed(tmp_path):
+    """A re-export is removed from __all__ while its import line and def survive.
+
+    Mirrors the taosmd/__init__.py pattern: __all__ names a symbol that is
+    imported from a submodule via from-import, with the definition living in
+    that submodule.
+    """
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    pkg = tmp_path / "taosmd"
+    pkg.mkdir(parents=True)
+
+    (pkg / "submodule.py").write_text("class Thing:\n    pass\n")
+    (pkg / "__init__.py").write_text(
+        'from .submodule import Thing\n\n'
+        '__all__ = ["Thing"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    # HEAD: drop from __all__, keep import line and def
+    (pkg / "__init__.py").write_text(
+        'from .submodule import Thing\n\n'
+        '__all__ = []\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+def _init_repo_reexport_legitimate(tmp_path):
+    """A re-export is removed from __all__ together with its import line AND definition.
+
+    This is a legitimate deletion: the def half catches it, the export half
+    must not also fire.
+    """
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    pkg = tmp_path / "taosmd"
+    pkg.mkdir(parents=True)
+
+    (pkg / "submodule.py").write_text("class Thing:\n    pass\n")
+    (pkg / "__init__.py").write_text(
+        'from .submodule import Thing\n\n'
+        '__all__ = ["Thing"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    # HEAD: remove __all__ entry, import line, and definition
+    (pkg / "submodule.py").write_text("")
+    (pkg / "__init__.py").write_text('__all__ = []\n')
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+def _init_repo_reexport_aliased(tmp_path):
+    """A re-export via ``as`` alias is removed from __all__ with import intact."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+
+    pkg = tmp_path / "taosmd"
+    pkg.mkdir(parents=True)
+
+    (pkg / "submodule.py").write_text("class RealThing:\n    pass\n")
+    (pkg / "__init__.py").write_text(
+        'from .submodule import RealThing as Thing\n\n'
+        '__all__ = ["Thing"]\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=tmp_path, check=True, capture_output=True)
+
+    (pkg / "__init__.py").write_text(
+        'from .submodule import RealThing as Thing\n\n'
+        '__all__ = []\n'
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "head"], cwd=tmp_path, check=True, capture_output=True)
+
+    return tmp_path
+
+
+class TestResolveExportKey:
+    def test_same_file_symbol_unchanged(self):
+        head_symbols = {"pkg/mod.py:foo": "def"}
+        resolved = _resolve_export_key(
+            "pkg/mod.py:foo", {}, head_symbols
+        )
+        assert resolved == "pkg/mod.py:foo"
+
+    def test_reexport_resolved(self):
+        head_symbols = {"pkg/sub.py:RealThing": "class"}
+        imports = {
+            "pkg/__init__.py": {"Thing": ["pkg/sub.py:RealThing"]},
+        }
+        resolved = _resolve_export_key("pkg/__init__.py:Thing", imports, head_symbols)
+        assert resolved == "pkg/sub.py:RealThing"
+
+    def test_reexport_falls_back_when_def_gone(self):
+        head_symbols = {}
+        imports = {
+            "pkg/__init__.py": {"Thing": ["pkg/sub.py:Thing"]},
+        }
+        resolved = _resolve_export_key("pkg/__init__.py:Thing", imports, head_symbols)
+        assert resolved == "pkg/__init__.py:Thing"
+
+
+class TestReexportRemovalIntegration:
+    def test_reexport_removal_fails(self, tmp_path, monkeypatch):
+        repo = _init_repo_reexport_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        assert len(export_removed) == 1
+        assert export_removed[0].symbol == "taosmd/__init__.py:Thing"
+        assert waived == set()
+
+    def test_reexport_removal_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo_reexport_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main(["--base", "HEAD~1"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "from __all__" in captured.out
+        assert "taosmd/__init__.py:Thing" in captured.out
+
+    def test_reexport_removal_passes_with_waiver(self, tmp_path, monkeypatch):
+        repo = _init_repo_reexport_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main([
+            "--base", "HEAD~1",
+            "--pr-body", "Removes-Intentionally: taosmd/__init__.py:Thing",
+        ])
+        assert rc == 0
+
+    def test_reexport_aliased_removal_fails(self, tmp_path, monkeypatch):
+        repo = _init_repo_reexport_aliased(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        assert len(export_removed) == 1
+        assert export_removed[0].symbol == "taosmd/__init__.py:Thing"
+
+    def test_reexport_added_by_resolves_to_definition(self, tmp_path, monkeypatch):
+        repo = _init_repo_reexport_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        # added_by should point to the commit, not "unknown"
+        assert export_removed[0].added_by != "unknown"
+
+
+class TestReexportRemovalControl:
+    def test_legitimate_reexport_deletion_no_export_violation(self, tmp_path, monkeypatch):
+        """Removing the __all__ entry, the import line, and the definition is
+        a legitimate deletion. The def half catches it; the export half must not."""
+        repo = _init_repo_reexport_legitimate(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        deleted = [v for v in violations if v.kind == "deleted"]
+        assert len(deleted) == 1
+        assert deleted[0].symbol == "taosmd/submodule.py:Thing"
+        assert waived == set()
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        assert export_removed == []
+
+    def test_legitimate_reexport_deletion_passes_with_def_waiver(self, tmp_path, monkeypatch):
+        repo = _init_repo_reexport_legitimate(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        rc = main([
+            "--base", "HEAD~1",
+            "--pr-body", "Removes-Intentionally: taosmd/submodule.py:Thing",
+        ])
+        assert rc == 0
+
+    def test_same_file_all_removal_still_works(self, tmp_path, monkeypatch):
+        """CONTROL 2: the same-file case from #306 must keep working."""
+        repo = _init_repo_all_removed(tmp_path)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr(cds, "REPO_ROOT", repo)
+
+        violations, waived = check_deleted_symbols(
+            base_ref="HEAD~1",
+            repo_root=repo,
+            pr_body=None,
+            waived=None,
+        )
+        export_removed = [v for v in violations if v.kind == "export-removed"]
+        assert len(export_removed) == 1
+        assert export_removed[0].symbol == "taosmd/service.py:func_b"
+
+    def test_noop_reexport_repo_is_clean(self, tmp_path, monkeypatch):
+        """A repo where __all__ re-exports match surviving defs stays green."""
+        repo = _init_repo_reexport_removed(tmp_path)
+        # Restore to base state for the head commit
+        pkg = repo / "taosmd"
+        (pkg / "__init__.py").write_text(
+            'from .submodule import Thing\n\n'
+            '__all__ = ["Thing"]\n'
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "noop"], cwd=repo, check=True, capture_output=True)
         monkeypatch.chdir(repo)
         monkeypatch.setattr(cds, "REPO_ROOT", repo)
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deleted-symbols-gate is blind to a re-export dropped from a package __init__.py

Autonomous build of board card tsk-cssuku.

The export-removal clause in find_removed_all_entries only matched
__all__ entries whose def/class lived in the same file.  Re-exports
(names imported via from-import, not defined locally) never matched, so
dropping e.g. KnowledgeGraph from taosmd/__init__.py __all__ while the
import line and the definition survived went unreported.

Add _extract_imports/_get_imports_at_ref to resolve from-import
bindings to candidate definition keys, and extend
find_removed_all_entries to follow those bindings when a same-file
definition is absent.  _resolve_export_key lets the existing def and
class search target the real definition file for an accurate added-by.
A genuine deletion that removes the __all__ entry, the import, and the
definition is not flagged by the export half (it is caught by the
def-deletion half).

Adds TestExtractImports, re-export cases to TestFindRemovedAllEntries,
TestResolveExportKey, TestReexportRemovalIntegration, and
TestReexportRemovalControl.

Files:
 changelog.d/tsk-cssuku-reexport-gate.md |   2 +
 scripts/check_deleted_symbols.py        | 142 ++++++++++++-
 tests/test_deleted_symbols.py           | 360 ++++++++++++++++++++++++++++++++
 3 files changed, 495 insertions(+), 9 deletions(-)