### PR TITLE
test(resume-arm): make the worktree refusal test exercise the refusal it is named for

### DIFF
--- a/changelog.d/tsk-3m3irr-worktree-refusal-test.md
+++ b/changelog.d/tsk-3m3irr-worktree-refusal-test.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `test_guard_refuses_linked_worktree` now exercises the refusal it is named for. It went through `main()`'s guard rather than calling `_is_in_linked_worktree` directly, so removing the worktree refusal from `_validate_helper_path` while leaving the detector intact left all nine tests green, and the real CLI went on emitting crontab lines pinning an ephemeral worktree path. The detector-level assertion is kept under the honest name `test_is_in_linked_worktree_detects_git_file`, joined by one covering the main worktree, where a `.git` directory must continue not to trip the guard so that arming keeps working.
+- The rewritten test neutralises `_is_under_temp` on purpose, and would be worthless without it: the two refusals are checked in order and `tmp_path` is itself under a temp root, so a fixture built there trips the temp refusal first and never reaches the branch under test. That masking is why the original test settled for the detector.

--- a/tests/test_resume_arm_time.py
+++ b/tests/test_resume_arm_time.py
@@ -183,7 +183,44 @@ def test_guard_refuses_temp_path(monkeypatch, capsys):
     assert "temp directory" in str(exc.value)
 
 
-def test_guard_refuses_linked_worktree(tmp_path):
+def test_guard_refuses_linked_worktree(monkeypatch, tmp_path):
+    """main() refuses when _HELPER_PATH sits inside a linked worktree.
+
+    This goes through main() rather than the detector, because the detector
+    returning a string is not the behaviour the guard exists to provide.
+
+    _is_under_temp is neutralised deliberately, and the test is worthless
+    without that. The two refusals are checked in order, and tmp_path IS under
+    a temp root, so a fixture built there trips the TEMP refusal first and
+    never reaches the branch this test is named for. Left in, the test would
+    pass on the sibling refusal's message while the worktree refusal could be
+    deleted outright.
+    """
+    fake_wt = tmp_path / "fake-wt"
+    fake_wt.mkdir()
+    (fake_wt / ".git").write_text("gitdir: /some/real/.git/worktrees/fake\n")
+    target = fake_wt / "scripts" / "resume_arm_time.py"
+
+    monkeypatch.setattr(resume_arm_time, "_is_under_temp", lambda path: None)
+    monkeypatch.setattr(resume_arm_time, "_HELPER_PATH", str(target))
+    monkeypatch.setattr(
+        resume_arm_time.subprocess, "run", _fake_run(WATCHER_LINE, [])
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["resume_arm_time.py", "2026-08-18T00:00:00+00:00"]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        resume_arm_time.main()
+
+    message = str(exc.value)
+    assert "is inside a git worktree" in message
+    assert str(fake_wt) in message
+    # Not the sibling refusal wearing this test's name.
+    assert "temp directory" not in message
+
+
+def test_is_in_linked_worktree_detects_git_file(tmp_path):
     """_is_in_linked_worktree returns the worktree root when .git is a file."""
     fake_wt = tmp_path / "fake-wt"
     fake_wt.mkdir()
@@ -191,6 +228,14 @@ def test_guard_refuses_linked_worktree(tmp_path):
     target = fake_wt / "scripts" / "resume_arm_time.py"
     result = resume_arm_time._is_in_linked_worktree(str(target))
     assert result == str(fake_wt)
+
+
+def test_is_in_linked_worktree_ignores_the_main_worktree(tmp_path):
+    """A .git DIRECTORY is the main worktree, where arming must keep working."""
+    main_wt = tmp_path / "main-wt"
+    (main_wt / ".git").mkdir(parents=True)
+    target = main_wt / "scripts" / "resume_arm_time.py"
+    assert resume_arm_time._is_in_linked_worktree(str(target)) is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes `tsk-3m3irr`, the follow-up carded when #369 was merged. Test-only: `scripts/resume_arm_time.py` is untouched, because the guard was already correct.

## The defect

`_validate_helper_path()` refuses two things, a helper path under a temp directory and one inside a linked git worktree. Only the first was covered.

`test_guard_refuses_linked_worktree` never called `main()` and never asserted a refusal. It called the detector and checked it returned a string:

```python
result = resume_arm_time._is_in_linked_worktree(str(target))
assert result == str(fake_wt)
```

The name promises `guard_refuses`. The body proves a path-inspection function returns a string, so anyone reading the suite sees a test named for the behaviour and reasonably assumes the behaviour is covered.

## Why a whole-suite count could never have found this

Killing the entire guard fails exactly **one** test, and one failure reads as coverage. **One honest test absorbed a whole-feature mutant and hid a vacuous sibling behind it.** The mutant has to be aimed at the individual branch, leaving the detector intact so the existing test still has its function to call:

```python
wt = _is_in_linked_worktree(path)
if False:  # MUTANT: worktree refusal removed
```

| mutant | before | after |
|---|---|---|
| worktree refusal only, detector intact | **9 passed** | **1 failed, 10 passed** on `test_guard_refuses_linked_worktree` |
| whole guard disabled | 1 failed, 8 passed | **2 failed, 9 passed** |

Both "before" figures reproduce the card's recorded measurements exactly. Under the first mutant the real CLI goes on emitting four crontab lines pinning a path that vanishes when the worktree is removed, which is precisely what the guard exists to prevent.

## The trap in the fix, which is the part worth reading

The obvious fix does not work, and it fails in a way that looks like success.

The two refusals are checked **in order**, temp first. `tmp_path` is itself under a temp root. So a fixture built there trips the **temp** refusal and never reaches the branch the test is named for. A test that only asserted `SystemExit` would pass, would survive the whole-guard mutant, and would still not notice the worktree refusal being deleted. It would be the same vacuity in a new costume.

So the test neutralises `_is_under_temp` deliberately and is worthless without it, which the docstring and the changelog both state outright. It then asserts the message names the worktree, names the fixture directory, and specifically that it is **not** the sibling refusal:

```python
assert "is inside a git worktree" in message
assert str(fake_wt) in message
assert "temp directory" not in message   # not the sibling refusal wearing this test's name
```

## Also added

The detector assertion is kept, under the honest name `test_is_in_linked_worktree_detects_git_file`, plus `test_is_in_linked_worktree_ignores_the_main_worktree`. The second pins behaviour that must not change: in the main worktree `.git` is a directory and the guard must keep **not** firing, or arming stops working on the live box. That is deliberate scope, not an oversight.

## Verification

```
full suite:  1648 passed, 12 skipped     (baseline 1646 post-#370, exactly +2)
git diff origin/master --stat:  2 files, 50 insertions, 1 deletion
scripts/resume_arm_time.py:     unchanged, confirmed pristine after both mutants
git grep conflict markers:      none
deleted-symbols-guard / normalise-handle-gate / witness-gate:  all clean
tail -c 1 changelog.d/tsk-3m3irr-worktree-refusal-test.md | xxd -p  ->  0a
em dashes in both changed files:  0
```
