### PR TITLE
Revise PR #324: the failure-class split folds registry-unavailable into the impersonation class, so a valid token hard-403s in warn mode during an outage

### DIFF
--- a/changelog.d/tsk-brirhl-registry-auth-staleness.md
+++ b/changelog.d/tsk-brirhl-registry-auth-staleness.md
@@ -1,0 +1,18 @@
+### Added
+
+- `RegistryVerifier` (and `verifier_from_url`) now accepts a configurable
+  `staleness_bound` (seconds); the revocation cache fails closed once it exceeds
+  the bound on a refresh failure, instead of tolerating stale data indefinitely.
+  The bound is configurable via the `TAOSMD_REGISTRY_STALENESS_BOUND` env var or
+  the `registry_staleness_bound` config key, defaulting to `6 * refresh_interval`.
+
+### Fixed
+
+- A2A bus auth now distinguishes missing-credentials from presented-credential
+  failures: a missing Bearer token is still warn-and-accept in verify-and-warn
+  mode (the default), but any token that is presented and fails verification
+  (bad signature, issuer mismatch, revoked id, sub != from) returns a hard 403
+  regardless of the `a2a_auth_enforce` flag. Grant failures -- a valid token
+  whose `sub` matches `from` but holds no active grant -- remain warn-and-accept
+  in warn mode and 403 in enforce mode, preserving the documented migration
+  contract.

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -52,6 +52,9 @@ _SERVE_DASHBOARD_KEY = "serve_dashboard"
 _GENERATOR_PROFILE_KEY = "generator_profile"
 # Whether A2A registry auth runs in enforce mode (True) or verify-and-warn mode (False).
 _A2A_AUTH_ENFORCE_KEY = "a2a_auth_enforce"
+# Maximum age (seconds) of a cached revocation set before refresh failures fail
+# closed. Defaults to 6 * refresh_interval inside RegistryVerifier.
+_REGISTRY_STALENESS_BOUND_KEY = "registry_staleness_bound"
 # Canonical IDs of human principals (controller sessions). These IDs skip the
 # registry revocation check and the grants check; a sub/from mismatch on a
 # human token is always rejected, even in verify-and-warn mode. They are also
@@ -656,6 +659,64 @@ def set_a2a_auth_enforce(value: bool, data_dir=None) -> None:
     _write(data, data_dir)
 
 
+def get_registry_staleness_bound(data_dir=None) -> float | None:
+    """Return the configured revocation staleness bound in seconds, or ``None``.
+
+    Resolution order (first non-empty wins):
+
+    1. ``TAOSMD_REGISTRY_STALENESS_BOUND`` environment variable
+    2. ``registry_staleness_bound`` key in ``~/.taosmd/config.json``
+
+    When set, a cached revocation set older than this many seconds is considered
+    stale: a refresh is attempted, and if it fails auth fails closed instead of
+    tolerating the old set indefinitely. When unset (``None``), the verifier
+    defaults to ``6 * refresh_interval`` (30 min with the default 5-min refresh).
+    """
+    env = os.environ.get("TAOSMD_REGISTRY_STALENESS_BOUND")
+    if env and env.strip():
+        try:
+            val = float(env.strip())
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    val = _read(data_dir).get(_REGISTRY_STALENESS_BOUND_KEY)
+    if val is not None:
+        try:
+            fval = float(val)
+            if fval > 0:
+                return fval
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def set_registry_staleness_bound(value: float, *, clear: bool = False,
+                                 data_dir=None) -> None:
+    """Persist the revocation staleness bound in seconds (or clear it).
+
+    Args:
+        value: Staleness bound in seconds (must be positive). Ignored when
+            ``clear`` is True.
+        clear: when True, remove the setting (verifier reverts to its default
+            of ``6 * refresh_interval``).
+
+    Raises:
+        ValueError: when ``clear`` is False and ``value`` is not a positive
+            number.
+    """
+    data = _read(data_dir)
+    if clear:
+        data.pop(_REGISTRY_STALENESS_BOUND_KEY, None)
+    else:
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError(
+                "staleness_bound must be a positive number (or pass clear=True)"
+            )
+        data[_REGISTRY_STALENESS_BOUND_KEY] = float(value)
+    _write(data, data_dir)
+
+
 # ---------------------------------------------------------------------------
 # Human principal IDs (controller sessions)
 # ---------------------------------------------------------------------------
