### PR TITLE
Revise PR #361: the helper-path constant already landed in #354, so keep only the guard and stop reverting two stronger tests

### DIFF
--- a/changelog.d/tsk-bxdfvz-helper-path-guard.md
+++ b/changelog.d/tsk-bxdfvz-helper-path-guard.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `scripts/resume_arm_time.py` now refuses to emit the system-crontab block when `_HELPER_PATH` resolves under a temp directory or inside a linked git worktree, naming the reason instead of pinning an ephemeral path that would orphan the self-removal cron line.

--- a/scripts/resume_arm_time.py
+++ b/scripts/resume_arm_time.py
@@ -56,6 +56,45 @@ import time
 
 _HELPER_PATH = os.path.realpath(__file__)
 
+
+def _is_under_temp(path):
+    temp_roots = ("/tmp", "/var/tmp", "/private/var/folders", "/var/folders")
+    for root in temp_roots:
+        if path == root or path.startswith(root + os.sep):
+            return root
+    return None
+
+
+def _is_in_linked_worktree(path):
+    parent = os.path.dirname(os.path.abspath(path))
+    while parent and parent != os.path.dirname(parent):
+        git_dir = os.path.join(parent, ".git")
+        if os.path.exists(git_dir):
+            if os.path.isfile(git_dir):
+                return parent
+            return None
+        parent = os.path.dirname(parent)
+    return None
+
+
+def _validate_helper_path():
+    path = _HELPER_PATH
+    tmp = _is_under_temp(path)
+    if tmp:
+        raise SystemExit(
+            f"FAIL: {_HELPER_PATH} resolves under a temp directory ({tmp}).\n"
+            "A cron line armed from a temp checkout cannot self-delete when the\n"
+            "directory is cleaned up. REFUSING to emit."
+        )
+    wt = _is_in_linked_worktree(path)
+    if wt:
+        raise SystemExit(
+            f"FAIL: {_HELPER_PATH} is inside a git worktree ({wt}).\n"
+            "Worktree checkouts are ephemeral; the cron line would pin a path\n"
+            "that vanishes when the worktree is removed. REFUSING to emit."
+        )
+
+
 # The two tunables, each stating WHAT IT IS A FUNCTION OF. That is the whole point of
 # this file: a constant whose dependency is unnamed is the bug it exists to prevent.
 #
@@ -747,6 +786,7 @@ def main():
           "           something in the SYSTEM crontab, outside the component that failed.\n"
           "           If instead you write these lines into a crontab, durability is fine but\n"
           "           recurring=false does not exist there, so re-read the ONE-SHOT line.")
+    _validate_helper_path()
     print(system_crontab_block(fire, r_fire))
 
 

--- a/tests/test_resume_arm_time.py
+++ b/tests/test_resume_arm_time.py
@@ -111,6 +111,11 @@ def test_canonical_derivation_emits_date_pinned_one_shot(monkeypatch, capsys):
     17 0 18 8 *, a date-pinned one-shot -- not the blocked PR's daily 17 0 * * *."""
     monkeypatch.setenv("TZ", "UTC")
     time.tzset()
+    monkeypatch.setattr(
+        resume_arm_time,
+        "_HELPER_PATH",
+        "/home/jay/.taos-fleet-tools/scripts/resume_arm_time.py",
+    )
     written = []
     monkeypatch.setattr(
         resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, written)
@@ -154,6 +159,38 @@ def test_helper_imports_getpass():
     assert "getpass" in dir(resume_arm_time)
     import getpass as _gp
     assert resume_arm_time.getpass is _gp
+
+
+# --------------------------------------------------------------------------- #
+# Helper-path guard: refuse to emit from a temp or linked-worktree location.
+# --------------------------------------------------------------------------- #
+
+def test_guard_refuses_temp_path(monkeypatch, capsys):
+    """A _HELPER_PATH under /tmp is refused with a named reason."""
+    monkeypatch.setattr(
+        resume_arm_time,
+        "_HELPER_PATH",
+        "/tmp/scratchpad/wt354/scripts/resume_arm_time.py",
+    )
+    monkeypatch.setattr(
+        resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, [])
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["resume_arm_time.py", "2026-08-18T00:00:00+00:00"]
+    )
+    with pytest.raises(SystemExit) as exc:
+        resume_arm_time.main()
+    assert "temp directory" in str(exc.value)
+
+
+def test_guard_refuses_linked_worktree(tmp_path):
+    """_is_in_linked_worktree returns the worktree root when .git is a file."""
+    fake_wt = tmp_path / "fake-wt"
+    fake_wt.mkdir()
+    (fake_wt / ".git").write_text("gitdir: /some/real/.git/worktrees/fake\n")
+    target = fake_wt / "scripts" / "resume_arm_time.py"
+    result = resume_arm_time._is_in_linked_worktree(str(target))
+    assert result == str(fake_wt)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #361: the helper-path constant already landed in #354, so keep only the guard and stop reverting two stronger tests

Autonomous build of board card tsk-if2fpm.

Adds _is_under_temp, _is_in_linked_worktree, and _validate_helper_path to
scripts/resume_arm_time.py, and calls _validate_helper_path() from main()
before emitting the crontab block. A temp checkout or linked worktree would
pin an ephemeral path that vanishes, orphaning the self-removal cron line.

Tests:
- monkeypatch _HELPER_PATH in test_canonical_derivation_emits_date_pinned_one_shot
  so the guard does not fire when the suite runs from a linked worktree under /tmp
- add test_guard_refuses_temp_path for the temp-directory refusal
- rewrite test_guard_refuses_linked_worktree as a unit test of
  _is_in_linked_worktree() using tmp_path, so it never touches /home/jay

Changelog fragment added for the guard only; _HELPER_PATH was already added
by #354 and is not repeated here.

Verified:
- git rev-list --count HEAD..origin/master = 0
- full suite from linked worktree: 1619 passed, 12 skipped
- full suite from main checkout: 1619 passed, 12 skipped
- /home/jay/Development/fake-wt-for-test is never created

Files:
 STATUS.md                                       | 11 ++++++-
 benchmarks/data/README.md                       |  6 ++--
 changelog.d/tsk-7xfpe2-fix-trailing-newlines.md |  3 ++
 changelog.d/tsk-bxdfvz-helper-path-guard.md     |  3 ++
 changelog.d/tsk-vghh6c-unify-mib-mb-units.md    |  2 ++
 scripts/resume_arm_time.py                      | 40 +++++++++++++++++++++++++
 tests/test_resume_arm_time.py                   | 37 +++++++++++++++++++++++
 7 files changed, 98 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented system cron entries from being generated when the helper resides in a temporary directory or linked Git worktree.
  * Added clear reporting when cron generation is skipped, helping avoid orphaned self-removal jobs.

* **Tests**
  * Added coverage for temporary-directory paths and linked worktree detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->