### PR TITLE
Two of the four resume_arm_time tests #354 touched pass against a hardcoded _HELPER_PATH, so they check symbol existence rather than path derivation

### DIFF
--- a/scripts/resume_arm_time.py
+++ b/scripts/resume_arm_time.py
@@ -53,6 +53,10 @@ import re
 import subprocess
 import sys
 import time
+from pathlib import Path
+
+# SCRIPT is a module-level constant representing the path to this script itself
+SCRIPT = Path(__file__).resolve()
 
 # The two tunables, each stating WHAT IT IS A FUNCTION OF. That is the whole point of
 # this file: a constant whose dependency is unnamed is the bug it exists to prevent.
@@ -503,8 +507,8 @@ def system_crontab_block(primary_fire, retry_fire):
     r_min, r_hou, r_dy, r_mo = cron_fields(retry_fire)
     p_ts = primary_fire.strftime("%Y%m%d%H%M")
     r_ts = retry_fire.strftime("%Y%m%d%H%M")
-    marker_prefix = "/home/jay/.taos-fleet-tools/resume_arm_time.py#"
-    helper = "/home/jay/.taos-fleet-tools/resume_arm_time.py"
+    marker_prefix = f"{SCRIPT}#"
+    helper = str(SCRIPT)
 
     lines = [
         "SYSTEM CRONTAB (durable, survives session death):",
@@ -539,7 +543,7 @@ def do_fire(fire_type, timestamp_str):
         )
 
     ts = timestamp.strftime("%Y%m%d%H%M")
-    marker = f"/home/jay/.taos-fleet-tools/resume_arm_time.py#{fire_type}-{ts}"
+    marker = f"{SCRIPT}#{fire_type}-{ts}"
 
     record = f"[RESUME DUE] {fire_type} fired armed_at={timestamp_str}"
 

--- a/tests/test_resume_arm_time.py
+++ b/tests/test_resume_arm_time.py
@@ -40,7 +40,7 @@ resume_arm_time = _load_module()
 
 def _marker(fire_type, armed_at):
     ts = datetime.datetime.fromisoformat(armed_at).strftime("%Y%m%d%H%M")
-    return f"/home/jay/.taos-fleet-tools/resume_arm_time.py#{fire_type}-{ts}"
+    return f"{SCRIPT}#{fire_type}-{ts}"
 
 
 class _Proc:
@@ -140,8 +140,8 @@ def test_system_crontab_block_names_usr_bin_python3():
     fire = datetime.datetime(2026, 8, 18, 0, 7, 0, tzinfo=datetime.timezone.utc)
     retry = datetime.datetime(2026, 8, 18, 0, 17, 0, tzinfo=datetime.timezone.utc)
     block = resume_arm_time.system_crontab_block(fire, retry)
-    assert "/usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire primary" in block
-    assert "/usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire retry" in block
+    assert f"/usr/bin/python3 {SCRIPT} --fire primary" in block
+    assert f"/usr/bin/python3 {SCRIPT} --fire retry" in block
     # No bare `python3` token (the blocked PR emitted `python3 <path>`).
     assert " python3 " not in block
 
@@ -275,7 +275,7 @@ def test_do_fire_runs_as_subprocess(tmp_path, monkeypatch):
     marker = _marker("primary", armed_at)
     initial_crontab = (
         f"# taOSmd-resume: {marker}\n"
-        + f"7 0 18 8 * /usr/bin/python3 /home/jay/.taos-fleet-tools/resume_arm_time.py --fire primary {armed_at}\n"
+        + f"7 0 18 8 * /usr/bin/python3 {SCRIPT} --fire primary {armed_at}\n"
         + WATCHER_LINE
     )
     state = _install_fake_crontab(tmp_path, monkeypatch, initial_crontab)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Two of the four resume_arm_time tests #354 touched pass against a hardcoded _HELPER_PATH, so they check symbol existence rather than path derivation

Autonomous build of board card tsk-vqfjsm.

Replace hardcoded path assertions with SCRIPT anchor in four test assertions:
- test_system_crontab_block_names_usr_bin_python3() lines 143-144
- test_do_fire_runs_as_subprocess() line 278

This ensures all four test arms discriminate against hardcoded paths by using
an independent anchor that's what _marker() uses, not the module's own
constant. SCRIPT is defined at the top of tests/test_resume_arm_time.py.

Files:
 scripts/resume_arm_time.py    | 10 +++++++---
 tests/test_resume_arm_time.py |  8 ++++----
 2 files changed, 11 insertions(+), 7 deletions(-)