### PR TITLE
Revise PR #328: the carry-forward landed and none of the three fixes did

### DIFF
--- a/changelog.d/tsk-2ohqj4-normalise-handle-gate-fixes.md
+++ b/changelog.d/tsk-2ohqj4-normalise-handle-gate-fixes.md
@@ -1,0 +1,2 @@
+### Fixed
+- The duplicate-definition gate no longer fires on definitions that sit in mutually exclusive sibling arms of the same ``if``/``elif``/``else`` chain or ``try``/``except``/``else`` block. The ``except ImportError:`` and ``except ModuleNotFoundError:`` fallback patterns are recognised and left silent. Nested-class duplicate methods are now scanned at any depth, with the correct ``class Outer.Inner`` scope string.

--- a/scripts/normalise_handle_gate.py
+++ b/scripts/normalise_handle_gate.py
@@ -11,6 +11,16 @@ functions -- and any other accidental redefinition -- are reported.
 ``@<name>.getter`` / ``@<name>.deleter`` accessories are legitimate same-name
 pairs and are therefore excluded.  Files that cannot be decoded as UTF-8 are
 skipped with a warning rather than allowed to crash the gate.
+
+Definitions inside module-level ``if`` / ``try`` / ``for`` / ``while`` /
+``with`` blocks are treated as module-scope, matching Python's binding rules.
+Same-name closures inside one parent function are also reported; same-name
+closures in different parents remain legal.  Sibling arms of the same
+``if`` / ``elif`` / ``else`` chain and the ``body`` / ``handlers`` /
+``orelse`` arms of one ``try`` statement are mutually exclusive and do not
+collide.  The ``try:`` / ``except ImportError:`` and ``except
+ModuleNotFoundError:`` fallback patterns are recognised and left silent.
+Nested classes are scanned at any depth.
 """
 from __future__ import annotations
 
@@ -30,6 +40,16 @@ class Duplicate:
     name: str
     scope: str
     lines: list[int] = field(default_factory=list)
+
+
+@dataclass
+class _Def:
+    scope: str
+    name: str
+    lineno: int
+    in_try: bool = False
+    in_import_error_except: bool = False
+    arm_tracker: tuple[int, str] | None = None
 
 
 def _has_overload_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
@@ -69,24 +89,171 @@ def _is_exempt(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     return _has_overload_decorator(node) or _has_property_decorator(node)
 
 
+def _is_import_error_handler(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:
+        return False
+
+    def _is_import_error_node(node):
+        if isinstance(node, ast.Name):
+            return node.id in ("ImportError", "ModuleNotFoundError")
+        if isinstance(node, ast.Attribute):
+            return (
+                isinstance(node.value, ast.Name)
+                and node.value.id == "builtins"
+                and node.attr == "ImportError"
+            )
+        return False
+
+    if isinstance(handler.type, ast.Tuple):
+        return any(_is_import_error_node(elt) for elt in handler.type.elts)
+    return _is_import_error_node(handler.type)
+
+
 def _collect_definitions(
-    body: list[ast.stmt], class_path: tuple[str, ...] = ()
-) -> list[tuple[str, str, int]]:
-    """Yield ``(scope, name, lineno)`` for every non-exempt function/method.
+    body: list[ast.stmt],
+    scope: str = "module",
+    class_path: tuple[str, ...] = (),
+    in_try: bool = False,
+    in_import_error_except: bool = False,
+    arm_tracker: tuple[int, str] | None = None,
+) -> list[_Def]:
+    """Yield ``_Def`` for every non-exempt function/method.
 
     ``scope`` is ``"module"`` for a top-level function, ``"class Foo.Bar"``
-    for a method of ``Foo.Bar``.  Nested functions (closures) are
-    intentionally NOT collected: they are neither top-level functions nor
-    methods, and same-name closures in different parents are legal.
+    for a method of ``Foo.Bar``, and ``"module > outer"`` for a closure
+    inside ``outer``.  Definitions inside module-level ``if`` / ``try`` /
+    ``for`` / ``while`` / ``with`` blocks are collected with ``"module"``
+    scope, matching Python's binding rules.  Closures are collected with a
+    scope that identifies their parent function, so that same-name closures
+    in one parent are reported while same-name closures in different parents
+    remain legal.
     """
