### PR TITLE
resume_arm_time.py emits a crontab line naming whatever checkout ran it, so arming from a worktree pins a path that will be deleted

### DIFF
--- a/changelog.d/tsk-bxdfvz-helper-path-guard.md
+++ b/changelog.d/tsk-bxdfvz-helper-path-guard.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `scripts/resume_arm_time.py` now refuses to emit the system-crontab block when `_HELPER_PATH` resolves under a temp directory or inside a linked git worktree, naming the reason instead of pinning an ephemeral path that would orphan the self-removal cron line.

--- a/scripts/resume_arm_time.py
+++ b/scripts/resume_arm_time.py
@@ -54,6 +54,8 @@ import subprocess
 import sys
 import time
 
+_HELPER_PATH = os.path.realpath(__file__)
+
 # The two tunables, each stating WHAT IT IS A FUNCTION OF. That is the whole point of
 # this file: a constant whose dependency is unnamed is the bug it exists to prevent.
 #
@@ -497,14 +499,52 @@ def retry_after(primary_fire, minutes, margin, lead=RETRY_LEAD_SECONDS):
     )
 
 
+def _is_under_temp(path):
+    temp_roots = ("/tmp", "/var/tmp", "/private/var/folders", "/var/folders")
+    for root in temp_roots:
+        if path == root or path.startswith(root + os.sep):
+            return root
+    return None
+
+
+def _is_in_linked_worktree(path):
+    parent = os.path.dirname(os.path.abspath(path))
+    while parent and parent != os.path.dirname(parent):
+        git_dir = os.path.join(parent, ".git")
+        if os.path.exists(git_dir):
+            if os.path.isfile(git_dir):
+                return parent
+            return None
+        parent = os.path.dirname(parent)
+    return None
+
+
+def _validate_helper_path():
+    path = _HELPER_PATH
+    tmp = _is_under_temp(path)
+    if tmp:
+        raise SystemExit(
+            f"FAIL: {_HELPER_PATH} resolves under a temp directory ({tmp}).\n"
+            "A cron line armed from a temp checkout cannot self-delete when the\n"
+            "directory is cleaned up. REFUSING to emit."
+        )
+    wt = _is_in_linked_worktree(path)
+    if wt:
+        raise SystemExit(
+            f"FAIL: {_HELPER_PATH} is inside a git worktree ({wt}).\n"
+            "Worktree checkouts are ephemeral; the cron line would pin a path\n"
+            "that vanishes when the worktree is removed. REFUSING to emit."
+        )
+
+
 def system_crontab_block(primary_fire, retry_fire):
     """System crontab lines for the resume pair, with self-deletion and path-precise markers."""
     p_min, p_hou, p_dy, p_mo = cron_fields(primary_fire)
     r_min, r_hou, r_dy, r_mo = cron_fields(retry_fire)
     p_ts = primary_fire.strftime("%Y%m%d%H%M")
     r_ts = retry_fire.strftime("%Y%m%d%H%M")
-    marker_prefix = "/home/jay/.taos-fleet-tools/resume_arm_time.py#"
-    helper = "/home/jay/.taos-fleet-tools/resume_arm_time.py"
+    marker_prefix = _HELPER_PATH + "#"
+    helper = _HELPER_PATH
 
     lines = [
         "SYSTEM CRONTAB (durable, survives session death):",
@@ -539,7 +579,7 @@ def do_fire(fire_type, timestamp_str):
         )
 
     ts = timestamp.strftime("%Y%m%d%H%M")
-    marker = f"/home/jay/.taos-fleet-tools/resume_arm_time.py#{fire_type}-{ts}"
+    marker = f"{_HELPER_PATH}#{fire_type}-{ts}"
 
     record = f"[RESUME DUE] {fire_type} fired armed_at={timestamp_str}"
 
@@ -745,6 +785,7 @@ def main():
           "           something in the SYSTEM crontab, outside the component that failed.\n"
           "           If instead you write these lines into a crontab, durability is fine but\n"
           "           recurring=false does not exist there, so re-read the ONE-SHOT line.")
+    _validate_helper_path()
     print(system_crontab_block(fire, r_fire))
 
 

--- a/tests/test_resume_arm_time.py
+++ b/tests/test_resume_arm_time.py
@@ -40,7 +40,7 @@ resume_arm_time = _load_module()
 
 def _marker(fire_type, armed_at):
     ts = datetime.datetime.fromisoformat(armed_at).strftime("%Y%m%d%H%M")
-    return f"/home/jay/.taos-fleet-tools/resume_arm_time.py#{fire_type}-{ts}"
+    return f"{resume_arm_time._HELPER_PATH}#{fire_type}-{ts}"
 
 
 class _Proc:
