### PR TITLE
Revise PR #288: it does not measure the quantity

### DIFF
--- a/benchmarks/measure_upstream_propagation.py
+++ b/benchmarks/measure_upstream_propagation.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Measure upstream usage-window rollover propagation via the real API.
+
+At an Anthropic usage-window reset boundary, the five_hour.utilization
+figure does not update instantly.  This harness polls the REAL Anthropic
+usage API at https://api.anthropic.com/api/oauth/usage, one request per
+second, and records the wall-clock delta between the nominal resets_at
+and the first response that serves the new window.
+
+The constant this measures -- MIN_LEAD_SECONDS in the resume helper --
+is labelled UNMEASURED until a live measurement succeeds.  If no
+credentials are available, the run writes an UNMEASURED evidence record
+to benchmarks/results/ so the label is never silently retired.
+
+Usage:
+    TAOSMD_ANTHROPIC_CREDS=/path/creds.json python3 benchmarks/measure_upstream_propagation.py
+    python3 benchmarks/measure_upstream_propagation.py --reset-at 2026-08-17T08:00:00+00:00 --creds /path/creds.json
+    python3 benchmarks/measure_upstream_propagation.py --dry-run --creds /path/creds.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+_BENCH_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _BENCH_DIR.parent
+_RESULTS_DIR = _BENCH_DIR / "results"
+_EVIDENCE_FILE = _RESULTS_DIR / "tsk-rcnct6_upstream_propagation.json"
+
+USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage"
+
+_HEADERS = {
+    "anthropic-beta": "oauth-2025-04-20",
+}
+
+
+def resolve_token(creds_path: str | None = None) -> str:
+    """Resolve the Anthropic OAuth token from a credentials file.
+
+    The path is configurable via --creds or TAOSMD_ANTHROPIC_CREDS so no
+    hardcoded absolute path is baked into the source.
+    """
+    path = creds_path or os.environ.get("TAOSMD_ANTHROPIC_CREDS")
+    if not path:
+        raise SystemExit(
+            "No credentials path: set TAOSMD_ANTHROPIC_CREDS or pass --creds"
+        )
+    with open(path, "r") as f:
+        creds = json.load(f)
+    return creds["claudeAiOauth"]["accessToken"]
+
+
+def fetch_usage(token: str, client: httpx.Client | None = None) -> dict:
+    """Fetch live usage data from the real Anthropic usage API.
+
+    Returns the parsed JSON body.  Does NOT return canned or mock data.
+    """
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=15.0)
+    try:
+        resp = client.get(
+            USAGE_API_URL,
+            headers={**_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+    finally:
+        if owns_client:
+            client.close()
+
+
+def parse_reset(resets_at: str) -> datetime.datetime:
+    """Parse a resets_at ISO timestamp into an aware datetime."""
+    cleaned = resets_at.replace("Z", "+00:00")
+    dt = datetime.datetime.fromisoformat(cleaned)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def measure_at_boundary(
+    reset_at: datetime.datetime,
+    token: str,
+    poll_interval: float = 1.0,
+    max_wait: float = 600.0,
+    fetch_fn=None,
+    sleep_fn=None,
+) -> dict:
+    """Poll the real API each second around a reset boundary.
+
+    Records the wall-clock delta between *reset_at* and the first
+    response whose five_hour.utilization differs from the pre-reset
+    value, proving the window has rolled over.
+    """
+    if fetch_fn is None:
+        fetch_fn = fetch_usage
+    if sleep_fn is None:
+        sleep_fn = time.sleep
+
+    pre_util = None
+    samples: list[dict] = []
+    now = datetime.datetime.now(datetime.timezone.utc)
+    t0 = time.monotonic()
+
+    while now < reset_at:
+        wait = (reset_at - now).total_seconds()
+        if wait <= 0:
+            break
+        sleep_fn(min(wait, poll_interval))
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+    while (time.monotonic() - t0) < max_wait:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        try:
+            usage = fetch_fn(token)
+        except Exception as exc:  # noqa: BLE001 - record, keep polling
+            samples.append({"time": now.isoformat(), "error": f"{type(exc).__name__}: {exc}"})
+            sleep_fn(poll_interval)
+            continue
+
+        util = usage.get("five_hour", {}).get("utilization")
+
+        if pre_util is None:
+            if util is not None:
+                pre_util = util
+            samples.append({"time": now.isoformat(), "utilization": util})
+            sleep_fn(poll_interval)
+            continue
+
+        if util is not None and util != pre_util:
+            delta = (now - reset_at).total_seconds()
+            return {
+                "reset_at": reset_at.isoformat(),
+                "flipped_at": now.isoformat(),
+                "propagation_seconds": delta,
+                "pre_reset_utilization": pre_util,
+                "post_reset_utilization": util,
+                "samples": samples,
+                "status": "MEASURED",
+            }
+
+        samples.append({"time": now.isoformat(), "utilization": util})
+        sleep_fn(poll_interval)
+
+    return {
+        "reset_at": reset_at.isoformat(),
+        "flipped_at": None,
+        "propagation_seconds": None,
+        "pre_reset_utilization": pre_util,
+        "samples": samples,
+        "status": "NO_FLIP_DETECTED",
+    }
+
+
+def write_evidence(result: dict, path: Path | None = None) -> Path:
+    """Write evidence to the repo's benchmarks/results/ directory."""
+    out = path or _EVIDENCE_FILE
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    return out
+
+
+def record_unmeasured(creds_path: str | None = None) -> dict:
+    """Record that the measurement could not be performed live."""
+    reason = "No live Anthropic credentials available in this environment."
+    if creds_path and not Path(creds_path).exists():
+        reason = f"Credentials file not found: {creds_path}"
+    result = {
+        "measurement": "upstream usage-window rollover propagation",
+        "target_constant": "MIN_LEAD_SECONDS",
+        "target_location": "resume helper (scripts/resume_arm_time.py / ~/.taos-team/resume_arm_time.py)",
+        "status": "UNMEASURED",
+        "reason": reason,
+        "procedure": (
+            "At a reset boundary, poll the live Anthropic usage API "
+            "https://api.anthropic.com/api/oauth/usage each second and "
+            "record the wall-clock delta between the nominal resets_at and "
+            "the first response serving the new five_hour window. "
+            "See measure_at_boundary() in this file."
+        ),
+        "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "measured_samples": [],
+        "script": "benchmarks/measure_upstream_propagation.py",
+    }
+    write_evidence(result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure upstream usage-window rollover propagation via the real Anthropic API."
+    )
+    parser.add_argument("--creds", help="Path to credentials JSON (or set TAOSMD_ANTHROPIC_CREDS)")
+    parser.add_argument("--reset-at", help="ISO timestamp of the reset boundary to measure")
+    parser.add_argument("--poll-interval", type=float, default=1.0, help="Seconds between polls")
+    parser.add_argument("--max-wait", type=float, default=600.0, help="Max seconds to wait for flip")
+    parser.add_argument("--dry-run", action="store_true", help="Check credentials and API reachability")
+    args = parser.parse_args()
+
+    try:
+        token = resolve_token(args.creds)
+    except SystemExit:
+        result = record_unmeasured(args.creds)
+        print(f"No credentials available. Evidence written as UNMEASURED: {_EVIDENCE_FILE}")
+        return 1
+
+    if args.dry_run:
+        try:
+            usage = fetch_usage(token)
+            resets_at = usage.get("five_hour", {}).get("resets_at", "N/A")
+            print(f"API reachable. five_hour resets_at: {resets_at}")
+            return 0
+        except Exception as exc:  # noqa: BLE001 - report any failure to reach API
+            print(f"API unreachable: {exc}", file=sys.stderr)
+            return 2
+
+    if args.reset_at:
+        reset_at = parse_reset(args.reset_at)
+    else:
+        try:
+            usage = fetch_usage(token)
+        except Exception as exc:  # noqa: BLE001 - report any failure to fetch
+            print(f"Failed to fetch usage: {exc}", file=sys.stderr)
+            return 2
+        resets_at = usage.get("five_hour", {}).get("resets_at")
+        if not resets_at:
+            print("No five_hour.resets_at in API response", file=sys.stderr)
+            return 2
+        reset_at = parse_reset(resets_at)
+        print(f"Next reset boundary: {reset_at.isoformat()}")
+
+    print(f"Polling the real API at {reset_at.isoformat()} each second...")
+    result = measure_at_boundary(
+        reset_at, token,
+        poll_interval=args.poll_interval,
+        max_wait=args.max_wait,
+    )
+    path = write_evidence(result)
+    print(f"Evidence written: {path}")
+    print(f"Status: {result['status']}")
+    if result.get("propagation_seconds") is not None:
+        print(f"Propagation: {result['propagation_seconds']:.3f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/results/tsk-rcnct6_upstream_propagation.json
+++ b/benchmarks/results/tsk-rcnct6_upstream_propagation.json
@@ -1,0 +1,11 @@
+{
+    "measurement": "upstream usage-window rollover propagation",
+    "target_constant": "MIN_LEAD_SECONDS",
+    "target_location": "resume helper (scripts/resume_arm_time.py / ~/.taos-team/resume_arm_time.py)",
+    "status": "UNMEASURED",
+    "reason": "No live Anthropic credentials available in this environment. The measurement requires polling https://api.anthropic.com/api/oauth/usage across a real 5h reset boundary (bounded wait).",
+    "procedure": "At a reset boundary, poll the live Anthropic usage API https://api.anthropic.com/api/oauth/usage each second and record the wall-clock delta between the nominal resets_at and the first response serving the new five_hour window. See measure_at_boundary() in benchmarks/measure_upstream_propagation.py.",
+    "recorded_at": "2026-08-17T23:05:00+00:00",
+    "measured_samples": [],
+    "script": "benchmarks/measure_upstream_propagation.py"
+}

--- a/changelog.d/tsk-rcnct6-measure-upstream-propagation.md
+++ b/changelog.d/tsk-rcnct6-measure-upstream-propagation.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Replaced the mock-API simulation in the upstream usage-window rollover
+  propagation measurement with a harness that polls the real Anthropic
+  usage API at `api.anthropic.com/api/oauth/usage`.  Evidence is now
+  committed to `benchmarks/results/` instead of `/tmp`, with no hardcoded
+  paths, no external-file mutation, and `MIN_LEAD_SECONDS` left labelled
+  UNMEASURED pending a live measurement.

--- a/tests/test_measure_upstream_propagation.py
+++ b/tests/test_measure_upstream_propagation.py
@@ -1,0 +1,219 @@
+"""Red-first tests for the upstream usage-window rollover measurement.
+
+Each test encodes a requirement violated by the original PR #288
+(revision card tsk-rcnct6).  The tests inspect source code and committed
+evidence to confirm the measurement is real, not simulated, and that
+every blocker from the review is addressed.
+
+Blockers addressed:
+  1. Does not measure the quantity (used a MockAPI instead of the real API)
+  2. Evidence not in the PR and not reproducible (stored in /tmp)
+  3. Measurement dated in the future
+  4. Range "10.0s-10.0s" (identical endpoints from a mock)
+  5. Mutates a file outside this repo
+  6. Source contradicts itself (TO MEASURE above a claim it was performed)
+  Required: scratch scripts must not live at the repo root
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "benchmarks" / "measure_upstream_propagation.py"
+RESULTS_DIR = REPO_ROOT / "benchmarks" / "results"
+EVIDENCE_PATH = RESULTS_DIR / "tsk-rcnct6_upstream_propagation.json"
+
+
+def _load_module():
+    """Load benchmarks/measure_upstream_propagation.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "measure_upstream_propagation", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _source():
+    return SCRIPT_PATH.read_text()
+
+
+# --- BLOCKER 1: it does not measure the quantity (used a mock API) ---
+
+def test_no_mock_api_class():
+    """The harness must call the real Anthropic API, never substitute a mock."""
+    src = _source()
+    assert "class MockAPI" not in src, "MockAPI class present: not a real measurement"
+
+
+def test_no_window_flips_dict():
+    """No pre-baked window_flips data that replaces real API responses."""
+    src = _source()
+    assert "window_flips" not in src
+
+
+def test_uses_real_api_endpoint():
+    """The harness must target the real Anthropic usage endpoint."""
+    src = _source()
+    assert "api.anthropic.com" in src
+    assert "oauth/usage" in src
+
+
+def test_fetch_usage_uses_httpx():
+    """fetch_usage must issue a real HTTP request via httpx."""
+    src = _source()
+    assert "def fetch_usage" in src
+    assert "httpx" in src
+
+
+def test_no_simulation_keywords():
+    """The harness must not describe itself as a simulation."""
+    src_lower = _source().lower()
+    for forbidden in ("simulate", "simulator", "simulation"):
+        assert forbidden not in src_lower, f"forbidden word '{forbidden}' in source"
+
+
+# --- BLOCKER 2: evidence not in the PR and not reproducible ---
+
+def test_evidence_file_exists_in_repo():
+    """Evidence must be committed in benchmarks/results/, not in /tmp."""
+    assert EVIDENCE_PATH.is_file(), "evidence file must be committed to the repo"
+
+
+def test_no_tmp_result_paths():
+    """No hardcoded /tmp paths for results or evidence."""
+    src = _source()
+    assert "/tmp/" not in src, "hardcoded /tmp path found in measurement script"
+
+
+# --- BLOCKER 3: measurement dated in the future ---
+
+def test_evidence_not_future_dated():
+    """Evidence must not be dated after today."""
+    today = datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()
+    data = json.loads(EVIDENCE_PATH.read_text())
+    recorded = data.get("recorded_at", "")
+    assert recorded, "evidence must carry a recorded_at timestamp"
+    assert recorded[:10] <= today, f"evidence dated in the future: {recorded}"
+
+
+# --- BLOCKER 4: range 10.0s-10.0s ---
+
+def test_evidence_no_fake_constant_range():
+    """Evidence must not claim a fake 10.0s measurement."""
+    blob = json.dumps(json.loads(EVIDENCE_PATH.read_text()))
+    assert "10.0s-10.0s" not in blob
+    assert '"average_delay": 10.0' not in blob
+
+
+def test_evidence_status_is_unmeasured():
+    """With no live credentials, status must remain UNMEASURED."""
+    data = json.loads(EVIDENCE_PATH.read_text())
+    assert data["status"] == "UNMEASURED"
+
+
+# --- BLOCKER 5: mutates a file outside this repo ---
+
+def test_no_external_file_mutation():
+    """No code that rewrites files outside the repository."""
+    src = _source()
+    assert "apply_change" not in src, "script generates external mutation: apply_change"
+    assert "sed -i" not in src
+    assert "cp ~/.taos-team" not in src
+    assert "resume_arm_time.py.backup" not in src
+
+
+def test_no_hardcoded_external_paths():
+    """No hardcoded paths to ~/.taos-team or /home/jay."""
+    src = _source()
+    assert "/home/jay/.taos-team" not in src, "hardcoded external path"
+    assert "/home/jay/.claude/.credentials.json" not in src
+
+
+# --- BLOCKER 6: file contradicts itself ---
+
+def test_no_contradictory_measurement_claims():
+    """Source must not claim the quantity was measured when it was not."""
+    src = _source()
+    assert "10.0s on average" not in src
+    assert "Measured propagation is" not in src
+
+
+# --- REQUIRED: scratch scripts at repo root ---
+
+def test_no_scripts_at_root():
+    """Measurement and helper scripts must not live at the repository root."""
+    assert not (REPO_ROOT / "measure_upstream_propagation.py").exists()
+    assert not (REPO_ROOT / "analyze_and_update.py").exists()
+    assert not (REPO_ROOT / "test_api_access.py").exists()
+    assert not (REPO_ROOT / "test_measurement.py").exists()
+
+
+# --- functional: fetch_usage returns parsed JSON from the real endpoint ---
+
+def test_fetch_usage_returns_parsed_json():
+    """fetch_usage must return the parsed JSON body, not canned data."""
+    mod = _load_module()
+    payload = {
+        "five_hour": {"utilization": 0.12, "resets_at": "2026-08-17T08:00:00Z"},
+        "seven_day": {"utilization": 0.03, "resets_at": "2026-08-18T02:00:00Z"},
+    }
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(200, json=payload)
+    )
+    with httpx.Client(transport=transport) as client:
+        result = mod.fetch_usage("token", client=client)
+    assert result["five_hour"]["utilization"] == 0.12
+
+
+# --- functional: measure_at_boundary polls and detects the flip ---
+
+def test_measure_at_boundary_detects_flip():
+    """measure_at_boundary must poll until utilization changes."""
+    mod = _load_module()
+    reset_at = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    state = {"call": 0}
+
+    def fake_fetch(token, client=None):
+        state["call"] += 1
+        if state["call"] <= 1:
+            return {
+                "five_hour": {"utilization": 0.80, "resets_at": "2020-01-01T08:00:00Z"}
+            }
+        return {
+            "five_hour": {"utilization": 0.20, "resets_at": "2020-01-01T13:00:00Z"}
+        }
+
+    result = mod.measure_at_boundary(
+        reset_at, "token", fetch_fn=fake_fetch, sleep_fn=lambda s: None
+    )
+    assert result["status"] == "MEASURED"
+    assert result["propagation_seconds"] is not None
+    assert state["call"] == 2
+
+
+def test_measure_at_boundary_no_flip_times_out():
+    """When the window never flips, status is NO_FLIP_DETECTED."""
+    mod = _load_module()
+    reset_at = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+    def no_flip(token, client=None):
+        return {
+            "five_hour": {"utilization": 0.80, "resets_at": "2020-01-01T08:00:00Z"}
+        }
+
+    result = mod.measure_at_boundary(
+        reset_at, "token",
+        fetch_fn=no_flip, sleep_fn=lambda s: None,
+        max_wait=0.1,
+    )
+    assert result["status"] == "NO_FLIP_DETECTED"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #288: it does not measure the quantity

Autonomous build of board card tsk-rcnct6.

Replace the mock-API simulation from PR #288 with a harness that
polls the real Anthropic usage API at api.anthropic.com/api/oauth/usage.
Evidence is committed to benchmarks/results/ instead of /tmp. No
hardcoded /home/jay paths, no external-file mutation, and
MIN_LEAD_SECONDS remains UNMEASURED pending a live measurement.

Blockers addressed:
- Uses the real API, not MockAPI
- Evidence committed to repo, not /tmp
- Evidence dated today (2026-08-17), not in the future
- No fake 10.0s-10.0s range
- No mutation of files outside this repo
- No contradictory claims in source or evidence
- Scripts in benchmarks/ and tests/, not at repo root

Files:
 benchmarks/measure_upstream_propagation.py         | 256 +++++++++++++++++++++
 .../results/tsk-rcnct6_upstream_propagation.json   |  11 +
 .../tsk-rcnct6-measure-upstream-propagation.md     |   8 +
 tests/test_measure_upstream_propagation.py         | 219 ++++++++++++++++++
 4 files changed, 494 insertions(+)