@@ -804,6 +865,8 @@ __all__ = [
     "set_serve_dashboard",
     "get_a2a_auth_enforce",
     "set_a2a_auth_enforce",
+    "get_registry_staleness_bound",
+    "set_registry_staleness_bound",
     "get_human_principal_ids",
     "set_human_principal_ids",
     "MANAGED_BY_STANDALONE",

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -688,11 +688,13 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             # configured taOS local token on them; pin the issuer.
             _registry_admin_token = _config.get_registry_token(data_dir)
             _human_principal_ids = set(_config.get_human_principal_ids(data_dir))
+            _staleness_bound = _config.get_registry_staleness_bound(data_dir)
             _registry_verifier = registry_auth.verifier_from_url(
                 _registry_url,
                 revoked_token=_registry_admin_token,
                 expected_iss=registry_auth.REGISTRY_ISS,
                 human_principal_ids=_human_principal_ids,
+                staleness_bound=_staleness_bound,
             )
             _grants_verifier = registry_auth.grants_verifier_from_url(
                 _registry_url,
@@ -1597,19 +1599,28 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         "'body' (non-empty string) is required when 'blocks' is present"
                     )
             # Registry auth (opt-in): when a verifier is configured, run the
-            # identity + grant checks and collect any failure reason.
-            # In enforce mode (a2a_auth_enforce=true) failures are rejected with
-            # 401/403. In verify-and-warn mode (default) failures are logged as
-            # a WARNING but the message is accepted, allowing operators to observe
-            # violations before enabling hard enforcement.
+            # identity + grant checks. Two failure classes:
+            #   1. Missing Bearer token -> the only tolerated class in
+            #      verify-and-warn mode (agent not migrated yet). Warn-and-
+            #      accept (200) when enforce is off; 401 when on.
+            #   2. Presented-credential failure (bad signature, issuer
+            #      mismatch, revoked id, sub != from) -> always 403 regardless
+            #      of the enforce flag. A matched-sub proof that fails is an
+            #      active impersonation attempt; tolerating it for migration
+            #      keeps the exact attack window open that the design exists to
+            #      close.
+            # Grant failure (valid token, no active grant) is NOT a credential
+            # failure: identity is proven and nothing is being impersonated, so
+            # it follows the same warn-or-enforce path as a missing token.
             if _registry_verifier is not None:
                 from . import registry_auth  # noqa: PLC0415 - optional path
                 auth = self.headers.get("Authorization", "")
                 token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
 
                 # Compute warn_reason (None = auth passed) and the status/message
-                # to use in enforce mode. We collect these without returning early
-                # so the enforce vs. warn decision is made in one place below.
+                # to use in enforce mode. Presented-credential failures return
+                # immediately; grant failures fall through to the single
+                # enforce-or-warn decision below.
                 warn_reason: str | None = None
                 _reject_status: int = 403
                 _reject_msg: str = ""
@@ -1626,9 +1637,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         self._send_json(403, {"error": f"registry auth: {exc}"})
                         return
                     except registry_auth.AuthError as exc:
-                        warn_reason = str(exc)
-                        _reject_status = 403
-                        _reject_msg = f"registry auth: {exc}"
+                        # Class 2: presented-credential failure. Always reject,
+                        # even in warn mode -- see the comment block above.
+                        logger.warning(
+                            "a2a auth: rejecting presented-credential failure "
+                            "from %r in warn mode: %s", from_, exc,
+                        )
+                        self._send_json(403, {"error": f"registry auth: {exc}"})
+                        return
 
                 # Grant check: token proves identity; grant proves permission.
                 # Human principals (controller sessions) have no registry grant,

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1641,7 +1641,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         # even in warn mode -- see the comment block above.
                         logger.warning(
                             "a2a auth: rejecting presented-credential failure "
-                            "from %r in warn mode: %s", from_, exc,
+                            "from %r (regardless of enforce mode): %s", from_, exc,
                         )
                         self._send_json(403, {"error": f"registry auth: {exc}"})
                         return

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -124,13 +124,18 @@ class RegistryVerifier:
     def __init__(self, *, pubkey_loader, revoked_loader,
                  refresh_interval: float = 300.0, clock=time.time,
                  expected_iss: str | None = None,
-                 human_principal_ids: set[str] | None = None):
+                 human_principal_ids: set[str] | None = None,
+                 staleness_bound: float | None = None):
         self._pubkey_loader = pubkey_loader
         self._revoked_loader = revoked_loader
         self._refresh_interval = refresh_interval
         self._clock = clock
         self._expected_iss = expected_iss
         self._human_principal_ids = human_principal_ids or set()
