### PR TITLE
Revise PR #358: everything lands except one figure -- unifying the units to MiB relabelled 277 MB as 277 MiB without reconverting, and my own card did not say which direction to unify

### DIFF
--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -54,8 +54,8 @@ canonical pinned copy is also kept on the project bench host under the repo's
   (64 hex, valid). Verify with: `shasum -a 256 benchmarks/data/longmemeval_oracle.json`
 - Question count: 500
 - The oracle variant has evidence-only haystacks (haystack_session_ids ==
-  answer_session_ids EXACTLY for all 500 questions), making it 15 MB against
-  `longmemeval_s_full.json`'s claimed 277 MB. The relationship between this
+  answer_session_ids EXACTLY for all 500 questions), making it 14.7 MiB against
+  `longmemeval_s_full.json`'s claimed 265 MiB. The relationship between this
   file and `longmemeval_s_full.json` is not verified here, as
   `longmemeval_s_full.json` does not exist on this machine.
 - How to obtain it: Get the LongMemEval-S oracle set from the upstream LongMemEval

--- a/changelog.d/tsk-vghh6c-unify-mib-mb-units.md
+++ b/changelog.d/tsk-vghh6c-unify-mib-mb-units.md
@@ -1,0 +1,2 @@
+### Fixed
+- Unified MiB/MB units in `benchmarks/data/README.md`: changed `15 MB` to `14.7 MiB` and `277 MB` to `265 MiB` so both figures use MiB and agree with byte counts


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #358: everything lands except one figure -- unifying the units to MiB relabelled 277 MB as 277 MiB without reconverting, and my own card did not say which direction to unify

Autonomous build of board card tsk-vghh6c.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 benchmarks/data/README.md                    | 4 ++--
 changelog.d/tsk-vghh6c-unify-mib-mb-units.md | 2 ++
 2 files changed, 4 insertions(+), 2 deletions(-)