### PR TITLE
Witness gate: a de-marked marker fails silently, and the scripts/ widening currently verifies nothing

### DIFF
--- a/changelog.d/tsk-g4jjtp-witness-gate-de-marked.md
+++ b/changelog.d/tsk-g4jjtp-witness-gate-de-marked.md
@@ -1,0 +1,6 @@
+### Fixed
+- The witness-token gate now reports de-marked or malformed ``# WITNESS``
+  markers as violations instead of silently ignoring them. The gate's own
+  docstring examples are explicitly exempted via a named exclusion. A
+  maintainer who copies the documented example with real values now gets a
+  failing gate instead of a silent false-positive.

--- a/changelog.d/tsk-ilz33f-witness-gate-rev.md
+++ b/changelog.d/tsk-ilz33f-witness-gate-rev.md
@@ -1,7 +1,8 @@
 ### Fixed
 - Widened the witness-token gate scan to include ``scripts/**/*.py`` so that
-  witness markers in gate scripts are checked, closing the gap where a cited
-  constant in ``scripts/`` was never verified. Fixed the sibling-gate citation in
+  witness markers in gate scripts are checked prospectively, closing the gap
+  where any future marker in ``scripts/`` would not have been verified.
+  Fixed the sibling-gate citation in
   the docstring from ``normalise_handle_gate.py`` (which also scans ``tests/``)
   to ``check_deleted_symbols.py`` (which is ``taosmd/``-only, matching the
   exclusion). De-marked illustrative marker examples in the gate docstring and

--- a/scripts/check_witness_token.py
+++ b/scripts/check_witness_token.py
@@ -38,6 +38,10 @@ resolve to real files, so scanning ``tests/`` would produce false violations.
 The sibling ``check_deleted_symbols.py`` gate follows the same pattern: it
 restricts to ``taosmd/`` only, excluding ``tests/``.
 
+The zero-width space (U+200B) between ``WITNESS`` and ``:`` in the on-disk
+examples above is intentional: it de-marks the docstring examples so they
+are not treated as live markers.
+
 An optional ``WITNESS_GATE_ROOT`` environment variable overrides the repo root
 the gate scans (defaulting to the tree containing this script). This lets the
 gate target an arbitrary checkout, a staged tree, or a fixture directory -- useful
@@ -59,6 +63,11 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 REPO_ROOT = Path(os.environ.get("WITNESS_GATE_ROOT") or _REPO_ROOT)
 WITNESS_RE = re.compile(r"#\s*WITNESS:\s*(.+)$")
+_NEAR_MISS_RE = re.compile(r"#\s*WITNESS[^:]")
+# Files whose docstrings contain de-marked illustrative examples. Greppable name.
+_DEMARKED_MARKER_EXEMPTION = frozenset({
+    "scripts/check_witness_token.py",
+})
 
 
 @dataclass
@@ -109,6 +118,24 @@ def _extract_claims(file_path: Path, repo_root: Path) -> list[WitnessClaim]:
     return claims
 
 
+def _check_near_misses(file_path: Path, repo_root: Path) -> list[Violation]:
+    rel = _relative_source(file_path, repo_root)
+    if rel in _DEMARKED_MARKER_EXEMPTION:
+        return []
+    try:
+        source = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    violations: list[Violation] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if _NEAR_MISS_RE.search(line):
+            claim = WitnessClaim(
+                source_file=rel, line_number=lineno, raw=line.strip()
+            )
+            violations.append(Violation(claim, "de-marked or malformed marker"))
+    return violations
+
+
 def _resolve_test_file(test_file: str, repo_root: Path) -> Path | None:
     candidate = repo_root / test_file
     if candidate.is_file():
@@ -157,6 +184,7 @@ def check_witnesses(repo_root: Path = REPO_ROOT) -> list[Violation]:
     violations: list[Violation] = []
     contents: dict[Path, str] = {}
     for source in _source_files(repo_root):
+        violations.extend(_check_near_misses(source, repo_root))
         for claim in _extract_claims(source, repo_root):
             violation = _check_claim(claim, repo_root, contents)
             if violation is not None:

--- a/tests/test_witness_gate.py
+++ b/tests/test_witness_gate.py
@@ -306,6 +306,32 @@ class TestWitnessGateIntegration:
         assert rc == 0
         assert "witness-gate: clean" in out
 
+    def test_de_marked_example_exits_nonzero(self, tmp_path):
+        repo = _repo(tmp_path)
+        _write(repo, TEST_TEST, GREEN_TEST)
+        _write(repo, TEST_SRC, f"# WITNESS\u200b: {TEST_TEST}::{TOKEN}\n")
+        violations = check_witnesses(repo)
+        assert len(violations) == 1
+        assert violations[0].reason == "de-marked or malformed marker"
+        rc, out = _run_main(repo)
+        assert rc == 1
+        assert "de-marked or malformed marker" in out
+
+    def test_near_miss_in_scripts_detected(self, tmp_path):
+        repo = _repo(tmp_path)
+        _write(repo, TEST_TEST, GREEN_TEST)
+        _write(
+            repo,
+            "scripts/near_miss_demo.py",
+            f"# WITNESS {TEST_TEST}::{TOKEN}\nVALUE = 1\n",
+        )
+        violations = check_witnesses(repo)
+        assert len(violations) == 1
+        assert violations[0].reason == "de-marked or malformed marker"
+        assert violations[0].claim.source_file == "scripts/near_miss_demo.py"
+        rc, out = _run_main(repo)
+        assert rc == 1
+
 
 # ----------------------------------------------------------------------
 # CLI subprocess tests: prove the real script exit codes (Layer A path)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Witness gate: a de-marked marker fails silently, and the scripts/ widening currently verifies nothing

Autonomous build of board card tsk-g4jjtp.

- Add near-miss regex and named exemption for gate docstring examples
- De-marked or malformed WITNESS markers now exit non-zero
- Docstring discloses U+200B and why it is there
- Changelog wording says widening is prospective, not retrospective

Files:
 changelog.d/tsk-g4jjtp-witness-gate-de-marked.md |  6 +++++
 changelog.d/tsk-ilz33f-witness-gate-rev.md       |  5 +++--
 scripts/check_witness_token.py                   | 28 ++++++++++++++++++++++++
 tests/test_witness_gate.py                       | 26 ++++++++++++++++++++++
 4 files changed, 63 insertions(+), 2 deletions(-)