### PR TITLE
Revise PR #330: the scope was never widened, the citation was never fixed, and the de-marking added a third live marker

### DIFF
--- a/changelog.d/tsk-ilz33f-witness-gate-rev.md
+++ b/changelog.d/tsk-ilz33f-witness-gate-rev.md
@@ -1,0 +1,8 @@
+### Fixed
+- Widened the witness-token gate scan to include ``scripts/**/*.py`` so that
+  witness markers in gate scripts are checked, closing the gap where a cited
+  constant in ``scripts/`` was never verified. Fixed the sibling-gate citation in
+  the docstring from ``normalise_handle_gate.py`` (which also scans ``tests/``)
+  to ``check_deleted_symbols.py`` (which is ``taosmd/``-only, matching the
+  exclusion). De-marked illustrative marker examples in the gate docstring and
+  the test module docstring so the live-marker count is 0.

--- a/scripts/check_witness_token.py
+++ b/scripts/check_witness_token.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Witness token gate.
 
-Verifies that every explicit ``# WITNESS: <test>::<token>`` marker in a source
+Verifies that every explicit ``# WITNESS​: <test>::<token>`` marker in a source
 file resolves to something real INSIDE the named test: the referenced test file
 must exist and ``<token>`` must appear in it as a case-sensitive substring (grep
 semantics).
@@ -16,7 +16,7 @@ test-filename mention in ordinary prose.
 
 Marker contract (the only thing that triggers the check):
 
-    # WITNESS: tests/test_foo.py::some_grepable_token
+    # WITNESS​: tests/test_foo.py::some_grepable_token
 
 - The ``WITNESS:`` marker is all-caps and opt-in. A bare mention of a test
   filename in prose -- whether describing a removal or stating a fact --
@@ -31,10 +31,12 @@ Marker contract (the only thing that triggers the check):
 - The token is matched as a case-sensitive substring, the same match ``grep``
   would perform.
 
-Scope: ``taosmd/**/*.py``. Witnesses are declared in source, not in tests --
-scanning ``tests/`` for markers would let a test's own example markers (which
-name fixture trees that do not exist in the checked-out repo) produce false
-violations. The sibling normalise-handle gate uses the same ``taosmd/`` scope.
+Scope: ``taosmd/**/*.py`` and ``scripts/**/*.py``. Witnesses are declared in
+source, not in tests -- the suite embeds fixture markers as f-strings
+(e.g. ``f"# WITNESS​: {TEST}::{TOK}"``) whose interpolated names never
+resolve to real files, so scanning ``tests/`` would produce false violations.
+The sibling ``check_deleted_symbols.py`` gate follows the same pattern: it
+restricts to ``taosmd/`` only, excluding ``tests/``.
 
 An optional ``WITNESS_GATE_ROOT`` environment variable overrides the repo root
 the gate scans (defaulting to the tree containing this script). This lets the
@@ -119,7 +121,10 @@ def _read_text(path: Path) -> str:
 
 
 def _source_files(repo_root: Path) -> list[Path]:
-    return sorted(set(repo_root.glob("taosmd/**/*.py")))
+    return sorted(
+        set(repo_root.glob("taosmd/**/*.py"))
+        | set(repo_root.glob("scripts/**/*.py"))
+    )
 
 
 def _check_claim(

--- a/tests/test_witness_gate.py
+++ b/tests/test_witness_gate.py
@@ -2,7 +2,7 @@
 
 Proves the witness-token gate in both directions:
 
-* RED, motivating: a source file declares ``# WITNESS: <test>::<token>`` but the
+* RED, motivating: a source file declares ``# WITNESS​: <test>::<token>`` but the
   token is absent from that test -- the gate exits non-zero and names the source
   file, the test and the token.
 * RED, non-vacuity: the passing case (token present) passes, then ONLY the token
@@ -11,6 +11,9 @@ Proves the witness-token gate in both directions:
 * GREEN, true positive: a declared witness whose token IS present exits 0.
 * GREEN, false positive: a source file that merely mentions a test filename in
   ordinary prose, with no ``WITNESS:`` marker, is not flagged.
+
+The same controls are repeated for ``scripts/`` source files, verifying that
+the widened scope catches witnesses declared outside ``taosmd/``.
 """
 from __future__ import annotations
 
@@ -35,6 +38,7 @@ GATE_SCRIPT = REPO_ROOT / "scripts" / "check_witness_token.py"
 TEST_SRC = "taosmd/svc.py"
 TEST_TEST = "tests/test_foo.py"
 TOKEN = "MAX_FIRE_TO_DELETE"
+SCRIPTS_SRC = "scripts/gate_demo.py"
 
 GREEN_SRC = (
     "# Constants justified by a live witness in the suite.\n"
@@ -249,6 +253,54 @@ class TestWitnessGateIntegration:
         _write(repo, "taosmd/prose.py", PROSE_SRC)
         # No WITNESS marker anywhere; the prose mention of the test filename
         # must not be treated as a declaration.
+        assert check_witnesses(repo) == []
+        rc, out = _run_main(repo)
+        assert rc == 0
+        assert "witness-gate: clean" in out
+
+    def test_scripts_scope_red_absent_token(self, tmp_path):
+        repo = _repo(tmp_path)
+        _write(repo, SCRIPTS_SRC, f"# WITNESS: {TEST_TEST}::{TOKEN}\nVALUE = 1\n")
+        _write(repo, TEST_TEST, RED_TEST)
+
+        violations = check_witnesses(repo)
+        assert len(violations) == 1
+        assert violations[0].claim.source_file == SCRIPTS_SRC
+        assert violations[0].claim.test_file == TEST_TEST
+        assert violations[0].claim.token == TOKEN
+        assert "not found" in violations[0].reason
+
+        rc, out = _run_main(repo)
+        assert rc == 1
+        assert "WITNESS GATE FAIL" in out
+        assert SCRIPTS_SRC in out
+
+    def test_scripts_scope_green_present_token(self, tmp_path):
+        repo = _repo(tmp_path)
+        _write(repo, SCRIPTS_SRC, f"# WITNESS: {TEST_TEST}::{TOKEN}\nVALUE = 1\n")
+        _write(repo, TEST_TEST, GREEN_TEST)
+        _run_main_clean(repo)
+
+    def test_scripts_scope_non_vacuity(self, tmp_path):
+        repo = _repo(tmp_path)
+        _write(repo, SCRIPTS_SRC, f"# WITNESS: {TEST_TEST}::{TOKEN}\nVALUE = 1\n")
+        _write(repo, TEST_TEST, GREEN_TEST)
+
+        # GREEN baseline: token present -> clean.
+        _run_main_clean(repo)
+
+        # Delete ONLY the token; file stays present and importable.
+        _write(repo, TEST_TEST, RED_TEST)
+        violations = check_witnesses(repo)
+        assert len(violations) == 1
+        assert violations[0].claim.token == TOKEN
+
+        rc, _out = _run_main(repo)
+        assert rc == 1
+
+    def test_green_prose_in_scripts(self, tmp_path):
+        repo = _green_repo(tmp_path)
+        _write(repo, "scripts/prose_demo.py", PROSE_SRC)
         assert check_witnesses(repo) == []
         rc, out = _run_main(repo)
         assert rc == 0


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #330: the scope was never widened, the citation was never fixed, and the de-marking added a third live marker

Autonomous build of board card tsk-ilz33f.

PR #330 claimed three changes but delivered only one: a docstring
rewording that actually increased the live-marker count from 2 to 3.
This revision fixes all three blockers:

- Widen _source_files() to scan scripts/**/*.py alongside taosmd/**/*.py,
  closing the gap where witness markers in gate scripts were never verified.
- Correct the sibling-gate citation from normalise_handle_gate.py (which
  also scans tests/) to check_deleted_symbols.py (which is taosmd/-only,
  matching the exclusion). State the real reason tests/ is excluded:
  fixture markers built as f-strings whose names do not resolve to files.
- De-mark every illustrative WITNESS example in the gate docstring (L4,
  L19) and the test module docstring (L5) with a zero-width space between
  WITNESS and :, so the gate's own regex reports 0 live-marker matches.

Add RED, GREEN, and non-vacuity controls for the scripts/ scope. Full
suite: 1505 passed, 12 skipped (master baseline was 1501 passed, 12
skipped; the 4 new tests account for the delta).

Files:
 changelog.d/tsk-ilz33f-witness-gate-rev.md |  8 +++++
 scripts/check_witness_token.py             | 19 +++++++----
 tests/test_witness_gate.py                 | 54 +++++++++++++++++++++++++++++-
 3 files changed, 73 insertions(+), 8 deletions(-)