### PR TITLE
tests/test_ref_fetch.py: test_local_path_passes_data_dir_to_ref_fetch never calls the code under test and asserts nothing

### DIFF
--- a/tests/test_ref_fetch.py
+++ b/tests/test_ref_fetch.py
@@ -364,7 +364,7 @@ class TestServiceFetchByRefRouting:
         result = asyncio.run(svc.fetch_by_ref(ref, agent="test", data_dir="/tmp"))
         assert result["bytes"] == "aGVsbG8="
 
-    def test_local_path_passes_data_dir_to_ref_fetch(self, monkeypatch):
+    def test_local_path_passes_data_dir_to_ref_fetch(self, tmp_path, monkeypatch):
         from taosmd import config as cfg
         from taosmd import service as svc
 
@@ -377,6 +377,12 @@ class TestServiceFetchByRefRouting:
         monkeypatch.setattr(svc, "_get_remote", lambda data_dir: None)
         monkeypatch.setattr(cfg, "get_files_url", lambda data_dir=None: "http://ctrl:8000")
         monkeypatch.setattr("taosmd.ref_fetch.fetch_by_ref", fake_fetch)
+
+        ref = {"uri": "taos://proj/files/hello.txt", "sha256": "abc"}
+        data_dir = str(tmp_path)
+        result = asyncio.run(svc.fetch_by_ref(ref, agent="test", data_dir=data_dir))
+        assert captured["data_dir"] == data_dir
+        assert result["bytes"] == "aGVsbG8="
 
     def test_service_fetch_by_ref_does_not_raise_when_files_url_unset_but_registry_set(self, tmp_path, monkeypatch):
         from taosmd import service as svc


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tests/test_ref_fetch.py: test_local_path_passes_data_dir_to_ref_fetch never calls the code under test and asserts nothing

Autonomous build of board card tsk-7a6brx.

The test set up a `captured` dict and a `fake_fetch` that recorded
`data_dir`, but never invoked `svc.fetch_by_ref`, so the dict stayed
empty and the body had zero asserts. It passed unconditionally.

Restore the intent: call svc.fetch_by_ref with a real data_dir and
assert the value reaches taosmd.ref_fetch.fetch_by_ref via the
captured dict, plus confirm the returned bytes are base64 of b"hello".

Proof of both runs (PR #379 trial-merge tree):
- Plumbed (service.py:399 data_dir=data_dir): 29 passed.
- Dropped to data_dir=None: FAILED
  AssertionError: assert None == '/tmp/...test_local_path_passes_data_di0'
  confirming the test now guards the data_dir wiring it is named for.

No changelog fragment: test-only change, not user-visible behaviour.

_MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085 || _MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085
Files:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage to verify that a specified data directory is correctly passed through during reference-based fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->