### PR TITLE
The out-of-repo resume_arm_time.py copy is 45 diff-lines behind the canonical one and nothing reconciles them

### DIFF
--- a/changelog.d/tsk-iavmeu-stale-copy-symlink.md
+++ b/changelog.d/tsk-iavmeu-stale-copy-symlink.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Replaced the out-of-repo `resume_arm_time.py` at `/home/jay/.taos-fleet-tools/resume_arm_time.py` with a symlink to the canonical repo copy at `scripts/resume_arm_time.py`, ensuring `do_fire` always posts `[RESUME DUE]` to the A2A bus and never silently falls back to the old "log and remove" implementation.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The out-of-repo resume_arm_time.py copy is 45 diff-lines behind the canonical one and nothing reconciles them

Autonomous build of board card tsk-iavmeu.



Files:
 changelog.d/tsk-iavmeu-stale-copy-symlink.md | 3 +++
 1 file changed, 3 insertions(+)