### PR TITLE
Revise PR #378: the lint gate is widened to tests/ AND benchmarks/ but only tests/ was partly cleared, so the step goes red on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Compile check (two merged branches previously shipped files that do not parse)
         run: uv run python -m compileall -q taosmd/
       - name: Lint (pyflakes via ruff; its own step so a lint failure is not read as a test failure)
-        run: uv run ruff check taosmd/
+        run: uv run ruff check taosmd/ tests/ benchmarks/
       - name: Tests
         run: uv run pytest tests/ -q

--- a/benchmarks/beam_feasibility_probe.py
+++ b/benchmarks/beam_feasibility_probe.py
@@ -94,7 +94,7 @@ async def main():
     print("  --- extrapolation (one conversation; a full BEAM run is 100 of these) ---")
     print(f"    this split full ingest (x100 convs): ~{embed_s*100/60:.1f} min embed")
     if SPLIT == "100K":
-        print(f"    1M tier is ~10x heavier per conversation; 10M ~100x")
+        print("    1M tier is ~10x heavier per conversation; 10M ~100x")
     print(f"  VERDICT INPUTS: tokens/conv={est_tokens}, embed_s/conv={embed_s:.1f}, RSS={rss_mb:.0f}MB")
 
 

--- a/benchmarks/claims_gate_probe.py
+++ b/benchmarks/claims_gate_probe.py
@@ -52,7 +52,6 @@ import json
 import os
 import sys
 import tempfile
-import time
 from pathlib import Path
 
 import httpx

--- a/benchmarks/combo_benchmark.py
+++ b/benchmarks/combo_benchmark.py
@@ -22,17 +22,16 @@ import os
 import sys
 import tempfile
 import time
-from itertools import product
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import httpx
 
-from taosmd import VectorMemory, KnowledgeGraph, Archive, SessionCatalog
+from taosmd import VectorMemory, KnowledgeGraph, Archive
 from taosmd.memory_extractor import extract_facts_from_text
 from taosmd.query_expansion import expand_query_fast
 from taosmd.temporal_boost import temporal_rerank, classify_temporal_query
-from taosmd.retrieval import retrieve, _rrf_merge, _deduplicate, _adapt_vector
+from taosmd.retrieval import retrieve
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "longmemeval_s_full.json")
 ONNX_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "models", "minilm-onnx")
@@ -244,7 +243,7 @@ async def run_question(item, top_k, config, http_client=None):
 
 async def run_benchmark(limit: int = 500, top_k: int = 5):
     print("=" * 78)
-    print(f"Combo Benchmark — Exhaustive pipeline path combinations")
+    print("Combo Benchmark — Exhaustive pipeline path combinations")
     print(f"LLM: {LLM_MODEL} | Embed: MiniLM ONNX | {limit} questions | Top-{top_k}")
     print("=" * 78)
 

--- a/benchmarks/fusion_shootout.py
+++ b/benchmarks/fusion_shootout.py
@@ -48,7 +48,6 @@ async def run_question(item, top_k, config):
 
     # Search with config-specific parameters
     search_query = question
-    retrieve_k = top_k
 
     if config == "raw_semantic":
         results = await vmem.search(question, limit=top_k, hybrid=False)

--- a/benchmarks/locomo_runner.py
+++ b/benchmarks/locomo_runner.py
@@ -1295,7 +1295,7 @@ async def _process_qa(
                         no_think_prefix=no_think_prefix,
                         force_empty_think=force_empty_think,
                     )
-            except Exception as cove_exc:
+            except Exception:
                 # if any verification step fails, fall back to draft
                 predicted = draft
         else:

--- a/benchmarks/longmemeval_enhanced.py
+++ b/benchmarks/longmemeval_enhanced.py
@@ -117,7 +117,7 @@ async def run_question(item, top_k, config):
 async def run_benchmark(limit: int = 500, top_k: int = 5):
     print("=" * 74)
     print(f"LongMemEval-S Enhanced Retrieval Experiments — Recall@{top_k}")
-    print(f"Model: all-MiniLM-L6-v2 (ONNX) — same as MemPalace")
+    print("Model: all-MiniLM-L6-v2 (ONNX) — same as MemPalace")
     print(f"Target: beat 96.6% (MemPalace) on {limit} questions")
     print("=" * 74)
 
@@ -168,7 +168,7 @@ async def run_benchmark(limit: int = 500, top_k: int = 5):
         overall = total_recall / total_questions * 100
 
         print(f"\n  Result: {total_recall}/{total_questions} ({overall:.1f}%) in {total_time:.0f}s")
-        print(f"  By category:")
+        print("  By category:")
         for qtype, data in sorted(results_by_type.items()):
             pct = data["hits"] / data["total"] * 100
             print(f"    {qtype:35s} {data['hits']:3d}/{data['total']:<3d} ({pct:.1f}%)")

--- a/benchmarks/longmemeval_granularity.py
+++ b/benchmarks/longmemeval_granularity.py
@@ -133,7 +133,7 @@ async def main():
 
     best = max(results, key=lambda x: x["pct"])
     print(f"\n  Best: {best['name']} ({best['pct']:.1f}%)")
-    print(f"  MemPalace (raw): 96.6%")
+    print("  MemPalace (raw): 96.6%")
     print(f"{'=' * 70}")
 
 

--- a/benchmarks/longmemeval_ku_runner.py
+++ b/benchmarks/longmemeval_ku_runner.py
@@ -267,7 +267,7 @@ async def main():
     if args.limit:
         ku = ku[:args.limit]
 
-    print(f"=== LongMemEval-KU supersede benchmark ===")
+    print("=== LongMemEval-KU supersede benchmark ===")
     print(f"config={args.config}  model={args.model}  questions={len(ku)}")
     print()
 

--- a/benchmarks/longmemeval_matrix.py
+++ b/benchmarks/longmemeval_matrix.py
@@ -130,7 +130,7 @@ async def run_question(item, top_k, config):
     # the KG to check if expanded entities give us confidence in existing
     # top-k results. We do NOT add new session IDs from outside top-k.
     if kg and results:
-        expanded = await expand_from_results(kg, results, max_hops=2, max_expanded=5)
+        await expand_from_results(kg, results, max_hops=2, max_expanded=5)
         # Graph expansion provides additional context but does NOT expand
         # the retrieved set beyond top-k. It's useful for QA accuracy (L2/L3
         # context assembly) but doesn't change Recall@k by design.
@@ -147,7 +147,7 @@ async def run_question(item, top_k, config):
 async def run_matrix(limit: int = 500, top_k: int = 5):
     print("=" * 74)
     print(f"LongMemEval-S Recall@{top_k} — Full Comparison Matrix")
-    print(f"Model: all-MiniLM-L6-v2 (ONNX, 384-dim) — same as MemPalace")
+    print("Model: all-MiniLM-L6-v2 (ONNX, 384-dim) — same as MemPalace")
     print(f"Dataset: {limit} questions, fresh index per question")
     print("=" * 74)
 
@@ -197,7 +197,7 @@ async def run_matrix(limit: int = 500, top_k: int = 5):
         overall = total_recall / total_questions * 100 if total_questions > 0 else 0
 
         print(f"\n  Result: {total_recall}/{total_questions} ({overall:.1f}%) in {total_time:.0f}s")
-        print(f"  By category:")
+        print("  By category:")
         for qtype, data in sorted(results_by_type.items()):
             pct = data["hits"] / data["total"] * 100 if data["total"] > 0 else 0
             print(f"    {qtype:35s} {data['hits']:3d}/{data['total']:<3d} ({pct:.1f}%)")
@@ -227,12 +227,12 @@ async def run_matrix(limit: int = 500, top_k: int = 5):
     print(f"  agentmemory (published, same model){'':>16s}  95.2%")
     print(f"  SuperMemory{'':>40s}  81.6%")
 
-    print(f"\n  Notes:")
-    print(f"  - All taOSmd runs use all-MiniLM-L6-v2 ONNX (same model as MemPalace)")
-    print(f"  - 'MemPalace method' = user-turns only, pure cosine similarity, no hybrid")
-    print(f"  - 'hybrid' = cosine + 30% keyword overlap boost")
-    print(f"  - 'graph expansion' provides richer context but doesn't change Recall@k")
-    print(f"  - 'all-turns' includes assistant responses (harder, more noise)")
+    print("\n  Notes:")
+    print("  - All taOSmd runs use all-MiniLM-L6-v2 ONNX (same model as MemPalace)")
+    print("  - 'MemPalace method' = user-turns only, pure cosine similarity, no hybrid")
+    print("  - 'hybrid' = cosine + 30% keyword overlap boost")
+    print("  - 'graph expansion' provides richer context but doesn't change Recall@k")
+    print("  - 'all-turns' includes assistant responses (harder, more noise)")
     print(f"{'='*74}")
 
     # Save results to JSON for reproducibility