+        self._staleness_bound = (
+            staleness_bound if staleness_bound is not None
+            else 6 * refresh_interval
+        )
         logger.info("resolved human principal set: %s",
                     sorted(self._human_principal_ids))
         self._pubkey: str | None = None
@@ -148,8 +153,10 @@ class RegistryVerifier:
 
     def _get_revoked(self) -> set[str]:
         now = self._clock()
-        stale = (self._revoked_fetched_at is None
-                 or now - self._revoked_fetched_at >= self._refresh_interval)
+        cache_age = (float("inf") if self._revoked_fetched_at is None
+                     else now - self._revoked_fetched_at)
+        stale = (cache_age >= self._refresh_interval
+                 or cache_age > self._staleness_bound)
         if stale:
             try:
                 self._revoked = set(self._revoked_loader())
@@ -158,6 +165,12 @@ class RegistryVerifier:
                 if self._revoked_fetched_at is None:
                     raise AuthError(
                         f"revocation feed unavailable, refusing to authorise: {exc}"
+                    ) from exc
+                if cache_age > self._staleness_bound:
+                    raise AuthError(
+                        f"revocation set stale ({cache_age:.0f}s > "
+                        f"{self._staleness_bound:.0f}s), "
+                        f"refusing to authorise: {exc}"
                     ) from exc
                 logger.warning("registry revocation refresh failed, "
                                "using last-good set: %s", exc)
@@ -383,7 +396,8 @@ def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
                       opener=_http_get, clock=time.time,
                       expected_iss: str | None = REGISTRY_ISS,
                       revoked_token: str | None = None,
-                      human_principal_ids: set[str] | None = None) -> "RegistryVerifier":
+                      human_principal_ids: set[str] | None = None,
+                      staleness_bound: float | None = None) -> "RegistryVerifier":
     """Build a :class:`RegistryVerifier` that fetches from a registry base URL.
 
     The HTTP getter is injectable (``opener``) so callers/tests can supply
@@ -396,6 +410,10 @@ def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
     ``human_principal_ids`` is the set of canonical_ids that belong to human
     principals (controller sessions). These principals skip the registry
     revocation check and their sub/from mismatch is always rejected.
+
+    ``staleness_bound`` is the maximum age (in seconds) of a cached revocation
+    set before a refresh failure fails closed instead of tolerating. When
+    ``None`` it defaults to ``6 * refresh_interval``.
     """
     base = base_url.rstrip("/")
     return RegistryVerifier(
@@ -404,4 +422,5 @@ def verifier_from_url(base_url: str, *, refresh_interval: float = 300.0,
             opener(base + REVOKED_PATH, token=revoked_token)),
         refresh_interval=refresh_interval, clock=clock, expected_iss=expected_iss,
         human_principal_ids=human_principal_ids,
+        staleness_bound=staleness_bound,
     )

--- a/tests/test_http_server_trust_enforcement.py
+++ b/tests/test_http_server_trust_enforcement.py
@@ -172,17 +172,45 @@ def test_warn_no_token_accepted(warn_server, caplog):
                for r in caplog.records)
 
 