-    scope = "module" if not class_path else "class " + ".".join(class_path)
-    found: list[tuple[str, str, int]] = []
+    found: list[_Def] = []
     for node in body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if not _is_exempt(node):
-                found.append((scope, node.name, node.lineno))
+                found.append(
+                    _Def(scope, node.name, node.lineno, in_try, in_import_error_except, arm_tracker)
+                )
+            closure_scope = (
+                f"{scope} > {node.name}"
+                if scope != "module"
+                else f"module > {node.name}"
+            )
+            found.extend(
+                _collect_definitions(
+                    node.body,
+                    closure_scope,
+                    class_path=(),
+                    in_try=False,
+                    in_import_error_except=False,
+                    arm_tracker=None,
+                )
+            )
         elif isinstance(node, ast.ClassDef):
-            found.extend(_collect_definitions(node.body, class_path + (node.name,)))
+            if " > " not in scope:
+                new_class_path = class_path + (node.name,)
+                new_scope = "class " + ".".join(new_class_path)
+                found.extend(
+                    _collect_definitions(
+                        node.body,
+                        new_scope,
+                        new_class_path,
+                        in_try=False,
+                        in_import_error_except=False,
+                        arm_tracker=None,
+                    )
+                )
+        elif isinstance(
+            node,
+            (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith),
+        ):
+            if " > " not in scope:
+                if arm_tracker is None:
+                    stmt_id = id(node)
+                    body_tracker = (stmt_id, "body")
+                    orelse_tracker = (stmt_id, "orelse")
+                else:
+                    body_tracker = arm_tracker
+                    orelse_tracker = arm_tracker
+                found.extend(
+                    _collect_definitions(
+                        node.body,
+                        scope,
+                        class_path,
+                        in_try,
+                        in_import_error_except,
+                        arm_tracker=body_tracker,
+                    )
+                )
+                if hasattr(node, "orelse") and node.orelse:
+                    found.extend(
+                        _collect_definitions(
+                            node.orelse,
+                            scope,
+                            class_path,
+                            in_try,
+                            in_import_error_except,
+                            arm_tracker=orelse_tracker,
+                        )
+                    )
+        elif isinstance(node, ast.Try):
+            if " > " not in scope:
+                if arm_tracker is None:
+                    stmt_id = id(node)
+                    body_tracker = (stmt_id, "body")
+                    handler_tracker = (stmt_id, "handler")
+                    orelse_tracker = (stmt_id, "orelse")
+                    finalbody_tracker = (stmt_id, "finalbody")
+                else:
+                    body_tracker = arm_tracker
+                    handler_tracker = arm_tracker
+                    orelse_tracker = arm_tracker
+                    finalbody_tracker = arm_tracker
+                found.extend(
+                    _collect_definitions(
+                        node.body,
+                        scope,
+                        class_path,
+                        in_try=True,
+                        in_import_error_except=in_import_error_except,
+                        arm_tracker=body_tracker,
+                    )
+                )
+                for handler in node.handlers:
+                    is_ie = _is_import_error_handler(handler)
+                    found.extend(
+                        _collect_definitions(
+                            handler.body,
+                            scope,
+                            class_path,
+                            in_try=True,
+                            in_import_error_except=is_ie,
+                            arm_tracker=handler_tracker,
+                        )
+                    )
+                if node.orelse:
+                    found.extend(
+                        _collect_definitions(
+                            node.orelse,
+                            scope,
+                            class_path,
+                            in_try=True,
+                            in_import_error_except=in_import_error_except,
+                            arm_tracker=orelse_tracker,
+                        )
+                    )
+                if node.finalbody:
+                    found.extend(
+                        _collect_definitions(
+                            node.finalbody,
+                            scope,
+                            class_path,
+                            in_try=True,
+                            in_import_error_except=in_import_error_except,
+                            arm_tracker=finalbody_tracker,
+                        )
+                    )
     return found
 
 
