### PR TITLE
Document that human_principal_ids is a revocation exemption list, including the fail-closed bypass

### DIFF
--- a/changelog.d/tsk-wa2bwk-human-principal-docs.md
+++ b/changelog.d/tsk-wa2bwk-human-principal-docs.md
@@ -1,0 +1,2 @@
+### Added
+- Documented that `human_principal_ids` exempts listed canonical_ids from the registry revocation check AND from the fail-closed refusal that fires when the revocation feed has never loaded. The id is not validated as belonging to a human, so naming an agent canonical_id there silently disables that agent's revocation.

--- a/docs/specs/a2a-bus-auth-transition.md
+++ b/docs/specs/a2a-bus-auth-transition.md
@@ -15,7 +15,21 @@ See Target state item 3 and open question 1.
 "unresolved" invites the opposite reading.** Nothing is broken today. With no
 `human_principal_ids` configured, #235's guard condition is always true, so revocation
 currently applies to **everyone**. The hole opens the first time the feature is used for its
-purpose, not before.
+purpose, not before. Once an id is listed, it is also exempt from the fail-closed refusal
+that fires when the revocation feed has never loaded, and it is not validated as belonging
+to a human: naming an agent's canonical_id there silently disables that agent's revocation.
+Measured on exec/tsk-legqtr at 8ba25e2:
+
+```
+revoked id IS on the feed:
+  human_principal_ids=set()            rejected   <- control, the check can reject
+  human_principal_ids={that id}        ACCEPTED
+  human_principal_ids={a different id} rejected   <- control, it is the membership
+
+revocation feed UNREACHABLE (never loaded, fail-closed path):
+  human_principal_ids=set()            rejected   <- control
+  human_principal_ids={that id}        ACCEPTED
+```
 
 Owner: @taOSmd-dev. Supersedes the held Phase 2 of #138, which was blocked on the registry
 identity layer that landed 2026-08-13.

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -54,7 +54,12 @@ _GENERATOR_PROFILE_KEY = "generator_profile"
 _A2A_AUTH_ENFORCE_KEY = "a2a_auth_enforce"
 # Canonical IDs of human principals (controller sessions). These IDs skip the
 # registry revocation check and the grants check; a sub/from mismatch on a
-# human token is always rejected, even in verify-and-warn mode.
+# human token is always rejected, even in verify-and-warn mode. They are also
+# exempt from the fail-closed refusal that fires when the revocation feed has
+# never loaded. The id is not validated as belonging to a human: the controller
+# has no human_principal concept. Naming an agent canonical_id here silently
+# disables that agent's revocation. The set resolves from
+# ``TAOSMD_HUMAN_PRINCIPAL_IDS`` (comma separated) before the config file.
 _HUMAN_PRINCIPAL_IDS_KEY = "human_principal_ids"
 # Section under which collections settings live. ``allowed_roots`` is the
 # safety line of the collections contract: source paths must resolve inside
@@ -665,7 +670,12 @@ def get_human_principal_ids(data_dir=None) -> list[str]:
 
     These IDs belong to human principals (controller sessions). They skip the
     registry revocation check and the grants check; a sub/from mismatch on a
-    human token is always rejected, even in verify-and-warn mode.
+    human token is always rejected, even in verify-and-warn mode. They are also
+    exempt from the revocation feed and from the fail-closed refusal that fires
+    when the feed has never loaded. The id is not validated as belonging to a
+    human: the controller has no human_principal concept, so naming an agent
+    canonical_id here silently disables that agent's revocation. Resolution is
+    from ``TAOSMD_HUMAN_PRINCIPAL_IDS`` before the config file.
     """
     env = os.environ.get("TAOSMD_HUMAN_PRINCIPAL_IDS")
     if env and env.strip():

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -166,8 +166,13 @@ class RegistryVerifier:
     def authorize(self, token: str, claimed_from: str) -> dict:
         """Authorise a sender; return verified claims or raise AuthError.
 
-        Human principals skip the revocation feed fetch entirely so the
-        fail-closed revocation check never blocks controller-signed humans.
+        Human principals skip the revocation feed fetch entirely. This is safe by
+        design: the feed is agent-only (the controller has no human_principal
+        concept), so a registry outage must not lock out controller sessions. The
+        exemption is only as trustworthy as the config that supplies it: any id
+        placed in human_principal_ids is exempt from revocation, and an agent
+        canonical_id placed there silently disables that agent's revocation check,
+        including the fail-closed refusal that fires when the feed has never loaded.
         """
         try:
             import jwt  # noqa: PLC0415


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Document that human_principal_ids is a revocation exemption list, including the fail-closed bypass

Autonomous build of board card tsk-wa2bwk.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 changelog.d/tsk-wa2bwk-human-principal-docs.md |  2 ++
 docs/specs/a2a-bus-auth-transition.md          | 16 +++++++++++++++-
 taosmd/config.py                               | 14 ++++++++++++--
 taosmd/registry_auth.py                        |  9 +++++++--
 4 files changed, 36 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that configured human principal IDs bypass revocation-feed checks and fail-closed behavior.
  * Documented that these IDs are not validated as human identities, so agent identifiers may unintentionally receive the same exemption.
  * Clarified that human-token subject mismatches remain rejected.
  * Documented that environment-variable settings take precedence over configuration-file values.
  * Added risk scenarios and control cases covering revoked IDs and unavailable revocation feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->