### PR TITLE
normalise-handle gate: classes defined inside a closure are skipped, so duplicate handle-normalisers in a function body are invisible

### DIFF
--- a/changelog.d/tsk-lvxars-closure-class-scan.md
+++ b/changelog.d/tsk-lvxars-closure-class-scan.md
@@ -1,0 +1,2 @@
+### Fixed
+- The duplicate-definition gate now descends into classes defined inside a function body (`factory` closures) instead of skipping them, so a redefined class within one closure is reported while the same class name in different closures still does not collide. The `if`/`elif`/`else` and `try`/`except` sibling-arm behaviour is unchanged.

--- a/scripts/normalise_handle_gate.py
+++ b/scripts/normalise_handle_gate.py
@@ -15,12 +15,17 @@ skipped with a warning rather than allowed to crash the gate.
 Definitions inside module-level ``if`` / ``try`` / ``for`` / ``while`` /
 ``with`` blocks are treated as module-scope, matching Python's binding rules.
 Same-name closures inside one parent function are also reported; same-name
-closures in different parents remain legal.  Sibling arms of the same
+closures in different parents remain legal.  Classes defined inside a function
+body are descended into as well: their methods are scoped under the enclosing
+closure (``module > factory > class Foo``), so a redefined class within one
+closure is reported while the same class name in different closures does not
+collide.  Sibling arms of the same
 ``if`` / ``elif`` / ``else`` chain and the ``body`` / ``handlers`` /
 ``orelse`` arms of one ``try`` statement are mutually exclusive and do not
 collide.  The ``try:`` / ``except ImportError:`` and ``except
 ModuleNotFoundError:`` fallback patterns are recognised and left silent.
-Nested classes are scanned at any depth.
+Nested classes are scanned at any depth, including those defined inside a
+function body.
 """
 from __future__ import annotations
 
@@ -151,19 +156,21 @@ def _collect_definitions(
                 )
             )
         elif isinstance(node, ast.ClassDef):
-            if " > " not in scope:
-                new_class_path = class_path + (node.name,)
+            new_class_path = class_path + (node.name,)
+            if scope.startswith("class ") or scope == "module":
                 new_scope = "class " + ".".join(new_class_path)
-                found.extend(
-                    _collect_definitions(
-                        node.body,
-                        new_scope,
-                        new_class_path,
-                        in_try=False,
-                        in_import_error_except=False,
-                        arm_tracker=None,
-                    )
+            else:
+                new_scope = f"{scope} > class {node.name}"
+            found.extend(
+                _collect_definitions(
+                    node.body,
+                    new_scope,
+                    new_class_path,
+                    in_try=False,
+                    in_import_error_except=False,
+                    arm_tracker=None,
                 )
+            )
         elif isinstance(
             node,
             (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith),

--- a/tests/test_normalise_handle_gate.py
+++ b/tests/test_normalise_handle_gate.py
@@ -20,7 +20,11 @@ Proves the duplicate-definition gate (the successor to the narrow
 - The ``try:`` / ``except ImportError:``, ``except ModuleNotFoundError:``,
   and ``except builtins.ImportError:`` fallback patterns are recognised and
   left silent.
-- Nested classes are scanned at any depth.
+- Nested classes are scanned at any depth, with the correct ``class Outer.Inner``
+  scope string.
+- Classes defined inside a function body are scanned: a redefined class within
+  one closure is reported under ``module > factory > class Foo``, while the same
+  class name in different closures does not collide.
 - Files that cannot be decoded as UTF-8 are skipped with a warning, and
   files that fail to parse are left silent.
 """
@@ -482,6 +486,81 @@ class TestDuplicateDefinitions:
         assert dups[0].lines == [3, 4]
 
     # ------------------------------------------------------------------
