### PR TITLE
Revise PR #326: the receipts implementation was dropped, so the suite will not collect and four of five endpoints 500

### DIFF
--- a/changelog.d/tsk-r4j272-receipts-restoration.md
+++ b/changelog.d/tsk-r4j272-receipts-restoration.md
@@ -1,0 +1,15 @@
+### Fixed
+- Restored the A2A receipts subsystem (ReceiptStore, registered migration,
+  service wrappers, ``_ensure_stores`` integration) that was dropped by PR #326,
+  which had left all receipt-write endpoints returning 500.
+- Fixed receipt identity: ``agent_id`` is now derived from the verified
+  registry token's ``sub`` claim via ``_get_authenticated_agent_id``, never from
+  the request body. A forged token produces a 401 with no receipt row written.
+- Added ``do_PATCH`` so ``PATCH /a2a/receipts`` routes correctly, and de-duplicated
+  the routing table so each receipt path is dispatched exactly once.
+- Fixed ``ttl_days`` unit handling in ``POST /a2a/admin/prune-receipts``: days are
+  now converted to an absolute epoch timestamp (``time.time() - ttl_days * 86400``)
+  instead of being passed through as epoch seconds.
+- Added five ``RemoteClient`` methods (``a2a_record_delivered``,
+  ``a2a_record_seen``, ``a2a_get_receipts``, ``a2a_get_receipt``,
+  ``a2a_prune_receipts``) so remote clients mirror the local service API.

--- a/taosmd/api.py
+++ b/taosmd/api.py
@@ -147,6 +147,9 @@ async def _ensure_stores(data_dir=None) -> dict:
         from taosmd.mentions import MentionStore  # noqa: PLC0415
         mentions = MentionStore(db_path=str(path / "a2a-mentions.db"))
         await mentions.init()
+        from taosmd.receipts import ReceiptStore  # noqa: PLC0415
+        receipts = ReceiptStore(db_path=str(path / "a2a-receipts.db"))
+        await receipts.init()
 
         stores = {
             "archive": archive,
@@ -154,6 +157,7 @@ async def _ensure_stores(data_dir=None) -> dict:
             "kg": kg,
             "claims": claims,
             "mentions": mentions,
+            "receipts": receipts,
             "data_dir": str(path),
         }
         _stores_cache[resolved] = stores

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -805,6 +805,39 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 return auth[len("Bearer "):].strip() == _server_token
             return False
 
+        def _get_authenticated_agent_id(self) -> str | None:
+            """Return the agent identity from a verified registry token, or None.
+
+            The token is verified via ``_registry_verifier.authorize``; the
+            claimed identity is the token's own ``sub`` claim, so the
+            ``sub == claimed_from`` policy is satisfied by construction and
+            only the signature/revocation/issuer checks actually filter.  A
+            forged token (bad signature) raises ``AuthError`` and yields
+            ``None``; a valid token yields its ``sub``.  When no registry
+            verifier is configured (standalone) it yields ``None``: receipt
+            writes require an authenticated identity, never a body claim.
+            """
+            if _registry_verifier is None:
+                return None
+            auth = self.headers.get("Authorization", "")
+            if not auth.startswith("Bearer "):
+                return None
+            token = auth[len("Bearer "):].strip()
+            if not token:
+                return None
+            from . import registry_auth as _ra  # noqa: PLC0415
+            try:
+                import jwt as _jwt  # noqa: PLC0415
+                unverified = _jwt.decode(token, options={"verify_signature": False})
+                claimed = unverified.get("sub", "") or ""
+                claims = _registry_verifier.authorize(token, claimed)
+                sub = claims.get("sub", "") or ""
+                return sub if sub else None
+            except _ra.AuthError:
+                return None
+            except Exception:  # noqa: BLE001
+                return None
+
         @staticmethod
         def _is_admin_route(method: str, path: str) -> bool:
             """Return True for admin write routes (#154).
@@ -833,6 +866,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 "/a2a/admin/delete-channel",
                 "/a2a/admin/rename-channel",
                 "/a2a/admin/supersede-message",
+                "/a2a/admin/prune-receipts",
             )
 
         def _check_admin_token(self) -> bool:
@@ -966,6 +1000,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         def do_DELETE(self) -> None:  # noqa: N802
             self._dispatch("DELETE")
 
+        def do_PATCH(self) -> None:  # noqa: N802
+            self._dispatch("PATCH")
+
         def _dispatch(self, method: str) -> None:
             parts = urlsplit(self.path)
             path = parts.path.rstrip("/") or "/"
@@ -1057,6 +1094,18 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         self._send_json(404, {"error": "thread name required"})
                     else:
                         self._handle_a2a_thread_messages(thread, query)
+                # ----- A2A receipt endpoints --------------------------------
+                elif method == "POST" and path == "/a2a/receipts":
+                    self._handle_a2a_receipts_delivered()
+                elif method == "PATCH" and path == "/a2a/receipts":
+                    self._handle_a2a_receipts_seen()
+                elif method == "GET" and path.startswith("/a2a/messages/") and path.endswith("/receipts"):
+                    msg_id = path[len("/a2a/messages/"):-len("/receipts")]
+                    self._handle_a2a_message_receipts(msg_id)
+                elif method == "GET" and path == "/a2a/receipts":
+                    self._handle_a2a_receipts(query)
+                elif method == "POST" and path == "/a2a/admin/prune-receipts":
+                    self._handle_admin_a2a_prune_receipts()
                 # Task graph endpoints — prefix matching for /tasks/{id} paths
                 elif method == "POST" and path == "/tasks":
                     self._handle_task_create()
@@ -1731,12 +1780,20 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             is a quick, bounded archive query; the sleep happens here in
             the request thread, never inside the service loop. Disconnects
             are detected via write errors and exit the loop cleanly.
+
+            When the subscriber's identity is known (authenticated proxy
+            path, ``sub`` claim present in the Bearer token) a delivered
+            receipt is written after each frame lands on the wire. Raw-bus
+            subscribers that carry no identifying token produce no delivered
+            mark.
             """
             thread = (qs.get("thread") or [None])[0]
             since_raw = (qs.get("since") or [None])[0]
             last_ts = _parse_since(since_raw)
             if last_ts is None:
                 last_ts = time.time()
