### PR TITLE
Revise PR #352: the docstring fix is correct, but it conflicts and the README half of the card is not in the diff at all

### DIFF
--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -41,13 +41,13 @@ canonical pinned copy is also kept on the project bench host under the repo's
   `benchmarks/longmemeval_runner.py`, `benchmarks/recall_v2_benchmark.py`,
   and `benchmarks/longmemeval_recall.py`. Each question has a haystack of
   conversation sessions and the gold answer session ids.
-- Byte size: 15388478 bytes (about 14.7 MiB), measured with `stat -c %s`
+- Byte size: 15388478 bytes (about 14.7 MiB), measured with `stat -c %s`.
 - sha256: `821a2034d219ab45846873dd14c14f12cfe7776e73527a483f9dac095d38620c`
   (64 hex, valid). Verify with: `shasum -a 256 benchmarks/data/longmemeval_oracle.json`
-- Question count: 500
+- Question count: 500.
 - The oracle variant has evidence-only haystacks (haystack_session_ids ==
-  answer_session_ids EXACTLY for all 500 questions), making it 15 MB against
-  `longmemeval_s_full.json`'s claimed 277 MB. The relationship between this
+  answer_session_ids EXACTLY for all 500 questions), making it 15 MiB against
+  `longmemeval_s_full.json`'s claimed 277 MiB. The relationship between this
   file and `longmemeval_s_full.json` is not verified here, as
   `longmemeval_s_full.json` does not exist on this machine.
 - How to obtain it: Get the LongMemEval-S oracle set from the upstream LongMemEval

--- a/changelog.d/tsk-lkctqr-docstring-readme-newline.md
+++ b/changelog.d/tsk-lkctqr-docstring-readme-newline.md
@@ -1,0 +1,4 @@
+### Fixed
+- Resolved the docstring conflict in `scripts/normalise_handle_gate.py` in favour of the PR #352 wording, joining the split `function body.` line so no docstring line starts with a space.
+- Restored the trailing newline on `benchmarks/data/README.md` (last byte `0x0a`).
+- Fixed two missing terminal periods and replaced mixed `MB`/`MiB` units with `MiB` throughout `benchmarks/data/README.md`.

--- a/scripts/normalise_handle_gate.py
+++ b/scripts/normalise_handle_gate.py
@@ -25,8 +25,7 @@ collide.  Sibling arms of the same
 collide.  The ``try:`` / ``except ImportError:`` and ``except
 ModuleNotFoundError:`` fallback patterns are therefore left silent by the
 same sibling-arm rule, since at most one arm ever binds.
-Nested classes are scanned at any depth, including those defined inside a
- function body.
+Nested classes are scanned at any depth, including those defined inside a function body.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #352: the docstring fix is correct, but it conflicts and the README half of the card is not in the diff at all

Autonomous build of board card tsk-lkctqr.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 benchmarks/data/README.md                          | 10 +++++-----
 changelog.d/tsk-lkctqr-docstring-readme-newline.md |  4 ++++
 scripts/normalise_handle_gate.py                   |  3 +--
 3 files changed, 10 insertions(+), 7 deletions(-)