### PR TITLE
benchmarks/data/README.md pins a size and sha256 for longmemeval_s_full.json that nothing on this box can verify, and no card tracked it

### DIFF
--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -16,16 +16,24 @@ before trusting a published number.
   `fusion_shootout.py`, `longmemeval_matrix.py`, `variations_sweep.py`.
   It is the source of the published 97.0% Recall@5 headline
   (see `benchmarks/REPRODUCE-longmemeval.md`).
-- Size: 277383467 bytes (about 265 MiB).
+- Byte size: 277383467 bytes (about 265 MiB) -- NOT YET PINNED, no verified
+  copy located on this machine; retained from prior documentation. Run
+  `stat -c %s benchmarks/data/longmemeval_s_full.json` to confirm.
 - Question count: 500.
 - sha256: `d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442`
+  -- NOT YET PINNED, no copy has been hashed on this machine; obtain the
+  file from the upstream LongMemEval project and run
+  `shasum -a 256 benchmarks/data/longmemeval_s_full.json` to verify.
 
-To verify a copy:
+To verify a copy when available:
 
 ```bash
 shasum -a 256 benchmarks/data/longmemeval_s_full.json
-# expect: d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442
 ```
+
+*(Note: this file does not currently exist on this machine. No copy has been
+located to confirm the size or checksum above. Obtain from the upstream LongMemEval
+project and confirm the checksum before use.)*
 
 ### How to obtain it
 

--- a/changelog.d/tsk-r44fqf-unverify-s-full-pin.md
+++ b/changelog.d/tsk-r44fqf-unverify-s-full-pin.md
@@ -1,0 +1,2 @@
+### Fixed
+- Marked `longmemeval_s_full.json` size and sha256 pins as NOT YET PINNED in `benchmarks/data/README.md` (unverified on this machine, no copy located to confirm them; numbers retained for future verification), matching the explicit style already used for `longmemeval_s_cleaned.json`


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): benchmarks/data/README.md pins a size and sha256 for longmemeval_s_full.json that nothing on this box can verify, and no card tracked it

Autonomous build of board card tsk-r44fqf.

The size and sha256 are unverified on this machine (find returned 0 hits
for longmemeval_s_full.json). Retain the claimed values but mark them
NOT YET PINNED, matching the explicit style already used for
longmemeval_s_cleaned.json. Show the stat and shasum commands a future
reader should run to verify.

Files:
 taosmd/mentions.py                                 |  92 +++
 taosmd/remote.py                                   |  20 +
 taosmd/service.py                                  | 168 +++++-
 tests/test_a2a_mentions.py                         | 646 +++++++++++++++++++++
 tests/test_api.py                                  | 292 +++++++++-
 tests/test_collections_ingest.py                   | 148 +++++
 tests/test_normalise_handle_gate.py                | 162 ++++++
 24 files changed, 1863 insertions(+), 38 deletions(-)