-def test_warn_invalid_token_accepted(warn_server, caplog):
-    """Invalid token: message accepted and warning logged in warn mode."""
+def test_warn_invalid_token_rejected(warn_server, caplog):
+    """Invalid (presented-but-unverifiable) token: 403 even in warn mode.
+
+    This is a presented-credential failure, not a migration gap: a token that
+    was supplied but does not verify is treated as an active impersonation
+    attempt and rejected regardless of the enforce flag.
+    """
     import logging
     with caplog.at_level(logging.WARNING, logger="taosmd.http_server"):
         status, body = _post_send(warn_server, "any-agent", "hello", token="not-a-jwt")
-    assert status == 200, body
-    assert any("verify-and-warn" in r.message for r in caplog.records)
+    assert status == 403, body
+    # A rejected request must not reach the service layer.
+    s2, t2 = _get(warn_server, "/a2a/messages?thread=general&limit=100")
+    assert s2 == 200
+    assert json.loads(t2)["messages"] == []
+
+
+def test_warn_mismatched_sub_rejected(warn_server):
+    """Agent token with sub != from is 403 EVEN in warn mode.
+
+    A presented credential that proves identity but mismatches the claimed
+    handle is a presented-credential failure, always 403 regardless of mode.
+    """
+    token = _mint("agent-OTHER")
+    status, body = _post_send(warn_server, "agent-1", "hello", token=token)
+    assert status == 403, body
+    # A rejected request must not reach the service layer.
+    s2, t2 = _get(warn_server, "/a2a/messages?thread=general&limit=100")
+    assert s2 == 200
+    assert json.loads(t2)["messages"] == []
 
 
 def test_warn_valid_token_no_grant_accepted(warn_server, caplog):
-    """Valid token but no grant: message accepted and warning logged in warn mode."""
+    """Valid token but no grant: warn-and-accept in warn mode (blocker fix).
+
+    Grant failure is an authorization gap, not a credential failure: the
+    identity is proven and nothing is being impersonated. It must follow the
+    same warn-or-enforce path as a missing token.
+    """
     import logging
     token = _mint("agent-no-grant")
     with caplog.at_level(logging.WARNING, logger="taosmd.http_server"):
@@ -192,6 +220,11 @@ def test_warn_valid_token_no_grant_accepted(warn_server, caplog):
         "verify-and-warn" in r.message and "no a2a_send grant" in r.message
         for r in caplog.records
     )
+    # Unlike presented-credential failures, a grant failure in warn mode
+    # still persists the message (warn-and-accept, not reject).
+    s2, t2 = _get(warn_server, "/a2a/messages?thread=general&limit=100")
+    assert s2 == 200
+    assert len(json.loads(t2)["messages"]) == 1
 
 
 def test_warn_valid_token_and_grant_no_warning(warn_server, caplog):

--- a/tests/test_registry_auth.py
+++ b/tests/test_registry_auth.py
@@ -263,6 +263,123 @@ def test_verifier_fails_closed_when_revocation_never_loaded():
         v.authorize(token, "agent-1")
 
 
