### PR TITLE
ci(lint): configure ruff, declare it, run it in CI, fix the docs invocation, and clear the 35 findings it exposes (tsk-rhuge6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
         run: uv sync --python 3.12
       - name: Compile check (two merged branches previously shipped files that do not parse)
         run: uv run python -m compileall -q taosmd/
+      - name: Lint (pyflakes via ruff; its own step so a lint failure is not read as a test failure)
+        run: uv run ruff check taosmd/
       - name: Tests
         run: uv run pytest tests/ -q

--- a/changelog.d/tsk-rhuge6-ruff-lint-gate.md
+++ b/changelog.d/tsk-rhuge6-ruff-lint-gate.md
@@ -1,0 +1,6 @@
+### Added
+- Ruff is configured for pyflakes rules (`[tool.ruff.lint] select = ["F"]`), declared as a pinned dev dependency, and run as its own `ci.yml` step against `taosmd/`, so a dead import or dead local binding fails the job instead of accumulating.
+
+### Fixed
+- Cleared the 35 pyflakes findings that configuration exposed: 28 unused imports, 6 dead local bindings and one redefinition. Six apparent findings in `taosmd/__init__.py` were deliberate re-exports and are now declared in `__all__` rather than deleted.
+- The five `docs/agent-jobs/` files now say `uv run ruff check`, matching how `ci.yml` invokes everything else. The previous `python3 -m ruff check` form was never broken; it failed only because ruff was not installed anywhere, which the dev dependency above fixes.

--- a/docs/agent-jobs/DONE-job-005-collections-db-connect.md
+++ b/docs/agent-jobs/DONE-job-005-collections-db-connect.md
@@ -106,7 +106,7 @@ from . import _db
    `grep -n "sqlite3\." taosmd/collections.py` that other uses remain.
 7. `python3 -m pytest tests/test_collections_db_connect.py -q` (2 passed),
    then the FULL suite `python3 -m pytest -q -m "not slow"`, then
-   `python3 -m ruff check taosmd/collections.py tests/test_collections_db_connect.py`.
+   `uv run ruff check taosmd/collections.py tests/test_collections_db_connect.py`.
 8. One commit, push, open the PR. PR body: the inconsistency, the one-line
    fix, confirmation that nothing in the store depended on the journal mode,
    and the test count. Reference issue #202. Do not merge.

--- a/docs/agent-jobs/README.md
+++ b/docs/agent-jobs/README.md
@@ -24,7 +24,9 @@ Do not improvise.
 7. The full test suite must pass before you push:
    `python3 -m pytest -q -m "not slow"` (well over a thousand tests, all
    green; record the exact number in your PR body). Lint the files you
-   changed: `python3 -m ruff check <files>`.
+   changed: `uv run ruff check <files>`. Do not invent a substitute tool. If
+   that command cannot run, your environment is broken: report it and stop,
+   rather than working around it.
 8. Never commit IP addresses, hostnames, tokens, or credentials.
 9. STOP on any surprise: a failing test you did not cause, a merge conflict,
    a file that does not look like the job describes. Open the PR with what

--- a/docs/agent-jobs/job-002-cross-encoder-path-fix.md
+++ b/docs/agent-jobs/job-002-cross-encoder-path-fix.md
@@ -103,7 +103,7 @@ def _default_onnx_path() -> str:
 7. `python3 -m pytest tests/test_cross_encoder_path.py -q` (3 passed), then
    the FULL suite `python3 -m pytest -q -m "not slow"` (all green; the
    existing reranker tests prove explicit-path behavior is unchanged), then
-   `python3 -m ruff check taosmd/cross_encoder.py tests/test_cross_encoder_path.py`.
+   `uv run ruff check taosmd/cross_encoder.py tests/test_cross_encoder_path.py`.
 8. One commit, push, open the PR. PR body: the bug (cwd-dependent default),
    the fix (repo-root-resolved default, explicit arg untouched), test counts.
 

--- a/docs/agent-jobs/job-003-http-server-dead-import.md
+++ b/docs/agent-jobs/job-003-http-server-dead-import.md
@@ -65,6 +65,6 @@ def _webui_dir() -> Path | None:
    it.
 5. `python3 -m pytest -q -m "not slow"` (all green; the webui-serving tests
    cover this function), and
-   `python3 -m ruff check taosmd/http_server.py` (the F401 finding for
+   `uv run ruff check taosmd/http_server.py` (the F401 finding for
    `_ir` must be gone; do not fix any OTHER findings).
 6. One commit, push, open the PR.

--- a/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
+++ b/docs/agent-jobs/job-004-eventqa-runner-exit-code.md
@@ -178,7 +178,7 @@ def test_zero_graph_expansion_never_probes(runner, monkeypatch):
 7. Re-run the file: `python3 -m pytest tests/test_eventqa_retrieve_wiring.py -q`
    (all green), then the FULL suite
    `python3 -m pytest -q -m "not slow"`, then
-   `python3 -m ruff check benchmarks/eventqa_runner.py tests/test_eventqa_retrieve_wiring.py`.
+   `uv run ruff check benchmarks/eventqa_runner.py tests/test_eventqa_retrieve_wiring.py`.
 8. One commit, push, open the PR. PR body: the bug (a refusal exited 0 so a
    chain read it as success), the fix (`sys.exit(1)` on both refusal paths,
    the dry-run success return untouched), the reference it copies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,14 @@ registry = ["pyjwt>=2.8", "cryptography>=42"]
 # Keeping both lets pip users keep using extras and uv users get tests for
 # free, without putting pyjwt/cryptography in core [project] dependencies.
 [dependency-groups]
-dev = ["pytest", "pytest-asyncio", "pyjwt>=2.8", "cryptography>=42"]
+dev = ["pytest", "pytest-asyncio", "pyjwt>=2.8", "cryptography>=42", "ruff==0.16.3"]
+
+# Pyflakes rules only. This catches dead imports and dead local bindings, the
+# drift that has actually occurred here, without ruff reformatting the tree or
+# ruling on style. Widen it deliberately or not at all: adding rules to hide a
+# finding is the failure this gate exists to prevent.
+[tool.ruff.lint]
+select = ["F"]
 
 [tool.setuptools.packages.find]
 include = ["taosmd*"]

--- a/taosmd/__init__.py
+++ b/taosmd/__init__.py
@@ -202,4 +202,15 @@ __all__ = [
     "local_probe",
     # Librarian prompts
     "prompts",
+    # Re-exported above but previously undeclared. These are imported so that
+    # attribute access works (taosmd.config, taosmd.loaders and so on) and
+    # callers across the tree rely on it, so they are declared here rather than
+    # dropped. Declaring them also puts them under the deleted-symbols gate,
+    # which only tracks what __all__ names.
+    "predicate_vocab",
+    "emem_event_lift",
+    "loaders",
+    "config",
+    "list_pending_decisions",
+    "resolve_pending_decision",
 ]

--- a/taosmd/admin.py
+++ b/taosmd/admin.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import time
 from pathlib import Path
 from typing import Any

--- a/taosmd/agents.py
+++ b/taosmd/agents.py
@@ -31,7 +31,6 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,62}$")
 

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -15,7 +15,6 @@ import gzip
 import hashlib
 import json
 import logging
-import os
 import sqlite3
 import time
 from datetime import datetime, timezone

--- a/taosmd/backend.py
+++ b/taosmd/backend.py
@@ -9,7 +9,6 @@ settings_schema to dynamically render config forms.
 """
 
 from __future__ import annotations
-from typing import Any
 
 
 class MemoryBackend:

--- a/taosmd/catalog_pipeline.py
+++ b/taosmd/catalog_pipeline.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +23,6 @@ import httpx
 from .agents import run_if_enabled
 from .config import resolve_memory_model
 from .generator_profiles import split_provider
-from .prompts import intake_classification_prompt
 from .session_catalog import SessionCatalog
 from .crystallize import CrystalStore
 from .knowledge_graph import TemporalKnowledgeGraph
@@ -162,7 +161,6 @@ class CatalogPipeline:
         # --- Stage 1: Split ---
         split_result = self.catalog.split_day(date, force=force)
         result["split"] = split_result
-        sessions_created = split_result.get("sessions_created", 0)
 
         tier, model = await self.detect_best_tier()
         # The memory model is a system-wide setting. When configured it
@@ -359,7 +357,6 @@ class CatalogPipeline:
 
         for path in archive_files:
             # Expect structure: archive_dir/YYYY/MM/DD.jsonl[.gz]
-            parts = path.parts
             try:
                 # Walk up from filename to get year/month/day
                 day_part = path.stem  # "DD" (strip .jsonl or .jsonl from .gz)

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -611,7 +611,7 @@ def _install_skill_cmd(args: argparse.Namespace) -> int:
     if not skill_src_dir.is_dir():
         # Fallback: try importlib.resources (wheel installs)
         try:
-            ref = _pkg_files("taosmd").joinpath("skills/taosmd-a2a")
+            _ref = _pkg_files("taosmd").joinpath("skills/taosmd-a2a")
             # Convert Traversable to a concrete path via __file__ approach.
             skill_src_dir = Path(__file__).parent / "skills" / "taosmd-a2a"
         except Exception:
@@ -679,7 +679,6 @@ def _review_cmd(args: argparse.Namespace) -> int:
     import asyncio
     from pathlib import Path
     from .pending_decisions import PendingDecisionsStore
-    from .knowledge_graph import TemporalKnowledgeGraph
 
     kg_path = Path(args.data_dir) / "knowledge-graph.db"
     if not kg_path.exists():

--- a/taosmd/controls.py
+++ b/taosmd/controls.py
@@ -24,7 +24,7 @@ Scope:
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from . import generator_profiles as _gp
 

--- a/taosmd/emem_edu.py
+++ b/taosmd/emem_edu.py
@@ -23,7 +23,6 @@ and an empty-filter fallback at retrieval).
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import httpx
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -210,7 +210,6 @@ def _webui_dir() -> Path | None:
     try:
         ref = _pkg_files("taosmd").joinpath("webui")
         # In Python 3.9+ files() returns a Traversable; we need a real Path.
-        import importlib.resources as _ir  # noqa: PLC0415
         # For wheels, traverse to a concrete path via as_file context is
         # awkward to keep open; instead resolve via __file__ which always works.
         _ = ref  # suppress unused-variable on the import above

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -212,7 +212,7 @@ def _webui_dir() -> Path | None:
         # In Python 3.9+ files() returns a Traversable; we need a real Path.
         # For wheels, traverse to a concrete path via as_file context is
         # awkward to keep open; instead resolve via __file__ which always works.
-        _ = ref  # suppress unused-variable on the import above
+        _ = ref  # keeps `ref` above from tripping the unused-local rule
     except Exception:
         pass
     # Use __file__-relative path, reliable in both source and wheel.

--- a/taosmd/knowledge_graph.py
+++ b/taosmd/knowledge_graph.py
@@ -261,7 +261,7 @@ class TemporalKnowledgeGraph:
         synonyms collapse onto their canonical form. A warning is logged
         if the resulting predicate isn't in the vocab.
         """
-        from .predicate_vocab import normalise, validate
+        from .predicate_vocab import validate
         if strict_vocab:
             predicate = validate(predicate, strict=True)
         else:

--- a/taosmd/memory_extractor.py
+++ b/taosmd/memory_extractor.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -59,9 +59,9 @@ migration**, because the schema constant cannot deliver it.
 from __future__ import annotations
 
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable, Sequence, Union
+from typing import Callable, Sequence, Union
 
 __all__ = [
     "Migration",

--- a/taosmd/predicate_vocab.py
+++ b/taosmd/predicate_vocab.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Iterable
 
 logger = logging.getLogger(__name__)
 

--- a/taosmd/query_expansion.py
+++ b/taosmd/query_expansion.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import re
-import time
 from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)

--- a/taosmd/receipts.py
+++ b/taosmd/receipts.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-import time
 
 __all__ = ["SCHEMA", "ReceiptStore"]
 

--- a/taosmd/retrieval.py
+++ b/taosmd/retrieval.py
@@ -12,7 +12,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from taosmd.agents import run_if_enabled, is_task_enabled  # noqa: E402
+from taosmd.agents import is_task_enabled  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Normalised result schema (for reference):
@@ -849,7 +849,7 @@ async def retrieve(
     Returns:
         List of normalised result dicts, sorted by relevance, length <= limit.
     """
-    from taosmd.intent_classifier import classify_intent, get_search_strategy  # noqa: PLC0415
+    from taosmd.intent_classifier import get_search_strategy  # noqa: PLC0415
 
     if sources is None:
         sources = {}

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -29,7 +29,6 @@ import hashlib
 import json
 import logging
 import math
-import re
 import time
 
 from . import api as _api
@@ -368,7 +367,7 @@ async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
         return await remote.fetch_by_ref(ref, agent=agent)
 
     from . import config as _config
-    from .ref_fetch import HashMismatchError, NotFoundError, RefFetchError, UnauthorizedError, fetch_by_ref as _fetch_by_ref
+    from .ref_fetch import NotFoundError, RefFetchError, UnauthorizedError, fetch_by_ref as _fetch_by_ref
 
     registry_token = _config.get_registry_token(data_dir)
 
@@ -524,7 +523,6 @@ async def a2a_feed(
     # Apply admin alias resolution: reads of a new channel name include history
     # from the old name. Resolve thread through the alias map so callers
     # querying the canonical name see both old and new messages.
-    resolved_thread = thread
     alias_sources: list[str] = []
     if data_dir is not None:
         from .admin import A2AAdminState  # noqa: PLC0415

--- a/taosmd/service_install.py
+++ b/taosmd/service_install.py
@@ -125,7 +125,7 @@ def uninstall_systemd() -> int:
 
     Returns 0 on success, non-zero on error.
     """
-    rc = _run_systemctl(["disable", "--now", _SYSTEMD_UNIT_NAME])
+    _rc = _run_systemctl(["disable", "--now", _SYSTEMD_UNIT_NAME])
     # rc may be non-zero if the unit was never enabled; tolerate that.
     unit_path = Path.home() / ".config" / "systemd" / "user" / _SYSTEMD_UNIT_NAME
     if unit_path.exists():

--- a/taosmd/service_install.py
+++ b/taosmd/service_install.py
@@ -126,7 +126,8 @@ def uninstall_systemd() -> int:
     Returns 0 on success, non-zero on error.
     """
     _rc = _run_systemctl(["disable", "--now", _SYSTEMD_UNIT_NAME])
-    # rc may be non-zero if the unit was never enabled; tolerate that.
+    # The return code is deliberately discarded: it is non-zero when the unit
+    # was never enabled, which is not an error for an uninstall.
     unit_path = Path.home() / ".config" / "systemd" / "user" / _SYSTEMD_UNIT_NAME
     if unit_path.exists():
         unit_path.unlink()

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -460,7 +460,6 @@ async def prime(
     ]
 
     header = "=== taOSmd Task Briefing ===\n"
-    tail = ""
     if project:
         header += f"Project: {project}\n"
     header += "\n"

--- a/taosmd/temporal_boost.py
+++ b/taosmd/temporal_boost.py
@@ -10,7 +10,6 @@ Inspired by KG-IRAG and MemoTime temporal reasoning approaches.
 from __future__ import annotations
 
 import re
-from datetime import datetime
 
 
 # Temporal anchor patterns in queries


### PR DESCRIPTION
Executes `tsk-rhuge6`, which combines the revisions of blocked PRs #362 (the config) and #367 (the docs). Two commits so the review surfaces stay separate: the lint findings first, then the infrastructure that exposes them.

## The card's premise held, and one thing it did not anticipate

Re-measured rather than inherited. Ruff was declared nowhere, no workflow referenced it, and the bare `ruff check` form resolves on this box to `/home/jay/.local/bin/ruff`, a machine-local install in no manifest. `uv sync` in this branch now installs `ruff 0.16.3` to the worktree's own `.venv`, so the CI step resolves to a repo-local binary rather than that one.

What the card did not anticipate: **turning the config on made the tree red with 35 findings**, so there was no version of this PR where the lint step lands green without addressing them. The card forbids widening the config or adding ignores to hide findings, so they are fixed. That is commit 1.

**Six of the 35 were not dead code at all.** They are in `taosmd/__init__.py`, and a blind `--fix` would have deleted public API:

| symbol | why it is there |
|--------|-----------------|
| `config`, `loaders`, `predicate_vocab`, `emem_event_lift` | imported so `taosmd.<name>` attribute access works; referenced across the tree |
| `list_pending_decisions`, `resolve_pending_decision` | added to the api import block and never declared in `__all__` |

They are added to `__all__` rather than deleted, which is the remedy ruff itself suggests, and it also puts them under `check_deleted_symbols.py`, since that gate only tracks what `__all__` names. This is the exact defect class that gate exists for, so the order of work mattered: the declarations went in **before** `--fix` ran, so autofix could not remove them.

Two of the six dead bindings have right-hand sides with side effects or that can raise, so the call is preserved and only the binding is renamed with a leading underscore: `_pkg_files(...).joinpath(...)` in `cli.py`, which sits inside a `try/except`, and `_run_systemctl(...)` in `service_install.py`, whose own comment explains a non-zero result is tolerated. Deleting those lines would have removed behaviour, not dead weight.

One finding looked like a live bug and is not. `resolved_thread = thread` in `service.py` is assigned under a comment about alias resolution and never read, but the alias feature works through `alias_sources`, which is used correctly. It is a vestigial binding from an earlier approach, so removing it changes nothing.

## The lint step engages, proven red and green

A lint step only ever observed green is indistinguishable from one that is not running, which is the whole defect this card is about. Using the CI step's exact command:

```
uv run ruff check taosmd/          ->  All checks passed!        exit=0
  (one deliberate dead import added, insertion asserted present)
uv run ruff check taosmd/          ->  F401 `math` imported but unused
                                       Found 1 error.            exit=1
  (probe removed)
uv run ruff check taosmd/          ->  All checks passed!        exit=0
```

## The docs, and correcting #367's diagnosis

#367 rewrote the five files to a bare `ruff check` on the stated grounds that the module form was broken. That diagnosis is wrong and it had shipped as a changelog claim. With ruff installed, `python -m ruff check` and `ruff check` produce identical output and identical exit codes; the module form failed only because ruff was installed nowhere, which the dev dependency now fixes.

All five files use `uv run ruff check`, matching how `ci.yml` already invokes `uv run pytest` and `uv run python -m compileall`. Surrounding three-space continuation indentation is left alone. #367's sentence `Do not invent a substitute tool.` is kept; its companion instruction to skip the check when the tool is missing is dropped, since a missing binary now means a broken environment worth reporting. The changelog fragment does not repeat the false claim.

## Verification

- `git rev-list --count HEAD..origin/master` reads **0**.
- Acceptance 1: `git grep -n 'python3 -m ruff\|python -m ruff' docs/` returns nothing; `git grep -ln 'uv run ruff' docs/` returns **5** files.
- Full suite: **1661 passed, 12 skipped**, identical before and after the lint fixes, so the 35 removals changed no behaviour. Note the card's stated baseline of 1617 is stale; master is 1661 as of `80efb5cf`.
- `uv run python -m compileall -q taosmd/` clean, and `pyproject.toml` and `ci.yml` both parse.
- Gates on the branch: `check_deleted_symbols.py --base origin/master` clean, which is the one that matters most here, plus `normalise_handle_gate.py`, `check_witness_token.py` and the new `check_trailing_newline.py` all clean. No conflict markers.
- `import taosmd` asserts all six re-exports are present as attributes **and** declared in `__all__`, which is now 80 entries.
- Fragment ends `0x0a`.

## Two observations, neither blocking

`.venv` is not in the repository's `.gitignore`. It is invisible to `git status` only because uv writes a nested `.venv/.gitignore` containing `*`. That is uv's behaviour rather than the repo's, so any tool that populates a virtualenv differently would leave it stageable. Worth a one-line ignore entry at some point.

The lint step is scoped to `taosmd/`, matching the existing compile-check step. `tests/` has 68 findings and `benchmarks/` 77, none of them addressed here. Widening the scope is a separate piece of work and should be its own card rather than folded into this one; flagged rather than silently left out.
