### PR TITLE
ci(changelog): run the trailing-newline gate so a bad fragment cannot ship green (#368 revision, tsk-n3eubn)

### DIFF
--- a/.github/workflows/trailing-newline-gate.yml
+++ b/.github/workflows/trailing-newline-gate.yml
@@ -1,0 +1,36 @@
+name: Trailing newline gate
+
+# Verifies that every file in scope ends with exactly one `0x0a`. A file whose
+# last byte is not a newline silently concatenates the next appended entry onto
+# its final line, so two unrelated release notes merge into one corrupted line
+# when `changelog.d/` fragments are collected. A file ending in `0x0a0a` is the
+# same defect from the other side: a blank line at EOF that grows on every
+# append.
+#
+# The defect has shipped repeatedly because nothing rejects it. It is invisible
+# to the test suite (no test reads the real tree), invisible in review (the
+# missing byte does not render), and harmless-looking in isolation, so this gate
+# is the thing that makes it fail loudly on a pull request.
+#
+# Scope is deliberately narrow: `changelog.d/*.md` and `benchmarks/data/README.md`.
+#
+# See scripts/check_trailing_newline.py for the implementation.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  trailing-newline-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Install deps
+        run: uv sync --python 3.12
+      - name: Check that files in scope end with exactly one newline
+        run: python scripts/check_trailing_newline.py

--- a/changelog.d/tsk-7m6ju5-trailing-newline-gate.md
+++ b/changelog.d/tsk-7m6ju5-trailing-newline-gate.md
@@ -1,0 +1,3 @@
+### Added
+- Trailing-newline gate added to prevent silent corruption of release notes from missing trailing newlines in changelog fragments and the benchmarks data README.
+- The gate runs on every pull request via `.github/workflows/trailing-newline-gate.yml`, and against the repository's own tree in the test suite, so a fragment committed without its terminating byte fails both CI and a plain `pytest` run.

--- a/scripts/check_trailing_newline.py
+++ b/scripts/check_trailing_newline.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Trailing-newline gate.
+
+Verifies that every file in scope ends with exactly one ``0x0a`` (newline).
+A file missing its trailing newline silently concatenates the next appended
+entry onto the last line, corrupting release notes in ``changelog.d/`` and
+the pinned-data ``README.md``.
+
+Scope (deliberately narrow):
+  - ``changelog.d/*.md``
+  - ``benchmarks/data/README.md``
+
+An optional ``TRAILING_NEWLINE_ROOT`` environment variable overrides the repo
+root the gate scans (defaulting to the tree containing this script). This lets
+the gate target an arbitrary checkout or a fixture directory -- useful for CI
+on staged changes and for reproducible local demos.
+
+Usage:
+    python scripts/check_trailing_newline.py
+    TRAILING_NEWLINE_ROOT=/tmp/fixture python scripts/check_trailing_newline.py
+    (exits 0 when every file in scope ends in exactly one newline, 1 otherwise)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(os.environ.get("TRAILING_NEWLINE_ROOT") or _REPO_ROOT)
+
+SCOPE_GLOBS = (
+    "changelog.d/*.md",
+    "benchmarks/data/README.md",
+)
+
+
+def _last_byte_hex(file_path: Path) -> str | None:
+    """Return the last byte of *file_path* as a two-digit hex string, or None
+    if the file has fewer than 1 byte."""
+    try:
+        data = file_path.read_bytes()
+    except (OSError,):
+        return None
+    if len(data) == 0:
+        return None
+    return f"{(data[-1]):02x}"
+
+
+def _check_file(file_path: Path) -> tuple[bool, str | None]:
+    """Check whether *file_path* ends with exactly one newline.
+
+    Returns ``(pass, last_byte_hex)``:
+      - ``pass`` is ``True`` when the file ends with exactly one ``0x0a``.
+      - ``last_byte_hex`` is the hex value of the actual last byte when
+        ``pass`` is ``False`` (``None`` when the file is empty or when pass
+        is True).
+    """
+    try:
+        data = file_path.read_bytes()
+    except (OSError,):
+        return True, None
+
+    # Empty file: not an offender (nothing to concatenate onto).
+    if len(data) == 0:
+        return True, None
+
+    # Last byte must be 0x0a.
+    if data[-1] != 0x0a:
+        last_hex = f"{(data[-1]):02x}"
+        return False, last_hex
+
+    # Last byte is 0x0a. Check that the second-to-last byte is NOT 0x0a
+    # (which would be a blank line at EOF, i.e. more than one trailing newline).
+    if len(data) >= 2 and data[-2] == 0x0a:
+        # Blank line at EOF: the file ends with 0x0a0a or more.
+        # The last byte is still 0x0a, but it's not "exactly one".
+        last_hex = "0a"
+        return False, last_hex
+
+    # Exactly one trailing newline (0x0a) -> clean.
+    return True, None
+
+
+def _scan_scope() -> list[tuple[Path, bool, str | None]]:
+    """Scan all files in the scope and return (path, passes, last_byte_hex)."""
+    results: list[tuple[Path, bool, str | None]] = []
+    for glob in SCOPE_GLOBS:
+        for path in sorted(REPO_ROOT.glob(glob)):
+            passed, last_byte = _check_file(path)
+            results.append((path, passed, last_byte))
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # unused, kept for interface consistency
+    violations: list[str] = []
+
+    for path, passed, last_byte in _scan_scope():
+        if not passed:
+            violations.append(f"  {path}: last byte 0x{last_byte}")
+
+    if violations:
+        print("trailing-newline-gate FAIL:")
+        for v in violations:
+            print(v)
+        return 1
+
+    # Print nothing extra for empty files; they are not offenders.
+    print("trailing-newline-gate: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_trailing_newline_gate.py
+++ b/tests/test_trailing_newline_gate.py
@@ -1,0 +1,258 @@
+"""Tests for scripts/check_trailing_newline.py.
+
+Proves the trailing-newline gate in both directions:
+
+* GREEN, passing case: all files in scope end with exactly one ``0x0a``.
+* RED, failing case: a file missing its trailing newline exits non-zero and
+  names the offending path and its last byte.
+* RED, vacuous-fixture case: an empty file is not an offender.
+* RED, blank-line-at-EOF case: a file ending in two newlines (``0x0a0a``)
+  exits non-zero.
+* RED, two offenders in one run: both paths are reported.
+* SCOPE, file outside scope: a file with no newline outside the globs is
+  ignored (exit 0).
+* OVERRIDE: ``TRAILING_NEWLINE_ROOT`` actually redirects the scan, proven from
+  a fresh interpreter because the variable is read at import time.
+* REAL TREE: the gate is clean against this checkout, so a bad fragment turns a
+  plain ``pytest`` run red as well as CI.
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import scripts.check_trailing_newline as tng
+from scripts.check_trailing_newline import main as check_main
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_SCRIPT = REPO_ROOT / "scripts" / "check_trailing_newline.py"
+
+
+def _write(repo: Path, rel: str, text: str) -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(text.encode("utf-8"))
+    return path
+
+
+# ----------------------------------------------------------------------
+# Integration tests: the six required scenarios
+# ----------------------------------------------------------------------
+
+
+def _repo(tmp_path: Path) -> Path:
+    """Create a minimal repo checkout under *tmp_path*."""
+    repo = tmp_path / "repo"
+    (repo / "changelog.d").mkdir(parents=True)
+    (repo / "benchmarks" / "data").mkdir(parents=True)
+    return repo
+
+
+def _run_check(repo: Path) -> tuple[int, str]:
+    """Run the gate against *repo* in-process and return (exit_code, stdout).
+
+    This rebinds ``tng.REPO_ROOT`` directly. It does NOT exercise the
+    ``TRAILING_NEWLINE_ROOT`` environment variable, which is only read at import
+    time and therefore only reachable from a fresh interpreter; see
+    ``TestTrailingNewlineRootOverride`` for that.
+    """
+    original = tng.REPO_ROOT
+    buf = io.StringIO()
+    try:
+        tng.REPO_ROOT = repo
+        with redirect_stdout(buf):
+            rc = check_main([])
+    finally:
+        tng.REPO_ROOT = original
+    return rc, buf.getvalue()
+
+
+class TestTrailingNewlineGate:
+    def test_green_all_end_0x0a(self, tmp_path):
+        """fixture ends 0x0a -> exit 0"""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes\n")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n")
+        rc, out = _run_check(repo)
+        assert rc == 0, f"expected exit 0, got {rc}: {out!r}"
+        assert "trailing-newline-gate: clean" in out
+
+    def test_red_no_newline(self, tmp_path):
+        """fixture ends 0x2e (no newline) -> exit 1, offending path in output"""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes")
+        _write(repo, "benchmarks/data/README.md", "Pinned data")
+        rc, out = _run_check(repo)
+        assert rc == 1, f"expected exit 1, got {rc}: {out!r}"
+        assert "changelog.d/test.md" in out
+
+    def test_red_blank_line_at_eof(self, tmp_path):
+        """fixture ends 0x0a0a (blank line at EOF) -> exit 1 (exactly one newline)"""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes\n\n")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n\n")
+        rc, out = _run_check(repo)
+        assert rc == 1, f"expected exit 1, got {rc}: {out!r}"
+        assert "trailing-newline-gate FAIL" in out
+
+    def test_green_empty_fixture(self, tmp_path):
+        """empty fixture -> exit 0"""
+        repo = _repo(tmp_path)
+        changelog = repo / "changelog.d" / "empty.md"
+        changelog.write_text("")
+        readme = repo / "benchmarks" / "data" / "README.md"
+        readme.write_text("")
+        rc, out = _run_check(repo)
+        assert rc == 0, f"expected exit 0 for empty fixtures, got {rc}: {out!r}"
+        assert "trailing-newline-gate: clean" in out
+
+    def test_two_offenders_one_run(self, tmp_path):
+        """two offenders in one run -> exit 1 and BOTH paths reported"""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test1.md", "### Release notes")
+        _write(repo, "changelog.d/test2.md", "### More notes")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n")
+        rc, out = _run_check(repo)
+        assert rc == 1, f"expected exit 1, got {rc}: {out!r}"
+        assert "changelog.d/test1.md" in out
+        assert "changelog.d/test2.md" in out
+
+    def test_scope_respected_outside_globs(self, tmp_path):
+        """file outside the scope globs, no newline -> exit 0 (scope is respected)"""
+        repo = _repo(tmp_path)
+        outside = repo / "src" / "orphan.md"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("orphan content")
+        rc, out = _run_check(repo)
+        assert rc == 0, f"expected exit 0 when outside scope, got {rc}: {out!r}"
+        assert "trailing-newline-gate: clean" in out
+
+    def test_last_byte_hex_report(self, tmp_path):
+        """Verify the exact hex byte is reported for a no-newline file."""
+        repo = _repo(tmp_path)
+        # Content ending with 0x2e (period) and no trailing newline.
+        _write(repo, "changelog.d/test.md", "### Release notes.")
+        rc, out = _run_check(repo)
+        assert rc == 1
+        # The output should contain the path and the hex byte
+        lines = out.strip().splitlines()
+        # Find lines containing the path
+        path_lines = [l for l in lines if "changelog.d/test.md" in l]
+        assert len(path_lines) >= 1, f"Expected path in output, got: {out!r}"
+        # The hex byte should be 0x2e (period, the last byte).
+        assert "0x2e" in out
+
+    def test_passing_with_exact_one_newline(self, tmp_path):
+        """Verify files with exactly one trailing newline pass."""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes\n")
+        readme = repo / "benchmarks" / "data" / "README.md"
+        readme.write_text("Pinned data\n")
+        rc, out = _run_check(repo)
+        assert rc == 0, f"expected exit 0 for files with exactly one newline, got {rc}: {out!r}"
+        assert "trailing-newline-gate: clean" in out
+
+    def test_benchmarks_readme_no_newline(self, tmp_path):
+        """RED: benchmarks/data/README.md missing trailing newline."""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes\n")
+        _write(repo, "benchmarks/data/README.md", "Pinned data")
+        rc, out = _run_check(repo)
+        assert rc == 1, f"expected exit 1 for missing README trailing newline, got {rc}: {out!r}"
+        assert "benchmarks/data/README.md" in out
+
+    def test_changelog_multiple_offenders(self, tmp_path):
+        """RED: multiple changelog fragments all missing newlines."""
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/fix1.md", "Fix one")
+        _write(repo, "changelog.d/fix2.md", "Fix two")
+        _write(repo, "changelog.d/fix3.md", "Fix three")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n")
+        rc, out = _run_check(repo)
+        assert rc == 1, f"expected exit 1 for multiple changelog offenders, got {rc}: {out!r}"
+        assert "changelog.d/fix1.md" in out
+        assert "changelog.d/fix2.md" in out
+        assert "changelog.d/fix3.md" in out
+
+
+# ----------------------------------------------------------------------
+# The TRAILING_NEWLINE_ROOT override, which is documented in the gate's
+# docstring and read at import time. Every test above rebinds tng.REPO_ROOT
+# in-process, so none of them touch the environment variable at all: dropping
+# the override entirely (``REPO_ROOT = _REPO_ROOT``) leaves them all green.
+# These tests spawn a real interpreter so the override is actually read.
+# ----------------------------------------------------------------------
+
+
+def _run_gate_subprocess(cwd: Path, root: str | None) -> subprocess.CompletedProcess[str]:
+    """Invoke the gate script in a fresh interpreter from *cwd*.
+
+    When *root* is not None it is passed as ``TRAILING_NEWLINE_ROOT``; when it
+    is None the variable is removed, so the gate falls back to the tree
+    containing the script.
+    """
+    env = os.environ.copy()
+    if root is None:
+        env.pop("TRAILING_NEWLINE_ROOT", None)
+    else:
+        env["TRAILING_NEWLINE_ROOT"] = root
+    return subprocess.run(
+        [sys.executable, str(GATE_SCRIPT)],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestTrailingNewlineRootOverride:
+    def test_override_redirects_the_scan_to_a_clean_tree(self, tmp_path):
+        """TRAILING_NEWLINE_ROOT=<clean fixture> -> exit 0 against the fixture.
+
+        Fails when the override is dropped: without it the gate scans the real
+        repository instead of the fixture, so the offender planted below is
+        never seen.
+        """
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/test.md", "### Release notes\n")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n")
+        result = _run_gate_subprocess(tmp_path, str(repo))
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stdout!r} {result.stderr!r}"
+        assert "trailing-newline-gate: clean" in result.stdout
+
+    def test_override_redirects_the_scan_to_an_offending_tree(self, tmp_path):
+        """TRAILING_NEWLINE_ROOT=<offending fixture> -> exit 1 naming the fixture path.
+
+        This is the assertion that kills the ``REPO_ROOT = _REPO_ROOT`` mutant:
+        the reported path must be the one under *tmp_path*, which can only
+        happen if the environment variable was honoured.
+        """
+        repo = _repo(tmp_path)
+        _write(repo, "changelog.d/offender.md", "no trailing newline")
+        _write(repo, "benchmarks/data/README.md", "Pinned data\n")
+        result = _run_gate_subprocess(tmp_path, str(repo))
+        assert result.returncode == 1, f"expected exit 1, got {result.returncode}: {result.stdout!r} {result.stderr!r}"
+        assert "trailing-newline-gate FAIL" in result.stdout
+        assert str(repo / "changelog.d" / "offender.md") in result.stdout
+        assert "last byte 0x65" in result.stdout
+
+
+class TestRealRepositoryTree:
+    def test_gate_is_clean_against_the_real_repository(self, tmp_path):
+        """The gate exits 0 against this checkout, with no override set.
+
+        This is the only test that reads the repository's own files, and so the
+        only one that makes a plain ``pytest`` run go red when a fragment is
+        committed without its trailing newline. It is intended to fail when a
+        fragment is added badly; that is the point of it.
+        """
+        result = _run_gate_subprocess(tmp_path, None)
+        assert result.returncode == 0, (
+            "the real tree has a file in scope that does not end in exactly one "
+            f"newline:\n{result.stdout}{result.stderr}"
+        )
+        assert "trailing-newline-gate: clean" in result.stdout


### PR DESCRIPTION
Executes `tsk-n3eubn`, the revision card for blocked PR #368. Supersedes #368; the gate script from that PR is kept almost as-is, because the script was never the problem.

## What was wrong with #368

The gate was correct and unreachable. Nothing invoked it: `grep -rln check_trailing_newline` across `*.yml`, `*.yaml`, `*.toml`, `*.cfg`, `*.ini`, `*.sh` and `Makefile` returned no hits, while the repo's three sibling gates each ship their own workflow. All ten of its tests ran against a `tmp_path` fixture, so none of them ever read the repository.

The consequence, measured end to end on a trial merge of #368: with a real fragment whose last byte was `0x65` sitting in `changelog.d/`, the suite returned **1627 passed, 12 skipped** against a 1617 baseline. All ten new gate tests ran green while the exact defect they exist to catch sat unreported in the tree.

A gate has two properties: can it detect the defect, and does anything ever ask it to run. #368 had the first and not the second.

## What this PR adds

**`.github/workflows/trailing-newline-gate.yml`** (the mandatory item), modelled directly on `witness-token-gate.yml`: `pull_request` on opened/synchronize/reopened, `contents: read`, checkout@v7, setup-uv@v7, `uv python install 3.12`, `uv sync --python 3.12`, then `python scripts/check_trailing_newline.py`. It carries a header comment explaining the defect class, as all three siblings do.

**A real-tree test** (the optional item B). One test, asserting the gate exits 0 against the repository root, with no override set. No existing fixture test was converted. This is the only test that reads the repo's own files, and so the only thing that makes a plain `pytest` run red on a bad fragment rather than only CI. It is intended to fail when a fragment is added badly.

**Coverage for the `TRAILING_NEWLINE_ROOT` override** (item C). The override is documented in the gate's docstring and had zero coverage: it is read at import time, the tests call `check_main` in-process and monkeypatch `tng.REPO_ROOT`, and the `env` dict built at line 54 was constructed and discarded. Confirmed by mutant before writing anything: replacing line 30 with `REPO_ROOT = _REPO_ROOT`, ignoring the variable entirely, left **10 passed**. Two subprocess tests now spawn a fresh interpreter so the variable is actually read, and the dead `env` dict is gone.

**Item D**: the em dash in `check_trailing_newline.py` is now a semicolon. The stale `# Still need to report empty-file cases.` line above it went with it, since it contradicted the line immediately below.

**Both new files now end in `0x0a`.** They did not. The script ended `0x29` and the test file ended `0x74`, while every sibling script on master ends `0x0a`. The PR was shipping the defect class it exists to prevent.

## Verification

Rebased onto current master first: `git rev-list --count HEAD..origin/master` reads **0**.

Full suite, twice, as the card asked:

| run | result |
|-----|--------|
| clean | **1661 passed, 12 skipped** (1648 baseline plus exactly the 13 gate tests) |
| with a fragment whose last byte is `0x61` in `changelog.d/` | **1 failed, 1660 passed, 12 skipped** |

The single failure is `TestRealRepositoryTree::test_gate_is_clean_against_the_real_repository`. That is the contrast with #368, where the same planted defect produced an all-green run.

The gate's own output, failing:

```
trailing-newline-gate FAIL:
  /tmp/exec-tsk-n3eubn/changelog.d/zz-probe-offender.md: last byte 0x65
exit=1
```

and clean:

```
trailing-newline-gate: clean
exit=0
```

Mutant results, aimed at the individual branch rather than the feature:

| mutant | before this PR | after |
|--------|----------------|-------|
| `REPO_ROOT = _REPO_ROOT` (override ignored) | 10 passed, survives | **1 failed**, 12 passed, killed by `test_override_redirects_the_scan_to_an_offending_tree` |

The surviving-mutant check kills on the reported path, not just the exit code: the offending path must be the one under `tmp_path`, which can only happen if the environment variable was honoured.

Other checks: no conflict markers; `check_deleted_symbols.py --base origin/master` clean; `normalise_handle_gate.py` clean; `check_witness_token.py` clean; all 38 fragments in `changelog.d/` terminate in `0x0a`; both new Python files `ast.parse()` cleanly and the workflow parses as YAML.

Trial merge against current master shows **4 files changed, 412 insertions, 0 deletions**, all four `A`. Zero deletions is the proof that nothing on master is reverted, which a diff against the branch base could not have shown.

## Not done, deliberately

The byte-checking logic is untouched: the empty-file rule, the `0x0a0a` blank-line-at-EOF rule and the reported hex byte are all correct and covered. `SCOPE_GLOBS` is not widened; `find benchmarks -name 'README*'` still returns exactly one file, so the two current globs are the right scope even though the card title says READMEs plural.