+
+            subscriber_agent = self._get_authenticated_agent_id()
 
             # Send SSE response headers before entering the poll loop.
             self.send_response(200)
@@ -1760,6 +1817,15 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                             frame = f"data: {json.dumps(msg)}\n\n"
                             self.wfile.write(frame.encode("utf-8"))
                             last_ts = msg["ts"]
+                            if subscriber_agent is not None:
+                                runner.run(
+                                    service.a2a_record_delivered(
+                                        msg["id"],
+                                        subscriber_agent,
+                                        ts=time.time(),
+                                        data_dir=data_dir,
+                                    )
+                                )
                         self.wfile.flush()
                     else:
                         self.wfile.write(b": keepalive\n\n")
@@ -1791,6 +1857,107 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     thread=thread, before=before, after=after,
                     limit=limit_i, data_dir=data_dir,
                 )
+            )
+            self._send_json(200, result)
+
+        # ----- A2A receipt handlers -----------------------------------------
+
+        def _handle_a2a_receipts_delivered(self) -> None:
+            """POST /a2a/receipts -- record that a message was delivered.
+
+            ``agent_id`` is derived from the verified registry token, never
+            from the request body.  ``message_id`` comes from the body.
+            """
+            body = self._read_json_body()
+            message_id_raw = body.get("message_id")
+            if message_id_raw is None:
+                raise _BadRequest("'message_id' is required")
+            try:
+                message_id = int(message_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'message_id' must be an integer") from exc
+            agent_id = self._get_authenticated_agent_id()
+            if agent_id is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            runner.run(
+                service.a2a_record_delivered(message_id, agent_id, data_dir=data_dir)
+            )
+            self._send_json(200, {"ok": True})
+
+        def _handle_a2a_receipts_seen(self) -> None:
+            """PATCH /a2a/receipts -- record that an agent has seen a message.
+
+            ``agent_id`` is derived from the verified registry token, never
+            from the request body.  ``message_id`` comes from the body.
+            """
+            body = self._read_json_body()
+            message_id_raw = body.get("message_id")
+            if message_id_raw is None:
+                raise _BadRequest("'message_id' is required")
+            try:
+                message_id = int(message_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'message_id' must be an integer") from exc
+            agent_id = self._get_authenticated_agent_id()
+            if agent_id is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            runner.run(
+                service.a2a_record_seen(message_id, agent_id, data_dir=data_dir)
+            )
+            self._send_json(200, {"ok": True})
+
+        def _handle_a2a_message_receipts(self, msg_id_str: str) -> None:
+            """GET /a2a/messages/{id}/receipts -- all receipts for one message."""
+            try:
+                message_id = int(msg_id_str)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("message id must be an integer") from exc
+            result = runner.run(
+                service.a2a_get_receipts(message_id, data_dir=data_dir)
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_receipts(self, qs: dict) -> None:
+            """GET /a2a/receipts?message_id=X&agent=Y -- a single receipt."""
+            message_id_raw = (qs.get("message_id") or [None])[0]
+            agent_id = (qs.get("agent") or [None])[0]
+            if message_id_raw is None or agent_id is None:
+                raise _BadRequest("'message_id' and 'agent' query parameters are required")
+            try:
+                message_id = int(message_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'message_id' must be an integer") from exc
+            receipt = runner.run(
+                service.a2a_get_receipt(message_id, agent_id, data_dir=data_dir)
+            )
+            if receipt is None:
+                self._send_json(404, {"error": "receipt not found"})
+                return
+            self._send_json(200, receipt)
+
+        def _handle_admin_a2a_prune_receipts(self) -> None:
+            """POST /a2a/admin/prune-receipts -- admin-only prune.
+
+            Accepts ``ttl_days`` (days) and converts to an absolute epoch
+            timestamp before delegating to the service layer, matching the
+            default path which also uses ``time.time() - N * 86400``.
+            """
+            if not self._check_admin_token():
+                return
+            body = self._read_json_body()
+            ttl_days = body.get("ttl_days")
+            if ttl_days is not None:
+                try:
+                    ttl_days = float(ttl_days)
+                except (TypeError, ValueError):
+                    raise _BadRequest("'ttl_days' must be a number when provided")
+                older_than_ts = time.time() - ttl_days * 86400
+            else:
+                older_than_ts = time.time() - 30 * 24 * 3600
+            result = runner.run(
+                service.a2a_prune_receipts(older_than_ts, data_dir=data_dir)
             )
             self._send_json(200, result)
 

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -302,6 +302,22 @@ _VECTOR_MEMORY: tuple[Migration, ...] = (
 )
 
 
+# --- a2a-receipts.db ----------------------------------------------------
+
+def _a2a_receipts_baseline(conn: sqlite3.Connection) -> None:
+    from taosmd.receipts import SCHEMA  # noqa: PLC0415
+
+    exec_script(conn, SCHEMA)
+
+
+_A2A_RECEIPTS: tuple[Migration, ...] = (
+    Migration(
+        1, "a2a_receipts_baseline", _a2a_receipts_baseline,
+        lambda c: table_exists(c, "a2a_receipts"),
+    ),
+)
+
+
 # --- knowledge-graph.db ------------------------------------------------
 
 def _knowledge_graph_baseline(conn: sqlite3.Connection) -> None:
@@ -357,6 +373,7 @@ _COLLECTIONS: tuple[Migration, ...] = (
 
 #: Logical database name -> ordered migration steps.
 REGISTRY: dict[str, tuple[Migration, ...]] = {
+    "a2a_receipts": _A2A_RECEIPTS,
     "archive_index": _ARCHIVE_INDEX,
     "claims": _CLAIMS,
     "collections": _COLLECTIONS,
@@ -394,6 +411,7 @@ for _db_name, _db_migs in REGISTRY.items():
 
 #: Logical database name -> filename inside the data directory.
 DB_FILES: dict[str, str] = {
+    "a2a_receipts": "a2a-receipts.db",
     "archive_index": "archive-index.db",
     "claims": "claims.db",
     "collections": "collections.db",

--- a/taosmd/receipts.py
+++ b/taosmd/receipts.py
@@ -1,0 +1,158 @@
+"""A2A read receipts store.
+
+Receipts are keyed by (message_id, agent_id) and track:
+
+* ``delivered_at`` -- epoch float, set once on first delivery, never moves.
+* ``seen_at`` -- epoch float, nullable, moves from null to a value exactly once.
+
+Design rules (from taOS 1472):
+
+* ``INSERT OR IGNORE`` is used for the delivered mark: a watcher redelivering
+  the same message to the same agent must NOT duplicate or move ``delivered_at``
+  earlier. After a prune removes the row, a subsequent delivery inserts a fresh
+  ``delivered_at`` because the row no longer exists.
+* ``seen_at`` is guarded by a ``WHERE seen_at IS NULL`` update: it only ever
+  moves from null to a value and is never cleared or moved back.
+* Raw-bus subscribers that do not present an identifiable agent produce no
+  delivered mark.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+
+__all__ = ["SCHEMA", "ReceiptStore"]
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS a2a_receipts (
+    message_id INTEGER NOT NULL,
+    agent_id TEXT NOT NULL,
+    delivered_at REAL NOT NULL,
+    seen_at REAL,
+    PRIMARY KEY (message_id, agent_id)
+);
+CREATE INDEX IF NOT EXISTS idx_receipts_message ON a2a_receipts(message_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_agent ON a2a_receipts(agent_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_delivered ON a2a_receipts(delivered_at);
+"""
+
+
+class ReceiptStore:
+    """Thread-affine store for A2A read receipts.
+
+    All methods are async so callers can ``await`` them uniformly; the body
+    runs synchronously against a single SQLite connection, exactly like the
+    other taOSmd stores.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+
+    async def init(self) -> None:
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(SCHEMA)
+        self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    async def record_delivered(
+        self, message_id: int, agent_id: str, ts: float
+    ) -> None:
+        """Record that a message was delivered to an agent.
+
+        Idempotent: when a row already exists for ``(message_id, agent_id)``
+        the existing ``delivered_at`` is left unchanged.  After a prune
+        removes the row a subsequent call inserts a fresh ``delivered_at``
+        because ``INSERT OR IGNORE`` fires only when the row is absent.
+        """
+        if self._conn is None:
+            raise RuntimeError("ReceiptStore not initialised")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO a2a_receipts (message_id, agent_id, delivered_at) "
+            "VALUES (?, ?, ?)",
+            (message_id, agent_id, ts),
+        )
+        self._conn.commit()
+
+    async def record_seen(
+        self, message_id: int, agent_id: str, ts: float
+    ) -> None:
+        """Record that an agent has seen a message.
+
+        * When no row exists for ``(message_id, agent_id)`` a new row is
+          created with both ``delivered_at`` and ``seen_at`` set to ``ts``.
+        * When ``seen_at`` is already set it is left unchanged (monotonic).
+        """
+        if self._conn is None:
+            raise RuntimeError("ReceiptStore not initialised")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO a2a_receipts "
+            "(message_id, agent_id, delivered_at, seen_at) "
+            "VALUES (?, ?, ?, ?)",
+            (message_id, agent_id, ts, ts),
+        )
+        self._conn.execute(
+            "UPDATE a2a_receipts SET seen_at = ? "
+            "WHERE message_id = ? AND agent_id = ? AND seen_at IS NULL",
+            (ts, message_id, agent_id),
+        )
+        self._conn.commit()
+
+    async def get_receipts_for_message(self, message_id: int) -> dict:
+        """Return ``{"delivered": [...], "read": [...]}`` for ``message_id``."""
+        if self._conn is None:
+            raise RuntimeError("ReceiptStore not initialised")
+        rows = self._conn.execute(
+            "SELECT agent_id, delivered_at, seen_at FROM a2a_receipts "
+            "WHERE message_id = ?",
+            (message_id,),
+        ).fetchall()
+        delivered = []
+        read = []
+        for row in rows:
+            delivered.append(
+                {"agent_id": row["agent_id"], "delivered_at": row["delivered_at"]}
+            )
+            if row["seen_at"] is not None:
+                read.append(
+                    {"agent_id": row["agent_id"], "seen_at": row["seen_at"]}
+                )
+        return {"delivered": delivered, "read": read}
+
+    async def get_receipt(
+        self, message_id: int, agent_id: str
+    ) -> dict | None:
+        """Return ``{"delivered_at", "seen_at"}`` for one receipt, or ``None``."""
+        if self._conn is None:
+            raise RuntimeError("ReceiptStore not initialised")
+        row = self._conn.execute(
+            "SELECT delivered_at, seen_at FROM a2a_receipts "
+            "WHERE message_id = ? AND agent_id = ?",
+            (message_id, agent_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"delivered_at": row["delivered_at"], "seen_at": row["seen_at"]}
+
+    async def prune(self, older_than_ts: float) -> int:
+        """Delete receipts whose ``delivered_at`` predates ``older_than_ts``.
+
+        Returns the number of rows removed.
+        """
+        if self._conn is None:
+            raise RuntimeError("ReceiptStore not initialised")
+        cur = self._conn.execute(
+            "DELETE FROM a2a_receipts WHERE delivered_at < ?",
+            (older_than_ts,),
+        )
+        self._conn.commit()
+        return cur.rowcount

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -302,6 +302,62 @@ class RemoteClient:
         resp = await self._run("GET", f"/a2a/threads/{thread}/messages", params=params)
         return resp
 
+    async def a2a_record_delivered(
+        self, message_id: int, agent_id: str, *, ts: float | None = None, **_opts,
+    ) -> dict:
+        """POST /a2a/receipts: record message delivery to an agent.
+
+        Returns ``{"ok": True}``.
+        """
+        body: dict = {"message_id": message_id, "agent_id": agent_id}
+        if ts is not None:
+            body["ts"] = ts
+        return await self._run("POST", "/a2a/receipts", body)
+
+    async def a2a_record_seen(
+        self, message_id: int, agent_id: str, *, ts: float | None = None, **_opts,
+    ) -> dict:
+        """PATCH /a2a/receipts: mark a message as seen by an agent.
+
+        Returns ``{"ok": True}``.
+        """
+        body: dict = {"message_id": message_id, "agent_id": agent_id}
+        if ts is not None:
+            body["ts"] = ts
+        return await self._run("PATCH", "/a2a/receipts", body)
+
+    async def a2a_get_receipts(self, message_id: int, **_opts) -> dict:
+        """GET /a2a/messages/{id}/receipts: return all receipts for a message.
+
+        Returns ``{"delivered": [...], "read": [...]}``.
+        """
+        return await self._run("GET", f"/a2a/messages/{message_id}/receipts")
+
+    async def a2a_get_receipt(
+        self, message_id: int, agent_id: str, **_opts,
+    ) -> dict | None:
+        """GET /a2a/receipts?message_id=X&agent=Y: return a single receipt.
+
+        Returns ``None`` when no receipt exists.
+        """
+        resp = await self._run(
+            "GET", "/a2a/receipts",
+            params={"message_id": message_id, "agent": agent_id},
+        )
+        if isinstance(resp, dict) and resp.get("error"):
+            return None
+        return resp
+
+    async def a2a_prune_receipts(self, older_than_ts: float, **_opts) -> dict:
+        """POST /a2a/admin/prune-receipts: prune receipts older than a timestamp.
+
+        Converts the absolute timestamp to ``ttl_days`` for the HTTP API.
+        Returns ``{"pruned": int}``.
+        """
+        import time as _time  # noqa: PLC0415
+        ttl_days = (_time.time() - older_than_ts) / 86400
+        return await self._run("POST", "/a2a/admin/prune-receipts", {"ttl_days": ttl_days})
+
     async def stats(self, *, agent: str, **_opts) -> dict:
         """Best-effort stats for ``agent`` on the remote server.
 

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1082,6 +1082,104 @@ async def can_read(reader: str, msg: dict, data_dir=None) -> bool:
     return True
 
 
+async def a2a_record_delivered(
+    message_id: int, agent_id: str, *, ts: float | None = None, data_dir=None
+) -> dict:
+    """Record that a message was delivered to an agent.
+
+    Thin wrapper over :func:`taosmd.receipts.ReceiptStore.record_delivered`.
+    ``ts`` defaults to ``time.time()`` when not supplied.
+    Returns ``{"ok": True}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    if ts is None:
+        ts = time.time()
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_record_delivered(message_id, agent_id, ts=ts)
+    stores = await _api._ensure_stores(data_dir)
+    receipt_store = stores["receipts"]
+    await receipt_store.record_delivered(message_id, agent_id, ts)
+    return {"ok": True}
+
+
+async def a2a_record_seen(
+    message_id: int, agent_id: str, *, ts: float | None = None, data_dir=None
+) -> dict:
+    """Record that an agent has seen a message.
+
+    Thin wrapper over :func:`taosmd.receipts.ReceiptStore.record_seen`.
+    ``ts`` defaults to ``time.time()`` when not supplied.
+    Returns ``{"ok": True}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    if ts is None:
+        ts = time.time()
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_record_seen(message_id, agent_id, ts=ts)
+    stores = await _api._ensure_stores(data_dir)
+    receipt_store = stores["receipts"]
+    await receipt_store.record_seen(message_id, agent_id, ts)
+    return {"ok": True}
+
+
+async def a2a_get_receipts(message_id: int, *, data_dir=None) -> dict:
+    """Return delivery and read receipts for a message.
+
+    Thin wrapper over :func:`taosmd.receipts.ReceiptStore.get_receipts_for_message`.
+    Returns ``{"delivered": [...], "read": [...]}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_get_receipts(message_id)
+    stores = await _api._ensure_stores(data_dir)
+    receipt_store = stores["receipts"]
+    return await receipt_store.get_receipts_for_message(message_id)
+
+
+async def a2a_get_receipt(
+    message_id: int, agent_id: str, *, data_dir=None
+) -> dict | None:
+    """Return a single receipt or ``None`` when not found.
+
+    Thin wrapper over :func:`taosmd.receipts.ReceiptStore.get_receipt`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_get_receipt(message_id, agent_id)
+    stores = await _api._ensure_stores(data_dir)
+    receipt_store = stores["receipts"]
+    return await receipt_store.get_receipt(message_id, agent_id)
+
+
+async def a2a_prune_receipts(
+    older_than_ts: float, *, data_dir=None
+) -> dict:
+    """Prune receipts older than ``older_than_ts`` (by delivered_at).
+
+    Thin wrapper over :func:`taosmd.receipts.ReceiptStore.prune`.
+    Returns ``{"pruned": int}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_prune_receipts(older_than_ts)
+    stores = await _api._ensure_stores(data_dir)
+    receipt_store = stores["receipts"]
+    n = await receipt_store.prune(older_than_ts)
+    return {"pruned": n}
+
+
 async def task_create(
     title: str,
     *,
@@ -1496,6 +1594,8 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",
            "admin_a2a_supersede_message",
+           "a2a_record_delivered", "a2a_record_seen", "a2a_get_receipts",
+           "a2a_get_receipt", "a2a_prune_receipts",
            "collections_create", "collections_list", "collections_get",
            "collections_index_start", "collections_index_run",
            "collections_index_background", "collections_link",

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -1,0 +1,443 @@
+"""Tests for the A2A receipts system: record, get, and prune.
+
+Covers tsk-r4j272 (fourth pass on receipts), which restores the dropped
+``receipts.py`` / migration / service wrappers / ``_ensure_stores`` integration
+and fixes four blockers:
+
+* BLOCKER 1 -- suite collection: ``from taosmd import receipts`` must succeed.
+* BLOCKER 2 -- all five endpoints reachable (POST /a2a/receipts,
+  PATCH /a2a/receipts, GET /a2a/receipts, GET /a2a/messages/{id}/receipts,
+  POST /a2a/admin/prune-receipts).
+* BLOCKER 3 -- identity: receipt writes derive ``agent_id`` from the
+  verified registry token, so a forged token produces no receipt row.
+* BLOCKER 4 -- ``ttl_days`` is converted to an absolute timestamp, not
+  passed through as epoch seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt  # noqa: E402
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+
+from taosmd import api as taosmd_api  # noqa: E402
+from taosmd import http_server, registry_auth, receipts  # noqa: E402
+from taosmd.registry_auth import REGISTRY_ISS  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Token / keypair helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+# Registry key pair -- the only one the verifier knows.
+REG_PRIV_PEM, REG_PUB_PEM = _keypair()
+
+# A second key pair that the verifier does NOT know -- used to forge tokens.
+FORGED_PRIV_PEM, _FORGED_PUB_PEM = _keypair()
+
+ADMIN_TOKEN = "test-admin-token-abc123"
+
+
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=None):
+    claims = {"sub": sub}
+    if iss is not None:
+        claims["iss"] = iss
+    return pyjwt.encode(claims, priv_pem, algorithm="EdDSA")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (POST, PATCH, GET)
+# ---------------------------------------------------------------------------
+
+def _request(url, method, payload=None, token=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode()
+        try:
+            return exc.code, json.loads(body)
+        except json.JSONDecodeError:
+            return exc.code, {"error": body}
+
+def _post(url, payload, token=None):
+    return _request(url, "POST", payload, token)
+
+def _patch(url, payload, token=None):
+    return _request(url, "PATCH", payload, token)
+
+def _get(url, token=None):
+    return _request(url, "GET", None, token)
+
+
+# ---------------------------------------------------------------------------
+# Server fixture with registry verifier (enforce mode)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    """Live server with a registry verifier and admin token, no server token."""
+    data_dir = tmp_path / "taosmd-receipts"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    monkeypatch.setenv("TAOSMD_ADMIN_TOKEN", ADMIN_TOKEN)
+
+    def fake_opener(url, token=None):
+        if url.endswith("pubkey"):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None,
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    stores["vector"].embed = _fake_embed  # type: ignore[assignment]
+
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# ReceiptStore direct tests (no server)
+# ---------------------------------------------------------------------------
+
+def test_receipt_store_importable():
+    """BLOCKER 1 guard: ``from taosmd import receipts`` succeeds."""
+    from taosmd import receipts
+    assert hasattr(receipts, "ReceiptStore")
+    assert hasattr(receipts, "SCHEMA")
+
+
+def test_receipt_store_basic():
+    """ReceiptStore record/get/prune work correctly."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "receipt-test-data"
+        data_dir.mkdir()
+        store = receipts.ReceiptStore(db_path=str(data_dir / "a2a-receipts.db"))
+        asyncio.run(store.init())
+        try:
+            asyncio.run(store.record_delivered(42, "agent-a", 100.0))
+            asyncio.run(store.record_seen(42, "agent-a", 101.0))
+            result = asyncio.run(store.get_receipts_for_message(42))
+            assert "delivered" in result
+            assert "read" in result
+            assert len(result["delivered"]) == 1
+            assert result["delivered"][0]["agent_id"] == "agent-a"
+            assert len(result["read"]) == 1
+            assert result["read"][0]["agent_id"] == "agent-a"
+            receipt = asyncio.run(store.get_receipt(42, "agent-a"))
+            assert receipt is not None
+            assert "delivered_at" in receipt
+            assert "seen_at" in receipt
+            n = asyncio.run(store.prune(99.0))
+            assert n == 0
+            n = asyncio.run(store.prune(999.0))
+            assert n == 1
+        finally:
+            asyncio.run(store.close())
+
+
+def test_receipt_store_get_receipt_missing():
+    """get_receipt with no matching row returns None."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "receipt-test-data"
+        data_dir.mkdir()
+        store = receipts.ReceiptStore(db_path=str(data_dir / "a2a-receipts.db"))
+        asyncio.run(store.init())
+        try:
+            receipt = asyncio.run(store.get_receipt(42, ""))
+            assert receipt is None
+        finally:
+            asyncio.run(store.close())
+
+
+def test_receipt_store_seen_idempotent():
+    """Seen timestamp is monotonic -- a second call does not move it back."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "receipt-test-data"
+        data_dir.mkdir()
+        store = receipts.ReceiptStore(db_path=str(data_dir / "a2a-receipts.db"))
+        asyncio.run(store.init())
+        try:
+            asyncio.run(store.record_delivered(1, "alice", 100.0))
+            asyncio.run(store.record_seen(1, "alice", 101.0))
+            asyncio.run(store.record_seen(1, "alice", 99.0))  # earlier -- should be ignored
+            receipt = asyncio.run(store.get_receipt(1, "alice"))
+            assert receipt["seen_at"] == 101.0
+        finally:
+            asyncio.run(store.close())
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests with valid registry tokens
+# ---------------------------------------------------------------------------
+
+def test_post_receipts_delivered(authed_server):
+    """POST /a2a/receipts records delivery under the verified identity."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    status, body = _post(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 42},
+        token=token,
+    )
+    assert status == 200, body
+    assert body["ok"] is True
+
+
+def test_patch_receipts_seen(authed_server):
+    """PATCH /a2a/receipts records seen under the verified identity."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    status, body = _patch(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 42},
+        token=token,
+    )
+    assert status == 200, body
+    assert body["ok"] is True
+
+
+def test_post_receipts_no_token_rejected(authed_server):
+    """Without a registry token, POST /a2a/receipts returns 401."""
+    status, body = _post(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 42},
+    )
+    assert status == 401, body
+
+
+def test_patch_receipts_no_token_rejected(authed_server):
+    """Without a registry token, PATCH /a2a/receipts returns 401."""
+    status, body = _patch(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 42},
+    )
+    assert status == 401, body
+
+
+def test_get_message_receipts(authed_server):
+    """GET /a2a/messages/{id}/receipts returns delivered + read lists."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    _post(f"{authed_server}/a2a/receipts", {"message_id": 42}, token=token)
+    _patch(f"{authed_server}/a2a/receipts", {"message_id": 42}, token=token)
+    status, body = _get(f"{authed_server}/a2a/messages/42/receipts")
+    assert status == 200, body
+    assert "delivered" in body
+    assert "read" in body
+    assert len(body["delivered"]) == 1
+    assert body["delivered"][0]["agent_id"] == "alice"
+    assert len(body["read"]) == 1
+    assert body["read"][0]["agent_id"] == "alice"
+
+
+def test_get_single_receipt(authed_server):
+    """GET /a2a/receipts?message_id=X&agent=Y returns one receipt."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    _post(f"{authed_server}/a2a/receipts", {"message_id": 42}, token=token)
+    status, body = _get(
+        f"{authed_server}/a2a/receipts?message_id=42&agent=alice"
+    )
+    assert status == 200, body
+    assert "delivered_at" in body
+    assert "seen_at" in body
+
+
+def test_get_single_receipt_not_found(authed_server):
+    """GET /a2a/receipts for a nonexistent receipt returns 404."""
+    status, body = _get(
+        f"{authed_server}/a2a/receipts?message_id=999&agent=nobody"
+    )
+    assert status == 404, body
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 3: forged-token rejects must leave no receipt row
+# ---------------------------------------------------------------------------
+
+def test_forged_token_post_writes_no_receipt(authed_server):
+    """BLOCKER 3: a forged (badly signed) token must NOT write a receipt row.
+
+    The token carries ``sub=alice`` but is signed with a key the verifier
+    does not know.  ``authorize`` fails the signature check, so
+    ``_get_authenticated_agent_id`` returns ``None`` and the handler replies
+    401 with no row inserted.
+    """
+    forged = _make_token("alice", priv_pem=FORGED_PRIV_PEM, iss=REGISTRY_ISS)
+    status, body = _post(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 77},
+        token=forged,
+    )
+    assert status == 401, body
+
+    # Confirm the DB stays empty for message 77.
+    status2, body2 = _get(f"{authed_server}/a2a/messages/77/receipts")
+    assert status2 == 200, body2
+    assert body2["delivered"] == []
+    assert body2["read"] == []
+
+
+def test_forged_token_patch_writes_no_receipt(authed_server):
+    """BLOCKER 3: forged token on PATCH must not write a seen receipt."""
+    forged = _make_token("alice", priv_pem=FORGED_PRIV_PEM, iss=REGISTRY_ISS)
+    status, body = _patch(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 77},
+        token=forged,
+    )
+    assert status == 401, body
+
+    status2, body2 = _get(f"{authed_server}/a2a/messages/77/receipts")
+    assert status2 == 200, body2
+    assert body2["delivered"] == []
+    assert body2["read"] == []
+
+
+def test_forged_token_does_not_impersonate(authed_server):
+    """BLOCKER 3: a forged token claiming sub=bob must not attribute to bob."""
+    forged = _make_token("bob", priv_pem=FORGED_PRIV_PEM, iss=REGISTRY_ISS)
+    status, body = _post(
+        f"{authed_server}/a2a/receipts",
+        {"message_id": 88},
+        token=forged,
+    )
+    assert status == 401, body
+
+    # Bob should have no receipts.
+    status2, body2 = _get(f"{authed_server}/a2a/messages/88/receipts")
+    assert status2 == 200, body2
+    assert len(body2["delivered"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 4: admin prune (ttl_days units + admin gate)
+# ---------------------------------------------------------------------------
+
+def test_admin_prune_no_token_returns_rejected(authed_server):
+    """Prune without an admin token is rejected."""
+    status, body = _post(
+        f"{authed_server}/a2a/admin/prune-receipts",
+        {"ttl_days": 0},
+    )
+    assert status in (401, 403), body
+
+
+def test_admin_prune_with_token(authed_server):
+    """POST /a2a/admin/prune-receipts prunes receipts older than ttl_days."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    _post(f"{authed_server}/a2a/receipts", {"message_id": 42}, token=token)
+
+    status, body = _post(
+        f"{authed_server}/a2a/admin/prune-receipts",
+        {"ttl_days": 0},
+        token=ADMIN_TOKEN,
+    )
+    assert status == 200, body
+    assert "pruned" in body
+    assert body["pruned"] >= 1
+
+    # Receipt should be gone.
+    status2, body2 = _get(f"{authed_server}/a2a/receipts?message_id=42&agent=alice")
+    assert status2 == 404, body2
+
+
+def test_admin_prune_default_ttl(authed_server):
+    """Admin prune with no body uses the 30-day default."""
+    token = _make_token("alice", iss=REGISTRY_ISS)
+    _post(f"{authed_server}/a2a/receipts", {"message_id": 50}, token=token)
+
+    status, body = _post(
+        f"{authed_server}/a2a/admin/prune-receipts",
+        {},
+        token=ADMIN_TOKEN,
+    )
+    assert status == 200, body
+    assert "pruned" in body
+    assert int(body["pruned"]) >= 0
+
+
+# ---------------------------------------------------------------------------
+# Delivered/seen round-trip
+# ---------------------------------------------------------------------------
+
+def test_delivered_seen_round_trip(authed_server):
+    """Record delivered, then seen, then read back the full receipt."""
+    token = _make_token("carol", iss=REGISTRY_ISS)
+    msg_id = 100
+
+    # Deliver
+    s, b = _post(f"{authed_server}/a2a/receipts", {"message_id": msg_id}, token=token)
+    assert s == 200, b
+    assert b["ok"] is True
+
+    # Read back: delivered yes, read empty
+    s, b = _get(f"{authed_server}/a2a/messages/{msg_id}/receipts")
+    assert s == 200, b
+    assert len(b["delivered"]) == 1
+    assert len(b["read"]) == 0
+
+    # Mark seen
+    s, b = _patch(f"{authed_server}/a2a/receipts", {"message_id": msg_id}, token=token)
+    assert s == 200, b
+    assert b["ok"] is True
+
+    # Read back: both delivered and read populated
+    s, b = _get(f"{authed_server}/a2a/messages/{msg_id}/receipts")
+    assert s == 200, b
+    assert len(b["delivered"]) == 1
+    assert len(b["read"]) == 1
+    assert b["delivered"][0]["agent_id"] == "carol"
+    assert b["read"][0]["agent_id"] == "carol"
+
+    # Single receipt
+    s, b = _get(f"{authed_server}/a2a/receipts?message_id={msg_id}&agent=carol")
+    assert s == 200, b
+    assert "delivered_at" in b
+    assert b["seen_at"] is not None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #326: the receipts implementation was dropped, so the suite will not collect and four of five endpoints 500

Autonomous build of board card tsk-r4j272.

Restores the A2A receipts implementation (ReceiptStore, registered
migration, service wrappers, _ensure_stores integration) from
origin/exec/tsk-qo6tpb that PR #326 had reduced to just routing + tests.

Fixes four blockers:

- BLOCKER 1 (suite collection): taosmd/receipts.py was absent, breaking
  'from taosmd import receipts' and interrupting all 1496 collected tests.
  The module is restored and the suite collects 1647 tests.

- BLOCKER 2 (four of five endpoints 500, fifth unreachable): adds do_PATCH
  (the handler class had no do_PATCH, so PATCH /a2a/receipts returned 501),
  routes each receipt path exactly once (de-duplicating the double PATCH
  route in #326), and wires POST /a2a/receipts -> a2a_record_delivered,
  PATCH /a2a/receipts -> a2a_record_seen, GET /a2a/receipts -> single
  receipt, GET /a2a/messages/{id}/receipts -> all receipts.

- BLOCKER 3 (identity fix is dead code): _get_authenticated_agent_id is
  now defined and called from both write handlers.  It verifies the
  token signature via _registry_verifier.authorize(token, claimed) where
  claimed is the token's own 'sub' claim (satisfying the sub == claimed_from
  policy by construction, so only signature/revocation/issuer checks filter).
  A forged token raises AuthError and yields None; agent_id is derived from
  the verified sub, never from the request body.  The forged-token test
  asserts no receipt row is written and goes red without this fix.

- BLOCKER 4 (ttl_days as epoch): _handle_admin_a2a_prune_receipts now
  converts ttl_days to an absolute timestamp via
  time.time() - ttl_days * 86400, matching the default path.

Also adds the five RemoteClient methods (a2a_record_delivered, a2a_record_seen,
a2a_get_receipts, a2a_get_receipt, a2a_prune_receipts) so the remote client
mirrors the local service API.

Files:
 taosmd/api.py                                  |   4 +
 taosmd/http_server.py                          | 167 ++++++++++
 taosmd/migrations.py                           |  18 +
 taosmd/receipts.py                             | 158 +++++++++
 taosmd/remote.py                               |  56 ++++
 taosmd/service.py                              | 100 ++++++
 tests/test_receipts.py                         | 443 +++++++++++++++++++++++++
 8 files changed, 961 insertions(+)