@@ -105,15 +272,30 @@ def _duplicate_definitions(file_path: Path) -> list[Duplicate]:
     except SyntaxError:
         return []
 
-    defs: dict[tuple[str, str], list[int]] = defaultdict(list)
-    for scope, name, lineno in _collect_definitions(tree.body):
-        defs[(scope, name)].append(lineno)
+    defs: dict[tuple[str, str], list[_Def]] = defaultdict(list)
+    for defn in _collect_definitions(tree.body):
+        defs[(defn.scope, defn.name)].append(defn)
 
-    duplicates: list[Duplicate] = [
-        Duplicate(name=name, scope=scope, lines=lines)
-        for (scope, name), lines in defs.items()
-        if len(lines) > 1
-    ]
+    duplicates: list[Duplicate] = []
+    for (scope, name), def_list in defs.items():
+        if len(def_list) <= 1:
+            continue
+
+        # Sibling arms of the same control-flow statement do not collide.
+        # A top-level definition always collides with arm definitions.
+        has_top_level = any(d.arm_tracker is None for d in def_list)
+        if has_top_level:
+            duplicates.append(
+                Duplicate(name=name, scope=scope, lines=[d.lineno for d in def_list])
+            )
+            continue
+
+        stmt_ids = {d.arm_tracker[0] for d in def_list}
+        if len(stmt_ids) == 1:
+            continue
+        duplicates.append(
+            Duplicate(name=name, scope=scope, lines=[d.lineno for d in def_list])
+        )
     duplicates.sort(key=lambda d: d.lines[0])
     return duplicates
 