--- a/benchmarks/longmemeval_recall.py
+++ b/benchmarks/longmemeval_recall.py
@@ -126,15 +126,15 @@ async def run_recall_benchmark(limit: int = 50, top_k: int = 5, question_type: s
     print(f"\n  Overall: {total_recall}/{total_questions} ({overall:.1f}%)")
     print(f"  Time: {total_time:.1f}s ({total_time/total_questions:.1f}s/question)")
 
-    print(f"\n  By category:")
+    print("\n  By category:")
     for qtype, data in sorted(results_by_type.items()):
         pct = data["hits"] / data["total"] * 100 if data["total"] > 0 else 0
         print(f"    {qtype:30s} {data['hits']:3d}/{data['total']:<3d} ({pct:.1f}%)")
 
     print(f"\n  Comparison (Recall@{top_k}):")
-    print(f"    MemPalace (raw, all-MiniLM-L6):    96.6%")
-    print(f"    MemPalace (AAAK compressed):        84.2%")
-    print(f"    MemPalace (room-based):             89.4%")
+    print("    MemPalace (raw, all-MiniLM-L6):    96.6%")
+    print("    MemPalace (AAAK compressed):        84.2%")
+    print("    MemPalace (room-based):             89.4%")
     print(f"    taOSmd (NPU, Qwen3-Embed-0.6B):    {overall:.1f}%")
     print(f"{'='*70}")
 

--- a/benchmarks/longmemeval_runner.py
+++ b/benchmarks/longmemeval_runner.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from taosmd.knowledge_graph import TemporalKnowledgeGraph
 from taosmd.archive import ArchiveStore
-from taosmd.memory_extractor import extract_facts_from_text, process_conversation_turn
+from taosmd.memory_extractor import process_conversation_turn
 from taosmd.context_assembler import ContextAssembler
 from taosmd.vector_memory import VectorMemory
 
@@ -450,15 +450,15 @@ async def run_benchmark(limit: int = 50, question_type: str | None = None, use_l
     print(f"\n  Overall: {total_correct}/{total_questions} ({overall:.1f}%)")
     print(f"  Total time: {total_time:.1f}s ({total_time/total_questions:.1f}s per question)")
 
-    print(f"\n  By question type:")
+    print("\n  By question type:")
     for qtype, data in sorted(results_by_type.items()):
         pct = data["correct"] / data["total"] * 100 if data["total"] > 0 else 0
         print(f"    {qtype:30s} {data['correct']:3d}/{data['total']:<3d} ({pct:.1f}%)")
 
-    print(f"\n  Comparison:")
-    print(f"    MemPalace (raw verbatim):     96.6%")
-    print(f"    SuperMemory:                  81.6%")
-    print(f"    GPT-4o (full context):        ~70%")
+    print("\n  Comparison:")
+    print("    MemPalace (raw verbatim):     96.6%")
+    print("    SuperMemory:                  81.6%")
+    print("    GPT-4o (full context):        ~70%")
     print(f"    taOSmd (Pi NPU, no cloud):    {overall:.1f}%")
     print(f"{'='*70}")
 

--- a/benchmarks/realworld_llm_benchmark.py
+++ b/benchmarks/realworld_llm_benchmark.py
@@ -29,11 +29,10 @@ import httpx
 
 from taosmd import (
     VectorMemory, KnowledgeGraph, Archive, SessionCatalog,
-    CrystalStore, retrieve,
+    retrieve,
 )
-from taosmd.memory_extractor import extract_facts_from_text, extract_facts_with_llm
+from taosmd.memory_extractor import extract_facts_from_text
 from taosmd.query_expansion import expand_query_fast
-from taosmd.session_catalog import SessionCatalog
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "longmemeval_s_full.json")
 ONNX_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "models", "minilm-onnx")
@@ -287,7 +286,7 @@ async def check_ollama():
 async def run_benchmark(limit: int = 500, top_k: int = 5):
     print("=" * 74)
     print(f"Real-World LLM Pipeline Benchmark — Recall@{top_k}")
-    print(f"Embedding: all-MiniLM-L6-v2 (ONNX)")
+    print("Embedding: all-MiniLM-L6-v2 (ONNX)")
     print(f"LLM: {LLM_MODEL} via Ollama")
     print(f"Dataset: {limit} questions")
     print("=" * 74)
@@ -309,7 +308,7 @@ async def run_benchmark(limit: int = 500, top_k: int = 5):
         ("vector_only", "Vector + hybrid + query expansion (baseline)"),
         ("regex_kg", "Vector + regex KG extraction"),
         ("llm_kg", f"Vector + LLM KG extraction ({LLM_MODEL})"),
-        ("full_llm_fanout", f"Full LLM pipeline + retrieve(thorough)"),
+        ("full_llm_fanout", "Full LLM pipeline + retrieve(thorough)"),
     ]
 
     all_results = {}

--- a/benchmarks/realworld_pipeline_benchmark.py
+++ b/benchmarks/realworld_pipeline_benchmark.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from taosmd import (
     VectorMemory, KnowledgeGraph, Archive, SessionCatalog,
-    CrystalStore, retrieve,
+    retrieve,
 )
 from taosmd.memory_extractor import extract_facts_from_text
 from taosmd.query_expansion import expand_query_fast
@@ -170,7 +170,7 @@ async def run_question_full_pipeline(item, top_k, use_fanout=False):
             continue
         sid = session_ids[si] if si < len(session_ids) else f"s{si}"
 
-        ingest_result = await ingest_session(text, sid, vmem, kg, archive)
+        await ingest_session(text, sid, vmem, kg, archive)
         vmem_id_row = vmem._conn.execute(
             "SELECT id FROM vector_memory ORDER BY id DESC LIMIT 1"
         ).fetchone()
@@ -247,7 +247,7 @@ async def run_benchmark(limit: int = 500, top_k: int = 5):
     print("=" * 74)
     print(f"Real-World Pipeline Benchmark — Recall@{top_k}")
     print(f"Model: all-MiniLM-L6-v2 (ONNX) | {limit} questions")
-    print(f"Tests the FULL taOSmd stack, not just vector search")
+    print("Tests the FULL taOSmd stack, not just vector search")
     print("=" * 74)
 
     with open(DATA_PATH) as f:

--- a/benchmarks/recall_v2_benchmark.py
+++ b/benchmarks/recall_v2_benchmark.py
@@ -20,7 +20,7 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from taosmd import VectorMemory, KnowledgeGraph
-from taosmd.graph_expansion import expand_from_results, extract_entities_from_text
+from taosmd.graph_expansion import expand_from_results
 from taosmd.query_expansion import expand_query_fast
 from taosmd.memory_extractor import extract_facts_from_text
 from taosmd.retention import retention_score, classify_tier
@@ -189,7 +189,7 @@ async def run_recall_benchmark(
 
         for i, item in enumerate(dataset):
             qtype = item["question_type"]
-            question = item["question"]
+            item["question"]
 
             t0 = time.time()
             recall_hit, tier_counts = await run_single_question(item, top_k, mode=run_mode)
@@ -205,7 +205,6 @@ async def run_recall_benchmark(
             if recall_hit:
                 results_by_type[qtype]["hits"] += 1
 
-            status = "✓" if recall_hit else "✗"
             running_pct = total_recall / total_questions * 100
             if (i + 1) % 50 == 0 or i == len(dataset) - 1:
                 print(f"  [{i+1:3d}/{len(dataset)}] {total_recall}/{total_questions} ({running_pct:.1f}%) — {elapsed:.1f}s")
@@ -217,16 +216,16 @@ async def run_recall_benchmark(
         print(f"  Overall: {total_recall}/{total_questions} ({overall:.1f}%)")
         print(f"  Time: {total_time:.0f}s ({total_time/total_questions:.1f}s/question)")
 
-        print(f"\n  By category:")
+        print("\n  By category:")
         for qtype, data in sorted(results_by_type.items()):
             pct = data["hits"] / data["total"] * 100 if data["total"] > 0 else 0
             print(f"    {qtype:35s} {data['hits']:3d}/{data['total']:<3d} ({pct:.1f}%)")
 
     print(f"\n{'='*70}")
     print(f"Comparison (Recall@{top_k}):")
-    print(f"  MemPalace (raw, all-MiniLM-L6):    96.6%")
-    print(f"  agentmemory (BM25+vec, MiniLM):    95.2%")
-    print(f"  taOSmd v0.1 (published):           97.2%")
+    print("  MemPalace (raw, all-MiniLM-L6):    96.6%")
+    print("  agentmemory (BM25+vec, MiniLM):    95.2%")
+    print("  taOSmd v0.1 (published):           97.2%")
     print(f"{'='*70}")
 
 

--- a/benchmarks/taosmd_benchmark.py
+++ b/benchmarks/taosmd_benchmark.py
@@ -8,9 +8,7 @@ Usage: .venv/bin/python benchmarks/taosmd_benchmark.py
 """
 
 import asyncio
-import json
 import time
-from pathlib import Path
 
 import httpx
 
@@ -278,10 +276,10 @@ async def run_benchmark():
         # Check services
         print("\nChecking services...")
         try:
-            kg_resp = await client.get(f"{BASE}/api/kg/stats")
-            print(f"  Knowledge Graph: OK")
+            await client.get(f"{BASE}/api/kg/stats")
+            print("  Knowledge Graph: OK")
         except Exception:
-            print(f"  Knowledge Graph: UNAVAILABLE")
+            print("  Knowledge Graph: UNAVAILABLE")
             return
 
         qmd_available = False
@@ -291,7 +289,7 @@ async def run_benchmark():
                 qmd_available = True
                 print(f"  QMD Vector Search: OK ({qmd_resp.json().get('backend', 'unknown')})")
         except Exception:
-            print(f"  QMD Vector Search: UNAVAILABLE (will benchmark KG only)")
+            print("  QMD Vector Search: UNAVAILABLE (will benchmark KG only)")
 
         # Seed data
         print("\nSeeding test data...")
@@ -342,20 +340,20 @@ async def run_benchmark():
 
         avg_kg = sum(kg_scores) / len(kg_scores) if kg_scores else 0
         avg_kg_lat = sum(kg_latencies) / len(kg_latencies) if kg_latencies else 0
-        print(f"\n  Knowledge Graph (structured triples):")
+        print("\n  Knowledge Graph (structured triples):")
         print(f"    Average precision: {avg_kg:.0%}")
         print(f"    Average latency:   {avg_kg_lat:.0f}ms")
 
         if qmd_scores:
             avg_qmd = sum(qmd_scores) / len(qmd_scores) if qmd_scores else 0
             avg_qmd_lat = sum(qmd_latencies) / len(qmd_latencies) if qmd_latencies else 0
-            print(f"\n  QMD Vector Search (semantic embeddings):")
+            print("\n  QMD Vector Search (semantic embeddings):")
             print(f"    Average precision: {avg_qmd:.0%}")
             print(f"    Average latency:   {avg_qmd_lat:.0f}ms")
 
             avg_comb = sum(combined_scores) / len(combined_scores) if combined_scores else 0
             avg_comb_lat = sum(combined_latencies) / len(combined_latencies) if combined_latencies else 0
-            print(f"\n  Combined (KG + QMD):")
+            print("\n  Combined (KG + QMD):")
             print(f"    Average precision: {avg_comb:.0%}")
             print(f"    Average latency:   {avg_comb_lat:.0f}ms")
 
@@ -363,11 +361,11 @@ async def run_benchmark():
                 improvement = ((avg_comb - avg_qmd) / avg_qmd * 100) if avg_qmd > 0 else 0
                 print(f"\n  -> Combined improves over QMD alone by {improvement:.0f}%")
             elif avg_comb > avg_kg:
-                print(f"\n  -> Combined improves over KG alone")
+                print("\n  -> Combined improves over KG alone")
             else:
-                print(f"\n  -> No clear improvement from combining (may need more diverse test data)")
+                print("\n  -> No clear improvement from combining (may need more diverse test data)")
         else:
-            print(f"\n  QMD not available — KG-only benchmark complete.")
+            print("\n  QMD not available — KG-only benchmark complete.")
 
         # KG stats
         stats = (await client.get(f"{BASE}/api/kg/stats")).json()

--- a/benchmarks/taosmd_iteration5.py
+++ b/benchmarks/taosmd_iteration5.py
@@ -6,7 +6,6 @@ Also runs standard memory benchmarks comparable to MemPalace/Mem0/SuperMemory.
 """
 
 import asyncio
-import json
 import os
 import tempfile
 import time
@@ -72,7 +71,6 @@ async def main():
     from tinyagentos.archive import ArchiveStore
     from tinyagentos.memory_extractor import process_conversation_turn
     from tinyagentos.context_assembler import ContextAssembler
-    from tinyagentos.intent_classifier import classify_intent
 
     print("=" * 70)
     print("taOSmd Iteration 5 — Intent-Aware Retrieval Benchmark")
@@ -139,7 +137,7 @@ async def main():
             avg_latency = total_latency / len(QUERIES)
 
             print(f"\n    OVERALL: {total_hits}/{total_expected} ({avg_precision:.0%}) avg {avg_latency:.1f}ms")
-            print(f"\n    By category:")
+            print("\n    By category:")
             for qtype, data in sorted(by_type.items()):
                 p = data["hits"] / data["expected"] if data["expected"] > 0 else 0
                 print(f"      {qtype:<15s} {data['hits']}/{data['expected']} ({p:.0%})")
@@ -177,7 +175,7 @@ async def main():
         past_facts = await kg.query_entity("Jay", as_of=now - 86400)
         print(f"    Current facts about Jay: {len(current_facts)}")
         print(f"    Facts about Jay 24h ago: {len(past_facts)}")
-        print(f"    Temporal queries: PASS" if len(current_facts) >= len(past_facts) else "    Temporal queries: FAIL")
+        print("    Temporal queries: PASS" if len(current_facts) >= len(past_facts) else "    Temporal queries: FAIL")
 
         # 3. Contradiction Resolution
         print("\n  3. Contradiction Resolution")
@@ -186,17 +184,17 @@ async def main():
         current = await kg.query_entity("Jay")
         works_on = [r["object_name"] for r in current if r["predicate"] == "works_on"]
         resolved = "ProjectB" in works_on and "ProjectA" not in works_on
-        print(f"    Added 'Jay works_on ProjectA' then 'Jay works_on ProjectB'")
+        print("    Added 'Jay works_on ProjectA' then 'Jay works_on ProjectB'")
         print(f"    Current: Jay works_on {', '.join(works_on)}")
         print(f"    Contradiction resolved: {'PASS' if resolved else 'FAIL'}")
 
         # 4. Archive completeness
         print("\n  4. Zero-Loss Archive Completeness")
         archive_stats = await archive.stats()
-        archive_events = await archive.query(limit=100)
+        await archive.query(limit=100)
         print(f"    Events archived: {archive_stats['total_events']}")
         print(f"    Disk usage: {archive_stats['disk_usage_mb']:.2f} MB")
-        print(f"    Archive PASS" if archive_stats["total_events"] >= len(SEED_TEXT) else "    Archive FAIL")
+        print("    Archive PASS" if archive_stats["total_events"] >= len(SEED_TEXT) else "    Archive FAIL")
 
         # 5. Extraction efficiency
         print("\n  5. Extraction Efficiency")
@@ -214,16 +212,16 @@ async def main():
         print("  taOSmd SCORECARD")
         print(f"{'='*70}")
         print(f"    Fact Recall:           {fact_recall:.0f}%")
-        print(f"    Temporal Queries:      PASS")
+        print("    Temporal Queries:      PASS")
         print(f"    Contradiction Resolve: {'PASS' if resolved else 'FAIL'}")
         print(f"    Archive Completeness:  {archive_stats['total_events']} events")
         print(f"    Extraction Speed:      {regex_time/len(SEED_TEXT):.1f}ms/passage (regex)")
         print(f"    KG Size:               {stats['entities']} entities, {stats['triples']} triples")
-        print(f"    Intent Classification: 20/20 tests passing")
-        print(f"\n    Comparable benchmarks:")
-        print(f"    MemPalace LongMemEval: 96.6% (raw verbatim)")
-        print(f"    SuperMemory LongMemEval: 81.6%")
-        print(f"    Mem0: +26% accuracy over OpenAI Memory")
+        print("    Intent Classification: 20/20 tests passing")
+        print("\n    Comparable benchmarks:")
+        print("    MemPalace LongMemEval: 96.6% (raw verbatim)")
+        print("    SuperMemory LongMemEval: 81.6%")
+        print("    Mem0: +26% accuracy over OpenAI Memory")
         print(f"    taOSmd Fact Recall:    {fact_recall:.0f}% (on Pi NPU, no cloud)")
         print(f"{'='*70}")
 

--- a/benchmarks/variations_sweep.py
+++ b/benchmarks/variations_sweep.py
@@ -149,7 +149,7 @@ async def run_sweep(sample_size: int = 100, top_k: int = 5, full_verify: int = 5
     results.sort(key=lambda x: x["score"], reverse=True)
 
     print(f"\n{'─'*74}")
-    print(f"Phase 1 Rankings (top 10):")
+    print("Phase 1 Rankings (top 10):")
     for i, r in enumerate(results[:10]):
         marker = " <<<" if r["score"] > results[0]["score"] - 0.5 else ""
         print(f"  {i+1:2d}. {r['name']:<35s} {r['score']:5.1f}%{marker}")
@@ -194,7 +194,7 @@ async def run_sweep(sample_size: int = 100, top_k: int = 5, full_verify: int = 5
 
     # Final summary
     print(f"\n{'='*74}")
-    print(f"FINAL VERIFIED RESULTS")
+    print("FINAL VERIFIED RESULTS")
     print(f"{'='*74}")
     for v in verified:
         print(f"  {v['name']:<40s} {v['score']:5.1f}% ({v['hits']}/{v['total']})")

--- a/changelog.d/tsk-d4jvo2-widen-lint-gate.md
+++ b/changelog.d/tsk-d4jvo2-widen-lint-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- Widened the ruff lint gate from `taosmd/` to `taosmd/ tests/ benchmarks/` and cleared all remaining pyflakes findings in `tests/` and `benchmarks/` so the step exits 0 on the merged tree.

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -9,7 +9,6 @@ patched wherever stores are initialised.
 from __future__ import annotations
 
 import asyncio
-import io
 import json
 import socket
 import threading
@@ -17,7 +16,6 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_a2a_channels.py
+++ b/tests/test_a2a_channels.py
@@ -13,7 +13,6 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_a2a_mentions.py
+++ b/tests/test_a2a_mentions.py
@@ -9,7 +9,6 @@ Covers all acceptance criteria from tsk-lmlx2v:
 
 from __future__ import annotations
 
-import ast
 import asyncio
 import inspect
 import json

--- a/tests/test_a2a_poll.py
+++ b/tests/test_a2a_poll.py
@@ -10,7 +10,6 @@ import asyncio
 import argparse
 import json
 import threading
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_admin_surface.py
+++ b/tests/test_admin_surface.py
@@ -11,16 +11,13 @@ variant that sets a server token via env or config.
 from __future__ import annotations
 
 import json
-import os
 import threading
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 import pytest
 
 from taosmd import api as taosmd_api
-from taosmd import config as taosmd_config
 from taosmd import http_server
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,7 +414,6 @@ def test_coerce_iso_string_timestamp_returns_hits(isolated_data_dir):
     On the unfixed tree float("2020-01-01T00:00:00Z") raises ValueError at
     api.py and search() propagates it as an error instead of returning hits.
     """
-    marker = "zqxklbm-coerce-iso-timestamp"
     hits = _coerce_and_search(
         isolated_data_dir, {"timestamp": "2020-01-01T00:00:00Z"},
         "The unique token zqxklbm-coerce-iso-timestamp was ingested.",
@@ -429,7 +428,6 @@ def test_coerce_int_review_by_returns_hits(isolated_data_dir):
 
     On the unfixed tree 2020 < "2026-08-18" raises TypeError at api.py.
     """
-    marker = "zqxklbm-coerce-int-review"
     hits = _coerce_and_search(
         isolated_data_dir, {"review_by": 2020},
         "The unique token zqxklbm-coerce-int-review was ingested.",

--- a/tests/test_binary_quant.py
+++ b/tests/test_binary_quant.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 
 from taosmd.vector_memory import VectorMemory
 

--- a/tests/test_catalog_pipeline.py
+++ b/tests/test_catalog_pipeline.py
@@ -7,7 +7,6 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 
 from taosmd.catalog_pipeline import CatalogPipeline
 

--- a/tests/test_collections_ingest.py
+++ b/tests/test_collections_ingest.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import time
 
 import pytest
 

--- a/tests/test_config_managed_by.py
+++ b/tests/test_config_managed_by.py
@@ -1,5 +1,4 @@
 """Tests for managed_by and serve_dashboard config keys."""
-import os
 import pytest
 from taosmd import config as cfg
 

--- a/tests/test_deleted_symbols.py
+++ b/tests/test_deleted_symbols.py
@@ -7,24 +7,16 @@ Proves both directions:
 """
 from __future__ import annotations
 
-import os
 import subprocess
-import sys
 
-import pytest
 
 import scripts.check_deleted_symbols as cds
 from scripts.check_deleted_symbols import (
     TRAILER,
-    Violation,
     _extract_all_exports,
     _extract_imports,
     _extract_symbols,
-    _find_adding_commit,
-    _get_imports_at_ref,
-    _get_symbols_at_ref,
     _resolve_export_key,
-    _run_git,
     check_deleted_symbols,
     find_removed_all_entries,
     find_signal_symbols,

--- a/tests/test_emem_event_lift.py
+++ b/tests/test_emem_event_lift.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 from typing import Any
 
-import pytest
 
 from taosmd.emem_event_lift import lift_edu_to_triples, lift_edus_to_events
 from taosmd.knowledge_graph import TemporalKnowledgeGraph

--- a/tests/test_hermes_audit_batch2.py
+++ b/tests/test_hermes_audit_batch2.py
@@ -7,11 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import tempfile
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +189,7 @@ def test_bm25_cache_is_populated_after_search(tmp_path, live_embed_backend):
             # Cache should be dirty before first search
             assert vm._bm25_dirty is True
 
-            results = await vm.search("quick fox", hybrid=True, fusion="bm25_rrf", limit=2)
+            await vm.search("quick fox", hybrid=True, fusion="bm25_rrf", limit=2)
 
         # After a bm25_rrf search the cache must be populated and clean
         assert "bm25_rrf" in vm._bm25_cache
@@ -363,7 +360,7 @@ def test_retrieve_calls_llm_reranker_when_set():
             )
         return results
 
-    results = asyncio.run(go())
+    asyncio.run(go())
     assert len(call_log) == 1, "_apply_llm_rerank should have been called once"
     assert call_log[0]["query"] == "test query"
 
@@ -372,7 +369,6 @@ def test_retrieve_default_behavior_unchanged_without_llm_reranker():
     """When llm_reranker=None (default), behavior is unchanged."""
     from taosmd.retrieval import retrieve
 
-    call_log = []
 
     class MockVMem:
         async def search(self, q, limit=5, hybrid=True, **_):

--- a/tests/test_http_generator_profile.py
+++ b/tests/test_http_generator_profile.py
@@ -51,7 +51,7 @@ def live_server_with_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(taosmd_api, "_stores_cache", {})
 
     httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
-    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
 
     host, port = httpd.server_address[:2]
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -16,7 +16,6 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_intent_timeline.py
+++ b/tests/test_intent_timeline.py
@@ -2,7 +2,6 @@
 
 import re
 
-import pytest
 from taosmd.intent_classifier import (
     classify_intent,
     get_search_strategy,

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 
 from taosmd.loaders import (
-    Blob,
     BlobType,
     ChatBlob,
     ChatLoader,

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -1,9 +1,7 @@
-import json
 import os
 import subprocess
 import stat
 
-import pytest
 
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "merge_gate")
@@ -51,7 +49,7 @@ if __name__ == '__main__':
 
 
 def _run(script, args, tmpdir, **fixtures):
-    fake_gh = _make_fake_gh(tmpdir, **fixtures)
+    _make_fake_gh(tmpdir, **fixtures)
     env = os.environ.copy()
     env["PATH"] = tmpdir + ":" + env.get("PATH", "")
     script_path = os.path.abspath(os.path.join("scripts", "merge-gate", script))

--- a/tests/test_predicate_vocab.py
+++ b/tests/test_predicate_vocab.py
@@ -10,7 +10,6 @@ import pytest
 from taosmd.predicate_vocab import (
     ALLOWED_PREDICATES,
     PREDICATE_CATEGORIES,
-    SYNONYMS,
     categories,
     extract_with_vocab,
     is_allowed,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,13 +1,10 @@
 """Tests for project identity fingerprinting."""
 from __future__ import annotations
 
-import os
 import subprocess
 
-import pytest
 
 from taosmd.project import (
-    ProjectInfo,
     ProjectResolver,
     _get_git_remote,
     _hash_remote,

--- a/tests/test_pylate_loader.py
+++ b/tests/test_pylate_loader.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 import sys
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-import pytest
 from pathlib import Path
-import re
 from taosmd import recipes
 
 

--- a/tests/test_recipes_search.py
+++ b/tests/test_recipes_search.py
@@ -1,7 +1,6 @@
 # tests/test_recipes_search.py
 from __future__ import annotations
 import asyncio
-import pytest
 from taosmd import retrieval
 
 
@@ -33,7 +32,6 @@ def test_retrieve_threads_fusion_and_candidate_top_k():
     assert results[0]["text"] == "hit"
 
 
-from pathlib import Path
 from taosmd import api as taosmd_api
 from taosmd import agents as taosmd_agents
 from taosmd import recipes

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -97,7 +97,7 @@ def _drop_all_vector_rows_by_text(data_dir, text: str) -> int:
 def test_reconcile_repairs_crash_gap(isolated):
     """ingest 3 turns, drop one vector row, reconcile repairs it."""
     data_dir = isolated
-    stores = _setup(data_dir)
+    _setup(data_dir)
     agent = "reconcile-agent"
 
     turns = [

--- a/tests/test_ref_fetch.py
+++ b/tests/test_ref_fetch.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import os
-import urllib.parse
 
 import pytest
 
@@ -237,7 +235,6 @@ class TestFetchByRef:
             # The real fetch path uses _NoRedirect which returns None from
             # redirect_request, preventing the 302 from being followed.
             # Origin B must NOT receive the Authorization header.
-            auth_leaked = False
             try:
                 asyncio.run(
                     svc.fetch_by_ref(ref, agent="test", data_dir="/tmp")
@@ -355,7 +352,6 @@ class TestServiceFetchByRefRouting:
     def test_local_path_when_no_remote(self, monkeypatch):
         from taosmd import config as cfg
         from taosmd import service as svc
-        from taosmd.ref_fetch import fetch_by_ref as _orig_fetch
 
         async def fake_fetch(ref, fetcher, agent, data_dir=None):
             return b"hello"
@@ -382,9 +378,7 @@ class TestServiceFetchByRefRouting:
         monkeypatch.setattr(cfg, "get_files_url", lambda data_dir=None: "http://ctrl:8000")
         monkeypatch.setattr("taosmd.ref_fetch.fetch_by_ref", fake_fetch)
 
-        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "abc"}
     def test_service_fetch_by_ref_does_not_raise_when_files_url_unset_but_registry_set(self, tmp_path, monkeypatch):
-        from taosmd import config as cfg
         from taosmd import service as svc
 
         async def fake_fetch(ref, fetcher, agent, data_dir=None):

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -542,7 +542,7 @@ def test_authorize_sender_logs_human_auth_error(caplog):
 def test_registry_verifier_logs_human_principal_set(caplog):
     import logging
     with caplog.at_level(logging.INFO, logger="taosmd.registry_auth"):
-        v = registry_auth.RegistryVerifier(
+        registry_auth.RegistryVerifier(
             pubkey_loader=lambda: "pk",
             revoked_loader=lambda: set(),
             human_principal_ids={"human-1", "user-alice"},

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -12,7 +12,6 @@ import json
 import threading
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_service_install.py
+++ b/tests/test_service_install.py
@@ -18,10 +18,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
-from typing import Optional
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -599,7 +596,6 @@ class TestCliFlags:
 
     def test_service_flags_are_mutually_exclusive(self, monkeypatch):
         """argparse should refuse two service flags at once."""
-        import io
         with pytest.raises(SystemExit) as exc:
             self._run_cli(
                 ["serve", "--install-service", "--uninstall-service"],

--- a/tests/test_session_catalog.py
+++ b/tests/test_session_catalog.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from pathlib import Path
 
-import pytest
 
 from taosmd.session_catalog import SessionCatalog
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -11,7 +11,6 @@ Covers:
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
 
@@ -343,7 +342,7 @@ def test_prime_under_cap(data_dir):
 
 def test_prime_sections_present(data_dir):
     """prime() text mentions ready, in-progress, and blocked sections."""
-    t_ready = run(tasks_mod.create_task("Ready task", created_by="x", data_dir=data_dir))
+    run(tasks_mod.create_task("Ready task", created_by="x", data_dir=data_dir))
     t_ip = run(tasks_mod.create_task("In-progress task", created_by="x", data_dir=data_dir))
     run(tasks_mod.update_task(t_ip["id"], status="in_progress", data_dir=data_dir))
 

--- a/tests/test_vector_supersede.py
+++ b/tests/test_vector_supersede.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 
-import pytest
 
 from taosmd.knowledge_graph import TemporalKnowledgeGraph
 from taosmd.vector_memory import SCHEMA, VectorMemory


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #378: the lint gate is widened to tests/ AND benchmarks/ but only tests/ was partly cleared, so the step goes red on merge

Autonomous build of board card tsk-d4jvo2.



Files:
 tests/test_ref_fetch.py                    |  6 ------
 tests/test_registry_auth.py                |  2 +-
 tests/test_remote.py                       |  1 -
 tests/test_service_install.py              |  4 ----
 tests/test_session_catalog.py              |  2 --
 tests/test_tasks.py                        |  3 +--
 tests/test_vector_supersede.py             |  1 -
 50 files changed, 76 insertions(+), 138 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated lint checks to cover application code, tests, and benchmarks.
  * Removed unused imports, variables, and assignments across benchmark and test tooling.
  * Simplified unchanged console output formatting while preserving displayed results.

* **Documentation**
  * Added changelog coverage for the expanded lint gate and successful cleanup.

* **Tests**
  * Maintained existing test behavior and coverage while improving lint cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->