+    # Blocker 4: classes defined inside a function body (closures)
+    # ------------------------------------------------------------------
+
+    def test_redefined_class_inside_closure_is_reported(self, tmp_path):
+        """A class re-defined within one closure is a genuine duplicate the gate
+        must catch.  Before the closure-class fix this was invisible."""
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def factory():\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "_normalise_handle"
+        assert dups[0].scope == "module > factory > class Foo"
+        assert dups[0].lines == [3, 5]
+
+    def test_distinct_classes_inside_closure_are_silent(self, tmp_path):
+        """Two distinct class names in one closure do not collide, matching
+        module-level class semantics."""
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def factory():\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+            "    class Bar:\n"
+            "        def _normalise_handle(self): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_same_class_name_in_different_closures_are_silent(self, tmp_path):
+        """The closure name qualifies the class scope, so the same class name
+        in two separate closures does not produce a false duplicate."""
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def a():\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+            "def b():\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_class_inside_closure_does_not_collide_with_module_class(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "class Foo:\n"
+            "    def _normalise_handle(self): ...\n"
+            "def factory():\n"
+            "    class Foo:\n"
+            "        def _normalise_handle(self): ...\n"
+        )
+        assert _duplicate_definitions(f) == []
+
+    def test_closure_class_scanned_at_any_depth(self, tmp_path):
+        """A nested class inside a closure-class is descended into."""
+        f = tmp_path / "mod.py"
+        f.write_text(
+            "def factory():\n"
+            "    class Foo:\n"
+            "        class Inner:\n"
+            "            def run(self): ...\n"
+            "            def run(self): ...\n"
+        )
+        dups = _duplicate_definitions(f)
+        assert len(dups) == 1
+        assert dups[0].name == "run"
+        assert dups[0].scope == "module > factory > class Foo > class Inner"
+        assert dups[0].lines == [4, 5]
+
+    # ------------------------------------------------------------------
     # Scope-parity corpus: one case per claimed scope, verdicts pinned
     # ------------------------------------------------------------------
 
@@ -521,6 +600,37 @@ class TestDuplicateDefinitions:
             ),
             "closure_in_different_parents_silent": (
                 "def a():\n    def inner(): pass\ndef b():\n    def inner(): pass\n",
+                [],
+            ),
+            "closure_class_redefinition_duplicate": (
+                (
+                    "def factory():\n"
+                    "    class Foo:\n"
+                    "        def _normalise_handle(self): ...\n"
+                    "    class Foo:\n"
+                    "        def _normalise_handle(self): ...\n"
+                ),
+                [("module > factory > class Foo", "_normalise_handle", [3, 5])],
+            ),
+            "closure_distinct_classes_silent": (
+                (
+                    "def factory():\n"
+                    "    class Foo:\n"
+                    "        def _normalise_handle(self): ...\n"
+                    "    class Bar:\n"
+                    "        def _normalise_handle(self): ...\n"
+                ),
+                [],
+            ),
+            "closure_same_class_different_parents_silent": (
+                (
+                    "def a():\n"
+                    "    class Foo:\n"
+                    "        def _normalise_handle(self): ...\n"
+                    "def b():\n"
+                    "    class Foo:\n"
+                    "        def _normalise_handle(self): ...\n"
+                ),
                 [],
             ),
             "overload_pair_silent": (


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): normalise-handle gate: classes defined inside a closure are skipped, so duplicate handle-normalisers in a function body are invisible

Autonomous build of board card tsk-lvxars.

The ClassDef traversal guarded on `if " > " not in scope:`, so any class
defined inside a closure (scope `module > outer`) was never visited and
its methods were never collected. A redefined class within one closure
was therefore invisible.

Descend unconditionally and qualify the class scope with the enclosing
closure (`module > outer > class Foo`) so a redefined class in one closure
still collides, while the same class name in different closures does not.
Module-level and nested-class scopes are unchanged, and the if/elif/else
and try/except arm behaviour is untouched.

Closes tsk-lvxars.

Files:
 changelog.d/tsk-lvxars-closure-class-scan.md |   2 +
 scripts/normalise_handle_gate.py             |  33 ++++----
 tests/test_normalise_handle_gate.py          | 112 ++++++++++++++++++++++++++-
 3 files changed, 133 insertions(+), 14 deletions(-)