+# --- staleness_bound: fail-closed expiry of the cached revocation set ---------
+
+
+def test_verifier_staleness_bound_defaults_to_six_refresh_intervals():
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: "pk",
+        revoked_loader=lambda: set(),
+        refresh_interval=300,
+    )
+    assert v._staleness_bound == 6 * 300
+
+
+def test_verifier_staleness_bound_fails_closed_after_bound():
+    """When refresh fails and cache age exceeds staleness_bound, fail closed.
+
+    With refresh_interval=300 and staleness_bound=30, advancing 31s triggers a
+    refresh (31 > 30), the refresh fails, and the cache is too stale (31 > 30)
+    so authorize raises AuthError instead of tolerating.
+    """
+    priv_pem, pub_pem = _keypair()
+    state = {"fail": False}
+
+    def revoked_loader():
+        if state["fail"]:
+            raise OSError("registry unreachable")
+        return set()
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+        staleness_bound=30,
+    )
+    token = _sign(priv_pem, {"sub": "agent-1"})
+    v.authorize(token, "agent-1")  # primes cache
+
+    state["fail"] = True
+    clock.advance(31)  # cache_age=31 > staleness_bound=30, < refresh_interval=300
+    with pytest.raises(registry_auth.AuthError, match="stale"):
+        v.authorize(token, "agent-1")
+
+
+def test_verifier_staleness_bound_age_equal_to_bound_remains_valid():
+    """Age exactly equal to staleness_bound is still valid (strict > comparison).
+
+    At cache_age == staleness_bound, the stale predicate is False, so no refresh
+    is attempted and the cached revocation set is returned directly.
+    """
+    priv_pem, pub_pem = _keypair()
+    state = {"fail": False}
+
+    def revoked_loader():
+        if state["fail"]:
+            raise OSError("registry unreachable")
+        return {"agent-revoked"}
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+        staleness_bound=30,
+    )
+    token_ok = _sign(priv_pem, {"sub": "agent-ok"})
+    token_revoked = _sign(priv_pem, {"sub": "agent-revoked"})
+    v.authorize(token_ok, "agent-ok")  # primes cache with revoked set
+
+    state["fail"] = True
+    clock.advance(30)  # cache_age == staleness_bound: not stale, cache returned
+    # Revoked agent still rejected via the cached set
+    with pytest.raises(registry_auth.AuthError):
+        v.authorize(token_revoked, "agent-revoked")
+    # Non-revoked agent still accepted
+    v.authorize(token_ok, "agent-ok")
+
+
+def test_verifier_staleness_bound_triggers_refresh_before_refresh_interval():
+    """When staleness_bound < refresh_interval, refresh is attempted after the
+    bound expires even though the normal refresh interval hasn't elapsed."""
+    priv_pem, pub_pem = _keypair()
+    calls = {"revoked": 0}
+
+    def revoked_loader():
+        calls["revoked"] += 1
+        return set()
+
+    clock = _FakeClock()
+    v = registry_auth.RegistryVerifier(
+        pubkey_loader=lambda: pub_pem, revoked_loader=revoked_loader,
+        refresh_interval=300, clock=clock,
+        staleness_bound=30,
+    )
+    token = _sign(priv_pem, {"sub": "agent-1"})
+    v.authorize(token, "agent-1")
+    assert calls["revoked"] == 1
+
+    clock.advance(31)  # cache_age=31 > staleness_bound=30 -> stale -> refresh
+    v.authorize(token, "agent-1")
+    assert calls["revoked"] == 2
+
+
+def test_verifier_from_url_accepts_staleness_bound():
+    """verifier_from_url threads staleness_bound through to RegistryVerifier."""
+    import json
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": _PEM})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([])
+        raise AssertionError(f"unexpected url: {url}")
+
+    v = registry_auth.verifier_from_url(
+        "http://taos:8000", opener=fake_opener, staleness_bound=42, expected_iss=None,
+    )
+    assert v._staleness_bound == 42
+
+
 # --- response parsers (tolerant of the registry's exact JSON shape) ----------
 
 _PEM = ("-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA\n"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #324: the failure-class split folds registry-unavailable into the impersonation class, so a valid token hard-403s in warn mode during an outage

Autonomous build of board card tsk-g56qcg.

Revise PR #282 (closed) from master. Split A2A auth failure classes in
_handle_a2a_send: presented-credential failures (bad signature, issuer
mismatch, revoked id, sub != from) now return a hard 403 in warn mode,
which is the default, instead of being warn-and-accepted. Grant failures
remain warn-and-accept in warn mode and 403 in enforce mode, since a
valid token with no grant is an authorization gap, not a credential
failure. HumanAuthError stays always-403.

RegistryVerifier gains a configurable staleness_bound (default 6x
refresh_interval) that fails closed when the cached revocation set is too
old and the refresh feed is unreachable. The stale predicate now includes
cache age before the normal refresh interval, fixing the case where a
bound shorter than refresh_interval was bypassed. Thread the bound through
config (TAOSMD_REGISTRY_STALENESS_BOUND env var or
registry_staleness_bound config key) into verifier_from_url.

Adds 6 tests, RED-first confirmed against master: 2 for the failure-class
split (invalid token and mismatched sub reject at 403 in warn mode),
5 for staleness_bound fail-closed semantics, plus a regression guard that
grant failures remain warn-and-accept in warn mode.

_MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085 || _MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085
Files:
