### PR TITLE
uninstall_systemd documents a non-zero error return it can never produce, and swallows both systemctl results

### DIFF
--- a/changelog.d/tsk-23zx64-systemd-uninstall-return.md
+++ b/changelog.d/tsk-23zx64-systemd-uninstall-return.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `uninstall_systemd()` in `taosmd/service_install.py` now returns non-zero when
+  `daemon-reload` fails or the unit file cannot be removed, instead of always
+  returning 0. Added unit tests for both failure paths and the missing-unit
+  no-op path.

--- a/taosmd/service_install.py
+++ b/taosmd/service_install.py
@@ -130,9 +130,14 @@ def uninstall_systemd() -> int:
     # was never enabled, which is not an error for an uninstall.
     unit_path = Path.home() / ".config" / "systemd" / "user" / _SYSTEMD_UNIT_NAME
     if unit_path.exists():
-        unit_path.unlink()
+        try:
+            unit_path.unlink()
+        except OSError:
+            return 1
         print(f"Removed unit file: {unit_path}")
-        _run_systemctl(["daemon-reload"])
+        rc = _run_systemctl(["daemon-reload"])
+        if rc != 0:
+            return rc
     else:
         print("Unit file not found, nothing to remove.")
     print("taosmd service stopped and uninstalled.")

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -453,6 +453,88 @@ class TestXmlEscape:
         assert service_install._xml_escape("/usr/bin/python3") == "/usr/bin/python3"
 
 
+# ── uninstall_systemd ─────────────────────────────────────────────────────────
+
+class TestUninstallSystemd:
+    def test_uninstall_systemd_returns_zero_on_success(self, monkeypatch, tmp_path):
+        unit_dir = tmp_path / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+        unit_path = unit_dir / "taosmd.service"
+        unit_path.write_text("dummy")
+
+        calls = []
+        def fake_run_systemctl(args):
+            calls.append(args)
+            return 0
+
+        monkeypatch.setattr(service_install, "_run_systemctl", fake_run_systemctl)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        rc = service_install.uninstall_systemd()
+        assert rc == 0
+        assert not unit_path.exists()
+        assert calls == [
+            ["disable", "--now", "taosmd.service"],
+            ["daemon-reload"],
+        ]
+
+    def test_uninstall_systemd_returns_nonzero_on_daemon_reload_failure(
+        self, monkeypatch, tmp_path
+    ):
+        unit_dir = tmp_path / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+        unit_path = unit_dir / "taosmd.service"
+        unit_path.write_text("dummy")
+
+        results = [0, 1]
+        idx = [0]
+        def fake_run_systemctl(args):
+            rc = results[idx[0]]
+            idx[0] += 1
+            return rc
+
+        monkeypatch.setattr(service_install, "_run_systemctl", fake_run_systemctl)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        rc = service_install.uninstall_systemd()
+        assert rc == 1
+
+    def test_uninstall_systemd_returns_nonzero_on_unlink_failure(
+        self, monkeypatch, tmp_path
+    ):
+        unit_dir = tmp_path / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+        unit_path = unit_dir / "taosmd.service"
+        unit_path.write_text("dummy")
+
+        monkeypatch.setattr(service_install, "_run_systemctl", lambda args: 0)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        def fake_unlink(self, *args, **kwargs):
+            raise OSError("simulated unlink failure")
+
+        monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+        rc = service_install.uninstall_systemd()
+        assert rc == 1
+
+    def test_uninstall_systemd_missing_unit_file(self, monkeypatch, tmp_path):
+        unit_dir = tmp_path / ".config" / "systemd" / "user"
+        unit_dir.mkdir(parents=True)
+
+        calls = []
+        def fake_run_systemctl(args):
+            calls.append(args)
+            return 0
+
+        monkeypatch.setattr(service_install, "_run_systemctl", fake_run_systemctl)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        rc = service_install.uninstall_systemd()
+        assert rc == 0
+        assert calls == [["disable", "--now", "taosmd.service"]]
+
+
 # ── CLI integration (no subprocess side-effects) ──────────────────────────────
 
 class TestCliFlags:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): uninstall_systemd documents a non-zero error return it can never produce, and swallows both systemctl results

Autonomous build of board card tsk-23zx64.

The function previously discarded the daemon-reload result and let unlink()
exceptions propagate, while its docstring promised a non-zero return on
error. Catch OSError from unlink() and return 1, and return the
daemon-reload exit code when it is non-zero. The disable --now result
remains deliberately discarded. Added unit tests for the two new failure
paths and the missing-unit no-op path.

Files:
 changelog.d/tsk-23zx64-systemd-uninstall-return.md |  6 ++
 taosmd/service_install.py                          |  9 ++-
 tests/test_service_install.py                      | 82 ++++++++++++++++++++++
 3 files changed, 95 insertions(+), 2 deletions(-)