### PR TITLE
docs/agent-jobs tells agents to run `python3 -m ruff check`, which fails with both the system and the venv python, and those docs exist specifically for agents who cannot debug it

### DIFF
--- a/changelog.d/tsk-qpmnvt-fix-ruff-invocation-docs.md
+++ b/changelog.d/tsk-qpmnvt-fix-ruff-invocation-docs.md
@@ -1,0 +1,2 @@
+### Fixed
+- Replaced broken `python3 -m ruff check` invocations in `docs/agent-jobs/` with the standalone `ruff check` form, and added explicit guidance for agents to report a missing `ruff` binary in the PR body and skip that verification step rather than inventing a substitute.

--- a/docs/agent-jobs/DONE-job-005-collections-db-connect.md
+++ b/docs/agent-jobs/DONE-job-005-collections-db-connect.md
@@ -106,7 +106,9 @@ from . import _db
    `grep -n "sqlite3\." taosmd/collections.py` that other uses remain.
 7. `python3 -m pytest tests/test_collections_db_connect.py -q` (2 passed),
    then the FULL suite `python3 -m pytest -q -m "not slow"`, then
-   `python3 -m ruff check taosmd/collections.py tests/test_collections_db_connect.py`.
+    `ruff check taosmd/collections.py tests/test_collections_db_connect.py`.
+    If `ruff` is not found on PATH, report it in the PR body and skip this
+    verification step. Do not invent a substitute tool.
 8. One commit, push, open the PR. PR body: the inconsistency, the one-line
    fix, confirmation that nothing in the store depended on the journal mode,
    and the test count. Reference issue #202. Do not merge.

--- a/docs/agent-jobs/README.md
+++ b/docs/agent-jobs/README.md
@@ -24,7 +24,8 @@ Do not improvise.
 7. The full test suite must pass before you push:
    `python3 -m pytest -q -m "not slow"` (well over a thousand tests, all
    green; record the exact number in your PR body). Lint the files you
-   changed: `python3 -m ruff check <files>`.
+    changed: `ruff check <files>`. If `ruff` is not found on PATH, report it
+    in the PR body and skip this verification step. Do not invent a substitute tool.
 8. Never commit IP addresses, hostnames, tokens, or credentials.
 9. STOP on any surprise: a failing test you did not cause, a merge conflict,
    a file that does not look like the job describes. Open the PR with what

--- a/docs/agent-jobs/job-002-cross-encoder-path-fix.md
+++ b/docs/agent-jobs/job-002-cross-encoder-path-fix.md
@@ -103,7 +103,9 @@ def _default_onnx_path() -> str:
 7. `python3 -m pytest tests/test_cross_encoder_path.py -q` (3 passed), then
    the FULL suite `python3 -m pytest -q -m "not slow"` (all green; the
    existing reranker tests prove explicit-path behavior is unchanged), then
-   `python3 -m ruff check taosmd/cross_encoder.py tests/test_cross_encoder_path.py`.
+    `ruff check taosmd/cross_encoder.py tests/test_cross_encoder_path.py`.
+    If `ruff` is not found on PATH, report it in the PR body and skip this
+    verification step. Do not invent a substitute tool.
 8. One commit, push, open the PR. PR body: the bug (cwd-dependent default),
    the fix (repo-root-resolved default, explicit arg untouched), test counts.
 

--- a/docs/agent-jobs/job-003-http-server-dead-import.md
+++ b/docs/agent-jobs/job-003-http-server-dead-import.md
@@ -65,6 +65,8 @@ def _webui_dir() -> Path | None:
    it.
 5. `python3 -m pytest -q -m "not slow"` (all green; the webui-serving tests
    cover this function), and
-   `python3 -m ruff check taosmd/http_server.py` (the F401 finding for
-   `_ir` must be gone; do not fix any OTHER findings).
+    `ruff check taosmd/http_server.py` (the F401 finding for
+    `_ir` must be gone; do not fix any OTHER findings). If `ruff` is not
+    found on PATH, report it in the PR body and skip this verification step.
+    Do not invent a substitute tool.
 6. One commit, push, open the PR.

--- a/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
+++ b/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
@@ -178,7 +178,9 @@ def test_zero_graph_expansion_never_probes(runner, monkeypatch):
 7. Re-run the file: `python3 -m pytest tests/test_eventqa_retrieve_wiring.py -q`
    (all green), then the FULL suite
    `python3 -m pytest -q -m "not slow"`, then
-   `python3 -m ruff check benchmarks/eventqa_runner.py tests/test_eventqa_retrieve_wiring.py`.
+    `ruff check benchmarks/eventqa_runner.py tests/test_eventqa_retrieve_wiring.py`.
+    If `ruff` is not found on PATH, report it in the PR body and skip this
+    verification step. Do not invent a substitute tool.
 8. One commit, push, open the PR. PR body: the bug (a refusal exited 0 so a
    chain read it as success), the fix (`sys.exit(1)` on both refusal paths,
    the dry-run success return untouched), the reference it copies


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs/agent-jobs tells agents to run `python3 -m ruff check`, which fails with both the system and the venv python, and those docs exist specifically for agents who cannot debug it

Autonomous build of board card tsk-qpmnvt.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

ruff is installed as a standalone user binary, not as a module in any
Python environment the repo uses, so python3 -m ruff fails under both
/usr/bin/python3 and .venv/bin/python. Replace every occurrence in
docs/agent-jobs/ with the bare ruff check form and add explicit guidance
for agents to report a missing binary in the PR body and skip that
verification step rather than inventing a substitute.

Files:
 changelog.d/tsk-qpmnvt-fix-ruff-invocation-docs.md     | 2 ++
 docs/agent-jobs/DONE-job-005-collections-db-connect.md | 4 +++-
 docs/agent-jobs/README.md                              | 3 ++-
 docs/agent-jobs/job-002-cross-encoder-path-fix.md      | 4 +++-
 docs/agent-jobs/job-003-http-server-dead-import.md     | 6 ++++--
 docs/agent-jobs/job-004-eventqa-runner-exit-code.md    | 4 +++-
 6 files changed, 17 insertions(+), 6 deletions(-)