@@ -111,6 +111,11 @@ def test_canonical_derivation_emits_date_pinned_one_shot(monkeypatch, capsys):
     17 0 18 8 *, a date-pinned one-shot -- not the blocked PR's daily 17 0 * * *."""
     monkeypatch.setenv("TZ", "UTC")
     time.tzset()
+    monkeypatch.setattr(
+        resume_arm_time,
+        "_HELPER_PATH",
+        "/home/jay/.taos-fleet-tools/scripts/resume_arm_time.py",
+    )
     written = []
     monkeypatch.setattr(
         resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, written)
@@ -140,8 +145,8 @@ def test_system_crontab_block_names_usr_bin_python3():
     fire = datetime.datetime(2026, 8, 18, 0, 7, 0, tzinfo=datetime.timezone.utc)
     retry = datetime.datetime(2026, 8, 18, 0, 17, 0, tzinfo=datetime.timezone.utc)
     block = resume_arm_time.system_crontab_block(fire, retry)
-    assert "/usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire primary" in block
-    assert "/usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire retry" in block
+    assert f"/usr/bin/python3 {resume_arm_time._HELPER_PATH} --fire primary" in block
+    assert f"/usr/bin/python3 {resume_arm_time._HELPER_PATH} --fire retry" in block
     # No bare `python3` token (the blocked PR emitted `python3 <path>`).
     assert " python3 " not in block
 
@@ -154,6 +159,52 @@ def test_helper_imports_getpass():
     assert "getpass" in dir(resume_arm_time)
     import getpass as _gp
     assert resume_arm_time.getpass is _gp
+
+
+# --------------------------------------------------------------------------- #
+# Helper-path guard: refuse to emit from a temp or linked-worktree location.
+# --------------------------------------------------------------------------- #
+
+def test_guard_refuses_temp_path(monkeypatch, capsys):
+    """A _HELPER_PATH under /tmp is refused with a named reason."""
+    monkeypatch.setattr(
+        resume_arm_time,
+        "_HELPER_PATH",
+        "/tmp/scratchpad/wt354/scripts/resume_arm_time.py",
+    )
+    monkeypatch.setattr(
+        resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, [])
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["resume_arm_time.py", "2026-08-18T00:00:00+00:00"]
+    )
+    with pytest.raises(SystemExit) as exc:
+        resume_arm_time.main()
+    assert "temp directory" in str(exc.value)
+
+
+def test_guard_refuses_linked_worktree(tmp_path, monkeypatch, capsys):
+    """A _HELPER_PATH inside a linked worktree is refused with a named reason."""
+    fake_wt = Path("/home/jay/Development/fake-wt-for-test")
+    try:
+        fake_wt.mkdir(parents=True, exist_ok=True)
+        (fake_wt / ".git").write_text("gitdir: /some/real/.git/worktrees/fake\n")
+        fake_path = str(fake_wt / "scripts" / "resume_arm_time.py")
+        monkeypatch.setattr(resume_arm_time, "_HELPER_PATH", fake_path)
+        monkeypatch.setattr(
+            resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, [])
+        )
+        monkeypatch.setattr(
+            sys, "argv", ["resume_arm_time.py", "2026-08-18T00:00:00+00:00"]
+        )
+        with pytest.raises(SystemExit) as exc:
+            resume_arm_time.main()
+        assert "git worktree" in str(exc.value)
+    finally:
+        if (fake_wt / ".git").exists():
+            (fake_wt / ".git").unlink()
+        if fake_wt.exists():
+            fake_wt.rmdir()
 
 
 # --------------------------------------------------------------------------- #
@@ -275,7 +326,7 @@ def test_do_fire_runs_as_subprocess(tmp_path, monkeypatch):
     marker = _marker("primary", armed_at)
     initial_crontab = (
         f"# taOSmd-resume: {marker}\n"
-        + f"7 0 18 8 * /usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire primary {armed_at}\n"
+        + f"7 0 18 8 * /usr/bin/python3 {resume_arm_time._HELPER_PATH} --fire primary {armed_at}\n"
         + WATCHER_LINE
     )
     state = _install_fake_crontab(tmp_path, monkeypatch, initial_crontab)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): resume_arm_time.py emits a crontab line naming whatever checkout ran it, so arming from a worktree pins a path that will be deleted

Autonomous build of board card tsk-bxdfvz.



Files:
 changelog.d/tsk-bxdfvz-helper-path-guard.md |  3 ++
 scripts/resume_arm_time.py                  | 47 +++++++++++++++++++++--
 tests/test_resume_arm_time.py               | 59 +++++++++++++++++++++++++++--
 3 files changed, 102 insertions(+), 7 deletions(-)