--- a/tests/test_normalise_handle_gate.py
+++ b/tests/test_normalise_handle_gate.py
@@ -10,8 +10,17 @@ Proves the duplicate-definition gate (the successor to the narrow
 - ``@typing.overload`` stubs, ``@property`` getters, and
   ``@<name>.setter`` / ``@<name>.getter`` / ``@<name>.deleter`` accessories
   are legitimate same-name pairs and do not fire.
-- Nested functions (closures) are not collected: they are neither top-level
-  functions nor methods.
+- Definitions inside module-level ``if`` / ``try`` / ``for`` / ``while`` /
+  ``with`` blocks share the module scope, matching Python's binding rules.
+- Same-name closures inside one parent function are reported; same-name
+  closures in different parents remain legal.
+- Sibling arms of the same ``if`` / ``elif`` / ``else`` chain and the
+  ``body`` / ``handlers`` / ``orelse`` arms of one ``try`` statement are
+  mutually exclusive and do not collide.
+- The ``try:`` / ``except ImportError:``, ``except ModuleNotFoundError:``,
+  and ``except builtins.ImportError:`` fallback patterns are recognised and
+  left silent.
+- Nested classes are scanned at any depth.
 - Files that cannot be decoded as UTF-8 are skipped with a warning, and
   files that fail to parse are left silent.
 """
@@ -31,6 +40,7 @@ from scripts.normalise_handle_gate import (
 # ----------------------------------------------------------------------
 # unit tests for pure helpers
 # ----------------------------------------------------------------------
+
 
 class TestHasOverloadDecorator:
     def test_name_overload(self):
@@ -72,7 +82,7 @@ class TestHasPropertyDecorator:
         assert _has_property_decorator(funcs[0]) is True
 
     def test_deleter_is_exempt(self):
-        src = "class C:\n    @x.deleter\n    def x(self):\n        pass\n"
+        src = "class C:\n    @x.deleter\n    def x(self):\n        del self._x\n"
         tree = ast.parse(src)
         funcs = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
         assert _has_property_decorator(funcs[0]) is True
@@ -199,7 +209,7 @@ class TestDuplicateDefinitions:
         )
         assert _duplicate_definitions(f) == []
 
-    def test_nested_functions_are_not_collected(self, tmp_path):
+    def test_same_name_closures_in_one_parent_are_reported(self, tmp_path):
         f = tmp_path / "mod.py"
         f.write_text(
             "def outer():\n"
@@ -209,9 +219,107 @@ class TestDuplicateDefinitions:
             "        pass\n"
             "    return inner\n"
         )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "inner"
+        assert dups[0].scope == "module > outer"
+        assert dups[0].lines == [2, 4]
+
+    def test_same_name_closures_in_different_parents_are_fine(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def outer1():\n"
+            "    def inner():\n"
+            "        pass\n"
+            "def outer2():\n"
+            "    def inner():\n"
+            "        pass\n"
+        )
         assert _duplicate_definitions(f) == []
 
-    def test_try_except_import_error_fallback_is_silent(self, tmp_path):
+    def test_def_in_module_level_if_is_reported(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "if condition:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+        assert dups[0].lines == [2, 4]
+
+    def test_def_in_module_level_for_is_reported(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "for x in range(10):\n"
+            "    def foo():\n"
+            "        pass\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+
+    def test_def_in_module_level_while_is_reported(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "while True:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "    break\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+
+    def test_def_in_module_level_with_is_reported(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "with open('x') as f:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+
+    def test_try_except_import_error_fallback_with_defs_is_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "except ImportError:\n"
+            "    def foo():\n"
+            "        pass\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_try_except_value_error_sibling_arms_are_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "except ValueError:\n"
+            "    def foo():\n"
+            "        pass\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_import_fallback_with_import_inside_try_is_silent(self, tmp_path):
         f = tmp_path / "mod.py"
         f.write_text(
             "try:\n"
@@ -243,10 +351,211 @@ class TestDuplicateDefinitions:
         finally:
             f.chmod(0o644)
 
+    # ------------------------------------------------------------------
+    # Blocker 1: if/elif/try sibling arms must not collide
+    # ------------------------------------------------------------------
 
-# ----------------------------------------------------------------------
+    def test_if_else_sibling_arms_are_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "import sys\n"
+            "if sys.platform == 'win32':\n"
+            "    def p(): ...\n"
+            "else:\n"
+            "    def p(): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_elif_chain_arms_are_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "if a:\n"
+            "    def handle(): ...\n"
+            "elif b:\n"
+            "    def handle(): ...\n"
+            "else:\n"
+            "    def handle(): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_try_except_else_sibling_arms_are_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    def setup(): ...\n"
+            "except ValueError:\n"
+            "    def setup(): ...\n"
+            "else:\n"
+            "    def setup(): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_module_def_vs_def_in_if_body_fires(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def foo():\n"
+            "    pass\n"
+            "if condition:\n"
+            "    def foo():\n"
+            "        pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+
+    def test_def_in_try_body_vs_module_def_fires(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def foo():\n"
+            "    pass\n"
+            "try:\n"
+            "    def foo():\n"
+            "        pass\n"
+            "except Exception:\n"
+            "    pass\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "foo"
+        assert dups[0].scope == "module"
+
+    # ------------------------------------------------------------------
+    # Blocker 2: ModuleNotFoundError fallback must be silent
+    # ------------------------------------------------------------------
+
+    def test_module_not_found_error_bare_is_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    import something\n"
+            "except ModuleNotFoundError:\n"
+            "    pass\n"
+            "\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_module_not_found_error_in_tuple_is_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    import something\n"
+            "except (ModuleNotFoundError, OSError):\n"
+            "    pass\n"
+            "\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_builtins_import_error_is_silent(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "try:\n"
+            "    import something\n"
+            "except builtins.ImportError:\n"
+            "    pass\n"
+            "\n"
+            "def foo():\n"
+            "    pass\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    # ------------------------------------------------------------------
+    # Blocker 3: nested-class duplicate methods must fire
+    # ------------------------------------------------------------------
+
+    def test_nested_class_duplicate_methods_fire(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        def run(self): ...\n"
+            "        def run(self): ...\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "run"
+        assert dups[0].scope == "class Outer.Inner"
+        assert dups[0].lines == [3, 4]
+
+    # ------------------------------------------------------------------
+    # Scope-parity corpus: one case per claimed scope, verdicts pinned
+    # ------------------------------------------------------------------
+
+    def test_scope_parity_corpus(self, tmp_path):
+        cases = {
+            "module_plain_duplicate": (
+                "def foo():\n    pass\ndef foo():\n    pass\n",
+                [("module", "foo", [1, 3])],
+            ),
+            "module_if_body_vs_module": (
+                "def foo():\n    pass\nif True:\n    def foo():\n        pass\n",
+                [("module", "foo", [1, 4])],
+            ),
+            "module_if_else_silent": (
+                "if True:\n    def foo():\n        pass\nelse:\n    def foo():\n        pass\n",
+                [],
+            ),
+            "module_elif_chain_silent": (
+                "if a:\n    def h(): ...\nelif b:\n    def h(): ...\nelse:\n    def h(): ...\n",
+                [],
+            ),
+            "module_try_except_else_silent": (
+                "try:\n    def s(): ...\nexcept ValueError:\n    def s(): ...\nelse:\n    def s(): ...\n",
+                [],
+            ),
+            "class_method_duplicate": (
+                "class C:\n    def m(self): ...\n    def m(self): ...\n",
+                [("class C", "m", [2, 3])],
+            ),
+            "nested_class_method_duplicate": (
+                "class Outer:\n    class Inner:\n        def m(self): ...\n        def m(self): ...\n",
+                [("class Outer.Inner", "m", [3, 4])],
+            ),
+            "closure_in_one_parent_duplicate": (
+                "def outer():\n    def inner(): pass\n    def inner(): pass\n    return inner\n",
+                [("module > outer", "inner", [2, 3])],
+            ),
+            "closure_in_different_parents_silent": (
+                "def a():\n    def inner(): pass\ndef b():\n    def inner(): pass\n",
+                [],
+            ),
+            "overload_pair_silent": (
+                "from typing import overload\n@overload\ndef f(x: str) -> str: ...\n@overload\ndef f(x: int) -> int: ...\ndef f(x): return x\n",
+                [],
+            ),
+            "property_accessors_silent": (
+                "class C:\n    @property\n    def x(self): return 1\n    @x.setter\n    def x(self, v): pass\n",
+                [],
+            ),
+            "import_error_fallback_silent": (
+                "try:\n    import something\nexcept ImportError:\n    pass\n\ndef foo(): pass\n",
+                [],
+            ),
+            "module_not_found_error_fallback_silent": (
+                "try:\n    import something\nexcept ModuleNotFoundError:\n    pass\n\ndef foo(): pass\n",
+                [],
+            ),
+            "platform_if_else_silent": (
+                "import sys\nif sys.platform == 'win32':\n    def p(): ...\nelse:\n    def p(): ...\n",
+                [],
+            ),
+        }
+        for name, (src, expected) in cases.items():
+            f = tmp_path / f"{name}.py"
+            f.write_text(src)
+            dups = _duplicate_definitions(f)
+            actual = [(d.scope, d.name, d.lines) for d in dups]
+            assert actual == expected, f"case {name!r}: got {actual}, want {expected}"
+
+
+# ------------------------------------------------------------------
 # integration tests with a temporary repo
-# ----------------------------------------------------------------------
+# ------------------------------------------------------------------
+
 
 def _init_repo(tmp_path, module_rel: str, content: str):
     repo = tmp_path / "repo"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #328: the carry-forward landed and none of the three fixes did

Autonomous build of board card tsk-2ohqj4.

- Sibling arms of the same if/elif/else chain and try/except/else block no
  longer collide; a def in an arm still collides with a def at module level
- Accept ModuleNotFoundError and builtins.ImportError as legitimate import
  fallback spellings alongside bare ImportError
- Recurse into nested classes so class Outer.Inner duplicate methods fire
- Add scope-parity corpus test pinning every claimed scope and verdict
- Add changelog fragment for tsk-2ohqj4

Files:
 .../tsk-2ohqj4-normalise-handle-gate-fixes.md      |   2 +
 scripts/normalise_handle_gate.py                   | 218 ++++++++++++--
 tests/test_normalise_handle_gate.py                | 323 ++++++++++++++++++++-
 3 files changed, 518 insertions(+), 25 deletions(-)