### PR TITLE
taosmd has no linter at all, so dead imports and style drift are findable only by reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,7 @@ taosmd = "taosmd.cli:main"
 [project.urls]
 Homepage = "https://github.com/jaylfc/taosmd"
 Repository = "https://github.com/jaylfc/taosmd"
+
+[tool.ruff.lint]
+# Pyflakes (F) only: undefined names, unused imports/variables. Deliberately narrow so the linter catches the dead-import drift it was added for, without reformatting the tree or imposing style rules.
+select = ["F"]


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taosmd has no linter at all, so dead imports and style drift are findable only by reading

Autonomous build of board card tsk-lpfgxs.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 pyproject.toml | 4 ++++
 1 file changed, 4 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added linting configuration to enable Pyflakes checks.
  * Improved detection of common Python code issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->