### PR TITLE
taosmd: fix the doc gate from PR #295 (rename bypass, red proof, changelog convention, taosmd/ scope, conflict markers)

### DIFF
--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -1,0 +1,45 @@
+name: Doc drift gate
+
+# Authoritative documentation-drift gate. Blocks PRs that change feature code
+# (a taosmd module, an A2A handler, an installer, a catalog manifest) without
+# touching the doc that covers it, unless a commit in the PR carries a
+# "Docs-Reviewed: <why>" trailer. See docs/doc-gate.toml for the rules and
+# scripts/check_doc_gate.py for the implementation. This job is authoritative
+# regardless of local hooks (--no-verify does not skip it).
+#
+# Layer A (invariants) runs on the whole tree and rejects stale path references
+# and protected docs that have lost their required section headings. Layer B
+# (diff-gate) is the per-change rule engine; on_modify rules fire on file
+# modifications as well as add/delete, so gutting a doc is caught, not just
+# adding/removing one.
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  doc-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BASE_REF: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Sync dev deps (stdlib-only gate, but keeps the repo env uniform)
+        run: uv sync --python 3.12
+
+      - name: Fetch base branch
+        run: git fetch origin "$BASE_REF"
+
+      - name: Invariants (Layer A)
+        run: uv run python scripts/check_doc_gate.py invariants
+
+      - name: Diff gate (Layer B)
+        run: uv run python scripts/check_doc_gate.py diff-gate --base "origin/$BASE_REF"

--- a/changelog.d/tsk-ihgfz3-doc-gate.md
+++ b/changelog.d/tsk-ihgfz3-doc-gate.md
@@ -1,0 +1,3 @@
+### Added
+
+- Documentation-drift gate (`scripts/check_doc_gate.py` with `.github/workflows/doc-gate.yml` and `docs/doc-gate.toml`) that blocks PRs changing taosmd code, the A2A handlers (`taosmd/http_server.py`, `taosmd/service.py`), or contributor-surface files (`.github/workflows/`, `pyproject.toml`) without a matching doc update or a `Docs-Reviewed:` trailer; protected docs are asserted on their required section headings so they cannot be silently gutted by a path-only rule or a one-character edit.

--- a/changelog.d/tsk-t2lsre-doc-gate-fixes.md
+++ b/changelog.d/tsk-t2lsre-doc-gate-fixes.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Documentation-gate fix-forward (5 items from card tsk-t2lsre): renames and copies now expand to delete+add so structural rules fire; `changelog.d/*.md` fragments satisfy the changelog rule; Layer A now covers `taosmd/` path references with data-dir/generated exclusions; conflict-marker invariant added to the diff-gate

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -1,0 +1,90 @@
+# Documentation-drift gate configuration for taosmd.
+#
+# Read by scripts/check_doc_gate.py. Rules are data: add more [[rules]]
+# entries here to cover new feature areas without touching the script.
+#
+# Precision over recall: `when_changed` only triggers a rule on a structural
+# change (a file added or deleted) by default, never a plain modification, to
+# keep the gate precise -- a noisy gate gets disabled, so false positives are
+# worse than an occasional missed doc update. A rule opts into modifications
+# with `on_modify = true` (taOS card tsk-sxuexd); this repo's A2A-handler and
+# contributor-surface rules do, because a *modification* to those files (or to
+# the doc that protects them) must still trip a doc check.
+#
+# Every protected doc carries declared required section HEADINGS under
+# [invariants.required_headings]. Layer A asserts these on every run, so gutting
+# a doc (deleting a declared section) fails the gate even when no code rule
+# fires. Layer B also re-asserts them whenever a rule is satisfied by a doc
+# edit, so a one-character touch cannot mask a gutted section (taOS #2383).
+
+[gate]
+trailer = "Docs-Reviewed:"
+
+[invariants]
+# Key user-facing docs that reference repo paths (docs/ or scripts/).
+# Every matched token must exist on disk; a missing target means a stale
+# link in shipped documentation.
+referenced_paths_scan = [
+    "README.md",
+    "docs/multi-agent.md",
+    "docs/collections.md",
+    "docs/serve-service.md",
+    "docs/INSTALL-AGENT-PROMPT.md",
+    "docs/benchmarks.md",
+]
+
+# Required section headings per protected doc, asserted by Layer A on every
+# run and re-asserted by Layer B whenever the doc is touched to satisfy a
+# fired rule. Delete any heading below (or the section it heads) and the gate
+# fails. Matched as a substring of a markdown heading line, so rewording a
+# heading out of existence is enough to trip it.
+[invariants.required_headings]
+"taosmd/docs/a2a-comms.md" = [
+    "# A2A Comms: Agent-to-Agent Channels via taOSmd",
+    "## What this does",
+    "## Step 1: Ensure taOSmd is installed",
+    "## Step 5: Invite the user's other agents",
+    "## Querying the bus",
+    "## Reference",
+    "### HTTP endpoints",
+    "### Admin token (separate from the data plane)",
+    "### Registry auth (verify-and-warn)",
+    "### MCP tools",
+]
+"docs/pr-verification.md" = [
+    "# PR verification on taOSmd",
+    "## The split",
+    "## The zero-token layer",
+]
+
+[[rules]]
+# New, removed, or renamed code under the taosmd package may alter the
+# user-visible API or behaviour, so a CHANGELOG entry is required. Fires on
+# add/delete only (not modification): a routine edit under taosmd/ that does
+# not alter the API surface should not ping every contributor. Use a
+# Docs-Reviewed trailer for purely-internal additions under taosmd/docs/.
+name = "changelog"
+when_changed = ["taosmd/**"]
+require_doc = ["CHANGELOG.md", "changelog.d/*.md"]
+hint = "changes under taosmd/ that alter user-visible or API behaviour require a CHANGELOG entry"
+
+[[rules]]
+# The A2A bus handlers live in http_server.py and service.py, documented in
+# taosmd/docs/a2a-comms.md. on_modify = true so a modification to either
+# handler (or to the doc itself) trips the rule; the doc is then content-
+# asserted against [invariants.required_headings].
+name = "a2a-handlers"
+when_changed = ["taosmd/http_server.py", "taosmd/service.py", "taosmd/docs/a2a-comms.md"]
+on_modify = true
+require_doc = ["taosmd/docs/a2a-comms.md"]
+hint = "changes to the A2A handlers (taosmd/http_server.py, taosmd/service.py) require docs coverage in taosmd/docs/a2a-comms.md"
+
+[[rules]]
+# CI workflows and pyproject.toml are contributor-surface configuration,
+# documented in docs/pr-verification.md (this rule fires on that doc itself,
+# so gutting a required section here is caught, not just add/delete).
+name = "contributor-surface"
+when_changed = [".github/workflows/**", "pyproject.toml", "docs/pr-verification.md"]
+on_modify = true
+require_doc = ["docs/pr-verification.md"]
+hint = "changes to .github/workflows or pyproject require docs/pr-verification.md reviewed"

--- a/docs/pr-verification.md
+++ b/docs/pr-verification.md
@@ -97,3 +97,24 @@ in the checks list.
 `[dependency-groups]`). If `uv run pytest` reports "Failed to spawn: pytest", the environment
 is wrong and any test result from it is meaningless. Say so rather than forcing the deps in
 by hand, because a hand-forced environment hides the same breakage from the next person.
+
+## Documentation drift gate
+
+A pull request that changes feature code, an A2A handler, or contributor-surface files
+(`.github/workflows/`, `pyproject.toml`) must also touch the doc that covers it, or carry a
+`Docs-Reviewed: <why>` trailer. The check is `scripts/check_doc_gate.py`, wired in GitHub
+Actions as `.github/workflows/doc-gate.yml`; the rule set lives in `docs/doc-gate.toml`.
+
+The gate has two layers. Layer A (`invariants`) always runs against the tree: it verifies
+that path tokens mentioned in shipped docs still exist, and that every protected doc still
+contains the section headings declared under `[invariants.required_headings]` in
+`docs/doc-gate.toml`. This is what catches a doc that has been silently gutted -- emptied of
+the sections it exists to hold -- even when the change triggers no code rule. Layer B
+(`diff-gate`) is the per-change rule engine: a rule fires on an added or deleted file (and,
+for rules with `on_modify = true`, on a modification too), and is satisfied by editing its
+`require_doc` file *with its required sections still present*, or by a `Docs-Reviewed:`
+trailer. A touched doc is content-asserted, so a one-character edit cannot mask a gutted
+section.
+
+This gate applies to its own PR: adding `.github/workflows/doc-gate.yml` is a change to
+`.github/workflows/`, so this section is the matching doc update.

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Documentation-drift gate.
+
+Blocks commits/PRs that change feature code without a matching doc update,
+unless the change carries an explicit "Docs-Reviewed: <why>" trailer.
+
+Two layers:
+  invariants  -- deterministic sanity checks (Layer A). Currently: every
+                 scripts/ tinyagentos/ docs/ desktop/ taosmd/ path mentioned in the
+                 configured doc set actually exists on disk, AND every protected
+                 doc still contains its declared required section headings.
+                 Layer A runs regardless of what changed, so a doc emptied of
+                 the sections it exists to hold fails the gate even when no code
+                 rule fires (the "gutting hole").
+  diff-gate   -- path -> doc rule engine (Layer B). A configured rule fires
+                 when a *structural* change (a file added or deleted) matches
+                 one of its `when_changed` globs. A rule with the opt-in
+                 `on_modify = true` flag ALSO fires on a plain modification
+                 (taOS card tsk-sxuexd): this is what lets a change to a
+                 protected doc itself trip a content check, so a doc can never
+                 be silently gutted. A fired rule is satisfied by either editing
+                 one of its `require_doc` files in the same changeset, or by a
+                 commit-message trailer line starting with the configured
+                 trailer (default "Docs-Reviewed:"). Editing a require_doc is
+                 NOT path-only: the touched doc's declared `required_headings`
+                 are asserted, so a one-character edit cannot mask a gutted
+                 section.
+
+Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
+editing the TOML, no changes to this file required.
+
+Usage:
+    python scripts/check_doc_gate.py invariants
+    python scripts/check_doc_gate.py diff-gate --staged
+    python scripts/check_doc_gate.py diff-gate --base origin/master
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "docs" / "doc-gate.toml"
+DEFAULT_TRAILER = "Docs-Reviewed:"
+
+# A path-like token: one of the known repo prefixes followed by a run of
+# non-whitespace / non-quoting characters. The negative lookbehind stops us
+# matching a prefix that is actually embedded inside a larger path (e.g. the
+# "tinyagentos/" inside "/home/<user>/tinyagentos/data/" in a deploy-layout
+# table), which would otherwise falsely flag deploy-time paths that never
+# exist in the repo itself.
+_TOKEN_RE = re.compile(r"(?<![\w/])(?:scripts|tinyagentos|docs|desktop|taosmd)/[^\s`\"'|]+")
+
+# Runtime data-dir paths and generated files under taosmd/ that must not be
+# treated as repo-relative source references. These would otherwise match
+# when the prefix is embedded in a larger path (e.g. ~/.taosmd/config.json),
+# producing false positives for paths that never exist in the repo tree.
+_EXCLUDED_TOKEN_RE = re.compile(
+    r"^taosmd/(?:"
+    r"archive|"
+    r"archive-index\.db|"
+    r"config\.json|"
+    r"knowledge-graph\.db|"
+    r"vector-memory\.db|"
+    r"project\.toml|"
+    r"_build_info\.py"
+    r")(?:/|$)"
+)
+
+# Chars that mark a token as a glob pattern or a <placeholder> rather than a
+# concrete repo path -- these are never asserted to exist.
+_GLOB_OR_PLACEHOLDER_CHARS = set("*?[]{}<>$~")
+
+# Trailing punctuation that is prose/markdown decoration, not part of the path.
+_TRAILING_PUNCT = ".,;:!?)]}'\"`"
+
+
+def _clean_token(raw: str) -> str | None:
+    """Normalize a raw regex match into a bare repo-relative path, or None
+    if it should be ignored (glob, placeholder, anchor/query fragment)."""
+    token = raw
+    for sep in ("#", "?"):
+        if sep in token:
+            token = token.split(sep, 1)[0]
+    while token and token[-1] in _TRAILING_PUNCT:
+        token = token[:-1]
+    if not token:
+        return None
+    if any(c in _GLOB_OR_PLACEHOLDER_CHARS for c in token):
+        return None
+    return token
+
+
+def extract_path_tokens(text: str) -> list[str]:
+    """Pull candidate repo-relative path tokens out of doc prose."""
+    tokens = []
+    for m in _TOKEN_RE.finditer(text):
+        cleaned = _clean_token(m.group(0))
+        if cleaned and not _EXCLUDED_TOKEN_RE.match(cleaned):
+            tokens.append(cleaned)
+    return tokens
+
+
+def load_config(path: Path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _read_headings(doc_path: Path) -> list[str]:
+    """Return every markdown heading line (leading '#' preserved) in a doc.
+    Lines starting with '#' inside fenced code blocks are code comments, but
+    they only matter insofar as one happens to equal a declared required
+    heading (see _missing_headings), which never occurs for the sections this
+    gate protects."""
+    if not doc_path.is_file():
+        return []
+    return [
+        line
+        for line in doc_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        if line.lstrip().startswith("#")
+    ]
+
+
+def _missing_headings(repo_root: Path, doc: str, required: list[str]) -> list[str]:
+    """Return the declared headings absent from `doc`. A missing or empty doc
+    is not reported here -- existence is the referenced-paths job, and a doc
+    that exists but is empty simply fails the (non-empty) headings it declares.
+    The required list is matched as a substring of a heading line so that a
+    real edit deleting a whole section is caught, while whitespace/prefix churn
+    around an intact heading is not."""
+    if not required:
+        return []
+    headings = _read_headings(repo_root / doc)
+    if not headings:
+        return list(required)
+    missing: list[str] = []
+    for req in required:
+        if not any(req in h for h in headings):
+            missing.append(req)
+    return missing
+
+
+def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: dict) -> list[str]:
+    """Layer A: every scripts/tinyagentos/docs/desktop/taosmd path token mentioned in
+    the configured doc set must exist on disk. A scan-target file that itself
+    does not exist (e.g. a local-only, gitignored doc) is silently skipped
+    rather than treated as a failure. Runtime data-dir paths and generated
+    files under taosmd/ are excluded via _EXCLUDED_TOKEN_RE."""
+    failures: list[str] = []
+    for rel in files_to_scan:
+        doc_path = repo_root / rel
+        if not doc_path.is_file():
+            continue
+        text = doc_path.read_text(encoding="utf-8", errors="ignore")
+        for token in extract_path_tokens(text):
+            if not (repo_root / token).exists():
+                failures.append(f"{rel} references '{token}' which does not exist in the repo")
+    return failures
+
+
+def check_required_headings(repo_root: Path, config: dict) -> list[str]:
+    """Layer A, always-on: every protected doc must still contain its declared
+    required section headings. Because this runs on the committed/working-tree
+    content regardless of the changeset, gutting a doc (deleting a required
+    section) fails the gate even when the change triggers no rule -- closing
+    taOS #2383's escape hatches where a path-based gate passed an emptied doc."""
+    failures: list[str] = []
+    required_map = config.get("invariants", {}).get("required_headings", {})
+    for doc, headings in required_map.items():
+        for missing in _missing_headings(repo_root, doc, headings):
+            failures.append(f"{doc} -- required section '{missing}' is absent")
+    return failures
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    """Path-segment-aware glob match, unlike fnmatch (where `*` crosses `/`).
+
+    `**` matches zero or more path segments (so a trailing `/**` also matches
+    the bare parent, e.g. `a/**` matches `a`), a single `*` matches within one
+    path segment only (`[^/]*`), `?` matches one non-separator character
+    (`[^/]`), and every other character is matched literally.
+    """
+    regex_parts = []
+    i = 0
+    length = len(pattern)
+    while i < length:
+        char = pattern[i]
+        if char == "*":
+            if i + 1 < length and pattern[i + 1] == "*":
+                # A trailing `/**` should also match the bare parent path, so
+                # fold the preceding literal `/` into an optional group.
+                if regex_parts and regex_parts[-1] == "/" and i + 2 == length:
+                    regex_parts[-1] = "(?:/.*)?"
+                else:
+                    regex_parts.append(".*")
+                i += 2
+            else:
+                regex_parts.append("[^/]*")
+                i += 1
+        elif char == "?":
+            regex_parts.append("[^/]")
+            i += 1
+        else:
+            regex_parts.append(re.escape(char))
+            i += 1
+    return re.fullmatch("".join(regex_parts), path) is not None
+
+
+def _match_any(path: str, patterns: list[str]) -> bool:
+    return any(_glob_match(path, pat) for pat in patterns)
+
+
+def _is_test_path(path: str) -> bool:
+    """A test file is never a structural feature change (a new app, route,
+    etc.), so adding or removing one must not trip a doc-gate structural rule.
+    Covers frontend co-located tests and Python test modules (#171)."""
+    base = path.rsplit("/", 1)[-1]
+    if "/__tests__/" in path:
+        return True
+    if base.startswith("test_") and base.endswith(".py"):
+        return True
+    return base.endswith(
+        (".test.tsx", ".test.ts", ".test.jsx", ".test.js", ".spec.tsx", ".spec.ts")
+    )
+
+
+def evaluate_rules(
+    changed_status: list[tuple[str, str]],
+    commit_messages: list[str],
+    config: dict,
+    repo_root: Path,
+) -> list[str]:
+    """Layer B: run every configured rule against a changeset.
+
+    changed_status: list of (status, path) pairs as from `git diff
+    --name-status`, e.g. [("A", "desktop/src/apps/Foo/Foo.tsx"), ("M", "x")].
+    Only status "A" (added) or "D" (deleted) files count as structural change
+    for the purposes of *triggering* a rule; plain modifications ("M") are
+    ignored to keep the gate precise -- unless the rule opts in via
+    `on_modify = true`, in which case "M" triggers too (tsk-sxuexd). Any
+    changed file (any status) can *satisfy* a rule if it matches a require_doc
+    glob. When a require_doc is touched to satisfy a fired rule, the touched
+    doc's declared `required_headings` are asserted as well, so a path-based
+    "doc was edited" can no longer mask a gutted section.
+    commit_messages: full text of each commit message in range (empty list
+    when there is no finalized commit yet, i.e. --staged mode).
+    """
+    trailer = get_trailer(config)
+    rules = config.get("rules", [])
+    required_headings = config.get("invariants", {}).get("required_headings", {})
+
+    all_paths = [path for _status, path in changed_status]
+    structural_paths_default = [
+        path for status, path in changed_status
+        if status in ("A", "D") and not _is_test_path(path)
+    ]
+
+    trailer_present = any(
+        line.strip().startswith(trailer) and line.strip()[len(trailer):].strip()
+        for message in commit_messages
+        for line in message.splitlines()
+    )
+
+    failures: list[str] = []
+    for rule in rules:
+        name = rule.get("name", "?")
+        when_changed = rule.get("when_changed", [])
+        require_doc = rule.get("require_doc", [])
+        hint = rule.get("hint", "")
+        on_modify = rule.get("on_modify", False)
+
+        # Default structural set is add/delete only; on_modify adds "M" so a
+        # modification to a protected doc (or handler) can trip a content check.
+        if on_modify:
+            structural_paths = [
+                path for status, path in changed_status
+                if status in ("A", "D", "M") and not _is_test_path(path)
+            ]
+        else:
+            structural_paths = structural_paths_default
+
+        triggered = any(_match_any(p, when_changed) for p in structural_paths)
+        if not triggered:
+            continue
+
+        doc_edited = any(_match_any(p, require_doc) for p in all_paths)
+        # The trailer bypass is deliberate and must not be weakened: an explicit
+        # "Docs-Reviewed: <why>" waiver skips the doc-update obligation
+        # entirely, and with it the content assertion (the contributor swore the
+        # doc was reviewed and waives it).
+        if trailer_present:
+            continue
+
+        if doc_edited:
+            # HOLE 2 fix: a touched require_doc is not "satisfied" by its path
+            # alone. Assert the declared required sections are still present, so
+            # a one-character edit cannot mask a gutted section.
+            for doc in require_doc:
+                if not any(_match_any(p, [doc]) for p in all_paths):
+                    continue
+                for missing in _missing_headings(repo_root, doc, required_headings.get(doc, [])):
+                    failures.append(
+                        f"{name} -- required section '{missing}' is absent from {doc}"
+                    )
+            continue
+
+        failures.append(
+            f"{name} -- {hint} (edit one of: {', '.join(require_doc)}, "
+            f"or add a 'Docs-Reviewed: <why>' trailer)"
+        )
+    return failures
+
+
+def _run_git(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _parse_name_status(output: str) -> list[tuple[str, str]]:
+    changed: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        path = parts[-1]
+        if status.startswith("R") or status.startswith("C"):
+            old_path = parts[1]
+            changed.append(("D", old_path))
+            changed.append(("A", path))
+        else:
+            changed.append((status[0], path))
+    return changed
+
+
+def _git_changed_staged() -> list[tuple[str, str]]:
+    return _parse_name_status(_run_git(["diff", "--cached", "--name-status"]))
+
+
+def _git_changed_base(base_ref: str) -> list[tuple[str, str]]:
+    return _parse_name_status(_run_git(["diff", "--name-status", f"{base_ref}...HEAD"]))
+
+
+def _git_commit_messages(base_ref: str) -> list[str]:
+    out = _run_git(["log", f"{base_ref}..HEAD", "--format=%B%x00"])
+    return [m for m in out.split("\x00") if m.strip()]
+
+
+def _check_conflict_markers(
+    repo_root: Path, changed_paths: list[str], ref: str | None = None, cached: bool = False
+) -> list[str]:
+    """Greps each changed file for unresolved merge-conflict markers.
+
+    For ``--staged`` the index is searched (``--cached``); for ``--base`` the
+    given ref (usually ``HEAD``) is searched. A file that does not exist in the
+    searched tree is silently skipped."""
+    failures: list[str] = []
+    for path in changed_paths:
+        args = ["git", "grep", "-n", "-E", r"^(<<<<<<< |=======$|>>>>>>> )"]
+        if cached:
+            args.insert(4, "--cached")
+        elif ref:
+            args.append(ref)
+        args.extend(["--", path])
+        result = subprocess.run(args, cwd=repo_root, capture_output=True, text=True)
+        if result.returncode == 0:
+            failures.append(
+                f"conflict-marker -- {path} contains unresolved merge conflict markers"
+            )
+    return failures
+
+
+def get_trailer(config: dict) -> str:
+    """Single source of truth for the commit-message trailer prefix, shared
+    by the diff-gate check and the hooks (via the print-trailer command)."""
+    return config.get("gate", {}).get("trailer", DEFAULT_TRAILER)
+
+
+def _report(failures: list[str]) -> int:
+    if not failures:
+        print("doc-gate: clean")
+        return 0
+    for failure in failures:
+        print(f"DOC-GATE FAIL: {failure}")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("invariants", help="Run Layer-A deterministic checks")
+    sub.add_parser("print-trailer", help="Print the configured commit trailer prefix")
+
+    diff_parser = sub.add_parser("diff-gate", help="Run Layer-B path->doc rule engine")
+    group = diff_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--staged", action="store_true", help="Check the git index (pre-commit)")
+    group.add_argument("--base", help="Compare <base>...HEAD (CI / commit-msg)")
+
+    args = parser.parse_args(argv)
+    config = load_config(args.config)
+
+    if args.command == "invariants":
+        ic = config.get("invariants", {})
+        files_to_scan = ic.get("referenced_paths_scan", [])
+        failures = check_referenced_paths(REPO_ROOT, files_to_scan, config)
+        failures.extend(check_required_headings(REPO_ROOT, config))
+        return _report(failures)
+
+    if args.command == "print-trailer":
+        print(get_trailer(config))
+        return 0
+
+    # diff-gate
+    if args.staged:
+        changed = _git_changed_staged()
+        commit_messages: list[str] = []
+    else:
+        changed = _git_changed_base(args.base)
+        commit_messages = _git_commit_messages(args.base)
+
+    failures = evaluate_rules(changed, commit_messages, config, REPO_ROOT)
+    all_paths = [path for _status, path in changed]
+    if args.staged:
+        failures.extend(_check_conflict_markers(REPO_ROOT, all_paths, cached=True))
+    else:
+        failures.extend(_check_conflict_markers(REPO_ROOT, all_paths, ref="HEAD"))
+    return _report(failures)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -1,0 +1,572 @@
+"""Tests for scripts/check_doc_gate.py.
+
+Covers the two defects this port closes:
+  HOLE 1 -- a modification to a protected doc that deletes a required section
+            must fail (the old gate saw only A/D, and no rule listed a doc
+            path, so a doc-only change passed trivially).
+  HOLE 2 -- a rule satisfied by a doc touch is content-asserted, so a
+            one-character edit cannot mask a gutted section.
+
+Plus the tsk-t2lsre fix-forward set (5 items from card tsk-t2lsre):
+  1. rename/C bypass -- R/C expands to D + A so structural rules fire
+  2. changelog.d convention -- changelog.d/*.md added to require_doc
+  3. taosmd/ Layer A scope -- taosmd/ tokens checked, data-dir paths excluded
+  4. conflict-marker invariant -- changed files grepped for unresolved markers
+
+The red proofs in this file mirror the evidence blocks required by the merge
+gate (DOC-GATE FAIL: ... / exit 1).
+"""
+from __future__ import annotations
+
+import subprocess
+
+import scripts.check_doc_gate as dg
+from scripts.check_doc_gate import (
+    _glob_match,
+    _is_test_path,
+    _match_any,
+    _parse_name_status,
+    _missing_headings,
+    check_required_headings,
+    evaluate_rules,
+    extract_path_tokens,
+    main,
+)
+
+A2A_DOC = """# A2A Comms
+
+## What this does
+
+taOSmd bus lets agents share a channel.
+
+### HTTP endpoints
+
+POST /api/send
+"""
+
+A2A_DOC_GUTTED = """# A2A Comms
+
+## What this does
+
+taOSmd bus lets agents share a channel.
+
+No endpoints section anymore.
+"""
+
+PR_DOC = """# PR verification on taOSmd
+
+## The split
+
+Two stages.
+
+## The zero-token layer
+
+Three checks.
+"""
+
+# Mirrors docs/doc-gate.toml but kept minimal and self-contained.
+CFG = """
+[gate]
+trailer = "Docs-Reviewed:"
+
+[invariants]
+referenced_paths_scan = []
+
+[invariants.required_headings]
+"taosmd/docs/a2a-comms.md" = ["# A2A Comms", "## What this does", "### HTTP endpoints"]
+"docs/pr-verification.md" = ["# PR verification on taOSmd", "## The split", "## The zero-token layer"]
+
+[[rules]]
+name = "changelog"
+when_changed = ["taosmd/**"]
+require_doc = ["CHANGELOG.md", "changelog.d/*.md"]
+hint = "changelog required"
+
+[[rules]]
+name = "a2a-handlers"
+when_changed = ["taosmd/http_server.py", "taosmd/service.py", "taosmd/docs/a2a-comms.md"]
+on_modify = true
+require_doc = ["taosmd/docs/a2a-comms.md"]
+hint = "a2a handlers need docs"
+
+[[rules]]
+name = "contributor-surface"
+when_changed = [".github/workflows/**", "pyproject.toml", "docs/pr-verification.md"]
+on_modify = true
+require_doc = ["docs/pr-verification.md"]
+hint = "contributor surface needs doc"
+"""
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _init_repo(tmp_path):
+    """A temp git repo with the protected docs, a tiny taosmd package, and the
+    doc-gate config. Committed once as the base so diff-gate --staged / --base
+    both have something to compare against."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "taosmd").mkdir()
+    (repo / "taosmd" / "docs").mkdir(parents=True)
+    (repo / "docs").mkdir()
+    (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n")
+    (repo / "taosmd" / "service.py").write_text("def svc():\n    pass\n")
+    (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC)
+    (repo / "docs" / "pr-verification.md").write_text(PR_DOC)
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\n")
+    (repo / "docs" / "doc-gate.toml").write_text(CFG)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "t@t.com")
+    _git(repo, "config", "user.name", "T")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _load_cfg(repo):
+    import tomllib
+    with open(repo / "docs" / "doc-gate.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+# ----------------------------------------------------------------------
+# pure-function units
+# ----------------------------------------------------------------------
+
+class TestGlobMatch:
+    def test_star_stays_in_segment(self):
+        assert _glob_match("taosmd/foo.py", "taosmd/*.py")
+        assert not _glob_match("taosmd/sub/foo.py", "taosmd/*.py")
+
+    def test_double_star_matches_nested_and_parent(self):
+        assert _glob_match("taosmd/docs/x.md", "taosmd/**")
+        assert _glob_match("taosmd", "taosmd/**")
+        assert not _glob_match("other/taosmd/x", "taosmd/**")
+
+    def test_question_mark_single_char(self):
+        assert _glob_match("a/x.py", "a/?*.py")
+        assert not _glob_match("a/xy.py", "a/?")
+
+
+class TestMatchAny:
+    def test_matches_one_of_many(self):
+        assert _match_any("taosmd/service.py", ["taosmd/http_server.py", "taosmd/service.py"])
+
+    def test_no_match(self):
+        assert not _match_any("CHANGELOG.md", ["taosmd/docs/a2a-comms.md"])
+
+
+class TestExtractPathTokens:
+    def test_strips_trailing_punct(self):
+        tok = extract_path_tokens("see docs/foo.md, thanks")
+        assert tok == ["docs/foo.md"]
+
+    def test_ignores_globs_and_placeholders(self):
+        tok = extract_path_tokens("see docs/*.md and <scripts/run.sh>")
+        assert tok == []
+
+    def test_ignores_embedded_prefix(self):
+        # "tinyagentos/" inside a deploy path is not a repo path to assert.
+        tok = extract_path_tokens("copy to /home/u/tinyagentos/data/x")
+        assert tok == []
+
+    def test_includes_taosmd_module(self):
+        tok = extract_path_tokens("see taosmd/http_server.py for details")
+        assert tok == ["taosmd/http_server.py"]
+
+    def test_excludes_data_dir_paths(self):
+        text = (
+            "runtime paths: ~/.taosmd/config.json, taosmd/archive, "
+            "taosmd/archive-index.db, taosmd/knowledge-graph.db, "
+            "taosmd/vector-memory.db, taosmd/project.toml"
+        )
+        tok = extract_path_tokens(text)
+        assert "taosmd/config.json" not in tok
+        assert "taosmd/archive" not in tok
+        assert "taosmd/archive-index.db" not in tok
+        assert "taosmd/knowledge-graph.db" not in tok
+        assert "taosmd/vector-memory.db" not in tok
+        assert "taosmd/project.toml" not in tok
+
+    def test_excludes_generated_build_info(self):
+        tok = extract_path_tokens("see taosmd/_build_info.py")
+        assert "taosmd/_build_info.py" not in tok
+
+    def test_taosmd_in_other_prefix_not_matched(self):
+        tok = extract_path_tokens("see foo/taosmd/x.py")
+        assert tok == []
+
+
+class TestIsTestPath:
+    def test_pytest_module(self):
+        assert _is_test_path("tests/test_foo.py")
+        assert _is_test_path("taosmd/tests/test_bar.py")
+
+    def test_frontend_spec(self):
+        assert _is_test_path("dashboard/src/App.test.tsx")
+
+    def test_real_code(self):
+        assert not _is_test_path("taosmd/http_server.py")
+
+
+class TestParseNameStatus:
+    def test_add_unchanged(self):
+        assert _parse_name_status("A\tnewfile.py") == [("A", "newfile.py")]
+
+    def test_delete_unchanged(self):
+        assert _parse_name_status("D\tdeleted.py") == [("D", "deleted.py")]
+
+    def test_modify_unchanged(self):
+        assert _parse_name_status("M\tmodified.py") == [("M", "modified.py")]
+
+    def test_rename_expands_to_d_and_a(self):
+        result = _parse_name_status("R100\ttaosmd/http_server.py\ttaosmd/http_server_renamed.py")
+        assert ("D", "taosmd/http_server.py") in result
+        assert ("A", "taosmd/http_server_renamed.py") in result
+        assert len(result) == 2
+
+    def test_copy_expands_to_d_and_a(self):
+        result = _parse_name_status("C100\ttaosmd/http_server.py\ttaosmd/http_server_copy.py")
+        assert ("D", "taosmd/http_server.py") in result
+        assert ("A", "taosmd/http_server_copy.py") in result
+
+    def test_regular_statuses_unchanged(self):
+        result = _parse_name_status("A\tnewfile.py\nM\tmodified.py\nD\tdeleted.py")
+        assert result == [("A", "newfile.py"), ("M", "modified.py"), ("D", "deleted.py")]
+
+
+class TestMissingHeadings:
+    def test_all_present(self, tmp_path):
+        doc = tmp_path / "d.md"
+        doc.write_text("# Title\n\n## Body\n\n### HTTP endpoints\n")
+        assert _missing_headings(tmp_path, "d.md", ["# Title", "## Body"]) == []
+
+    def test_one_deleted(self, tmp_path):
+        doc = tmp_path / "d.md"
+        doc.write_text("# Title\n\n## Body\n\n")
+        assert _missing_headings(tmp_path, "d.md", ["# Title", "### HTTP endpoints"]) == [
+            "### HTTP endpoints"
+        ]
+
+    def test_missing_file_is_all_required(self, tmp_path):
+        assert _missing_headings(tmp_path, "d.md", ["# Title"]) == ["# Title"]
+
+    def test_no_required_returns_empty(self, tmp_path):
+        assert _missing_headings(tmp_path, "d.md", []) == []
+
+
+# ----------------------------------------------------------------------
+# evaluate_rules units (constructed changesets, no git)
+# ----------------------------------------------------------------------
+
+class TestEvaluateRules:
+    def test_default_rule_ignores_modification(self, tmp_path):
+        # changelog has no on_modify: a plain M under taosmd/ does NOT fire it.
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        fails = evaluate_rules([("M", "taosmd/retrieval.py")], [], cfg, repo)
+        assert fails == []
+
+    def test_changelog_fires_on_add(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        fails = evaluate_rules([("A", "taosmd/retrieval.py")], [], cfg, repo)
+        assert len(fails) == 1
+        assert "changelog" in fails[0]
+
+    def test_a2a_handlers_fires_on_modify_no_doc(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        fails = evaluate_rules([("M", "taosmd/http_server.py")], [], cfg, repo)
+        assert len(fails) == 1
+        assert "a2a-handlers" in fails[0]
+        assert "required section" not in fails[0]
+
+    def test_a2a_handlers_satisfied_by_intact_doc(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/http_server.py"), ("M", "taosmd/docs/a2a-comms.md")]
+        assert evaluate_rules(changed, [], cfg, repo) == []
+
+    def test_gutted_doc_fails_even_when_touched(self, tmp_path):
+        # HOLE 2 red: doc is touched (path-satisfied) but a required section
+        # was deleted -> content assertion must still fail.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/http_server.py"), ("M", "taosmd/docs/a2a-comms.md")]
+        fails = evaluate_rules(changed, [], cfg, repo)
+        assert any("a2a-handlers" in f and "required section" in f for f in fails)
+
+    def test_one_char_doc_touch_does_not_mask_gutting(self, tmp_path):
+        # A token edit to the gutted doc must not satisfy the rule.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED + "\n")
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/http_server.py"), ("M", "taosmd/docs/a2a-comms.md")]
+        fails = evaluate_rules(changed, [], cfg, repo)
+        assert any("required section" in f for f in fails)
+
+    def test_trailer_waives_doc_change(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/http_server.py")]
+        assert evaluate_rules(changed, ["Docs-Reviewed: no doc needed"], cfg, repo) == []
+
+    def test_trailer_does_not_mask_a_gutted_doc_in_layer_a(self, tmp_path):
+        # The trailer bypass is preserved (Layer B), but Layer A still catches
+        # content loss regardless of any waiver.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/http_server.py"), ("M", "taosmd/docs/a2a-comms.md")]
+        assert evaluate_rules(changed, ["Docs-Reviewed: waive"], cfg, repo) == []
+        assert check_required_headings(repo, cfg)
+
+    def test_doc_only_gutting_fires_a2a_rule(self, tmp_path):
+        # HOLE 1 red: ONLY the protected doc changes (a section deleted),
+        # nothing else. A rule with on_modify + doc in when_changed must fire
+        # and the content check must fail.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        cfg = _load_cfg(repo)
+        changed = [("M", "taosmd/docs/a2a-comms.md")]
+        fails = evaluate_rules(changed, [], cfg, repo)
+        assert any("a2a-handlers" in f and "required section" in f for f in fails)
+
+    def test_add_delete_triggers_without_on_modify(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        # An A of a non-test file under taosmd/** fires changelog (no on_modify).
+        fails = evaluate_rules([("A", "taosmd/newmod.py")], [], cfg, repo)
+        assert any("changelog" in f for f in fails)
+
+    def test_test_files_never_satisfy_or_trigger(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        # Adding a test file under a triggering glob must not fire a rule.
+        assert evaluate_rules([("A", "taosmd/test_newmod.py")], [], cfg, repo) == []
+        assert evaluate_rules([("A", "taosmd/newmod.py")], [], cfg, repo) != []
+
+    def test_rename_out_of_guarded_surface_fires_rules(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        # Rename out of taosmd/ is emitted as D (old) + A (new) by _parse_name_status.
+        fails = evaluate_rules(
+            [("D", "taosmd/http_server.py"), ("A", "taosmd/http_server_renamed.py")],
+            [],
+            cfg,
+            repo,
+        )
+        assert any("changelog" in f for f in fails)
+        assert any("a2a-handlers" in f for f in fails)
+
+    def test_benign_rename_outside_guarded_surface_is_clean(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        fails = evaluate_rules([("D", "README.md"), ("A", "README_NEW.md")], [], cfg, repo)
+        assert fails == []
+
+    def test_changelog_d_fragment_satisfies_changelog_rule(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        cfg = _load_cfg(repo)
+        changed = [("A", "taosmd/retrieval.py"), ("M", "changelog.d/tsk-xxx-add-thing.md")]
+        assert evaluate_rules(changed, [], cfg, repo) == []
+
+
+# ----------------------------------------------------------------------
+# end-to-end via main(): invariants (Layer A) and diff-gate --staged (Layer B)
+# ----------------------------------------------------------------------
+
+class TestMainIntegration:
+    def test_invariants_clean_on_intact_docs(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path)
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", str(repo / "docs" / "doc-gate.toml"), "invariants"])
+        assert rc == 0
+        assert "doc-gate: clean" in capsys.readouterr().out
+
+    def test_invariants_fails_when_section_deleted(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "invariants"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "DOC-GATE FAIL" in out
+        assert "required section" in out
+
+    def test_diff_gate_staged_red1_rule_triggered_doc_untouched(self, tmp_path, monkeypatch, capsys):
+        # RED 1: handler modified, doc untouched -> a2a-handlers fails.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n# touched\n")
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 1
+        assert "a2a-handlers" in capsys.readouterr().out
+
+    def test_diff_gate_staged_red2_doc_touched_section_deleted(self, tmp_path, monkeypatch, capsys):
+        # RED 2 / HOLE 1: doc present and touched, required section deleted.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n# touched\n")
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "DOC-GATE FAIL" in out
+        assert "required section" in out
+        assert "a2a-handlers" in out
+
+    def test_diff_gate_staged_doc_only_gutting_fails(self, tmp_path, monkeypatch, capsys):
+        # HOLE 1 red: only the doc changes, section deleted, nothing else.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC_GUTTED)
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 1
+        assert "DOC-GATE FAIL" in capsys.readouterr().out
+
+    def test_diff_gate_staged_green(self, tmp_path, monkeypatch, capsys):
+        # GREEN: handler modified AND doc touched intact -> satisfied.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n# touched\n")
+        (repo / "taosmd" / "docs" / "a2a-comms.md").write_text(A2A_DOC + "\n<!-- added line -->\n")
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 0
+        assert "doc-gate: clean" in capsys.readouterr().out
+
+    def test_diff_gate_base_red1(self, tmp_path, monkeypatch, capsys):
+        # Same red as --staged but via a real --base comparison (CI path).
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n# touched\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feat: touch handler\n\nno doc change")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--base", "HEAD~1"])
+        # No docs touched and no trailer on the commit message -> fail.
+        assert rc == 1
+        assert "a2a-handlers" in capsys.readouterr().out
+
+    def test_diff_gate_base_green_with_trailer(self, tmp_path, monkeypatch, capsys):
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text("def handler():\n    pass\n# touched\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feat: touch handler\n\nDocs-Reviewed: internal refactor, no API change")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--base", "HEAD~1"])
+        assert rc == 0
+
+    def test_diff_gate_staged_rename_out_of_guarded_surface_fails(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT RED: rename taosmd/http_server.py -> old path is D, new path
+        # is A, so both changelog and a2a-handlers must fire.
+        repo = _init_repo(tmp_path)
+        _git(repo, "mv", "taosmd/http_server.py", "taosmd/http_server_renamed.py")
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "changelog" in out
+        assert "a2a-handlers" in out
+
+    def test_diff_gate_staged_benign_rename_outside_taosmd_is_clean(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT GREEN: a rename outside taosmd/ does not trip any rule.
+        repo = _init_repo(tmp_path)
+        (repo / "docs" / "extra.md").write_text("# Extra\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add extra")
+        _git(repo, "mv", "docs/extra.md", "docs/extra_renamed.md")
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 0
+        assert "doc-gate: clean" in capsys.readouterr().out
+
+    def test_diff_gate_staged_conflict_markers_fail(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT RED: a file with conflict markers fails the gate.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text(
+            "def handler():\n    pass\n<<<<<<< HEAD\n# conflict\n=======\n# other\n>>>>>>> branch\n"
+        )
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 1
+        assert "conflict-marker" in capsys.readouterr().out
+
+    def test_diff_gate_staged_no_conflict_markers_green(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT GREEN: clean files pass.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "retrieval.py").write_text("def retrieve():\n    pass\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add retrieval")
+        (repo / "taosmd" / "retrieval.py").write_text("def retrieve():\n    pass\n# touched\n")
+        _git(repo, "add", ".")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--staged"])
+        assert rc == 0
+        assert "doc-gate: clean" in capsys.readouterr().out
+
+    def test_diff_gate_base_conflict_markers_fail(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT RED via --base path (CI flow): markers committed then
+        # diffed against HEAD~1 still fire.
+        repo = _init_repo(tmp_path)
+        (repo / "taosmd" / "http_server.py").write_text(
+            "def handler():\n    pass\n<<<<<<< HEAD\n# conflict\n=======\n# other\n>>>>>>> branch\n"
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add conflict markers")
+        cfg = str(repo / "docs" / "doc-gate.toml")
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", cfg, "diff-gate", "--base", "HEAD~1"])
+        assert rc == 1
+        assert "conflict-marker" in capsys.readouterr().out
+
+    def test_invariants_taosmd_module_reference_now_fails(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT RED: an invented taosmd/ module reference now fails invariants.
+        repo = _init_repo(tmp_path)
+        (repo / "docs" / "test.md").write_text("see taosmd/NOPE-NOT-REAL.py\n")
+        cfg = repo / "docs" / "doc-gate-test.toml"
+        cfg.write_text(
+            "[gate]\ntrailer = \"Docs-Reviewed:\"\n\n[invariants]\nreferenced_paths_scan = [\"docs/test.md\"]\n"
+        )
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", str(cfg), "invariants"])
+        assert rc == 1
+        assert "taosmd/NOPE-NOT-REAL.py" in capsys.readouterr().out
+
+    def test_invariants_taosmd_data_dir_paths_excluded(self, tmp_path, monkeypatch, capsys):
+        # PROVE IT GREEN: data-dir paths and generated files are excluded.
+        repo = _init_repo(tmp_path)
+        (repo / "docs" / "test.md").write_text(
+            "runtime paths: ~/.taosmd/config.json, taosmd/archive, taosmd/_build_info.py\n"
+        )
+        cfg = repo / "docs" / "doc-gate-test.toml"
+        cfg.write_text(
+            "[gate]\ntrailer = \"Docs-Reviewed:\"\n\n[invariants]\nreferenced_paths_scan = [\"docs/test.md\"]\n"
+        )
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = main(["--config", str(cfg), "invariants"])
+        assert rc == 0
+        assert "doc-gate: clean" in capsys.readouterr().out


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taosmd: fix the doc gate from PR #295 (rename bypass, red proof, changelog convention, taosmd/ scope, conflict markers)

Autonomous build of board card tsk-t2lsre.

Fix-forward for card tsk-t2lsre. The engine from PR #295 (84dbfec) and
its 34 tests are verified good and preserved as-is -- all 5 fixes are at
the edges. 54 tests pass, ruff check passes.

1. BLOCKER -- rename bypass: _parse_name_status now expands R/C statuses
   into D (old path) + A (new path) so structural rules fire for both source
   and destination. Before, R100 was reduced to "R" and evaluate_rules only
   counted A/D (and A/D/M under on_modify), so R and C triggered nothing.

   RED: git mv taosmd/http_server.py taosmd/http_server_renamed.py
   DOC-GATE FAIL: changelog -- changes under taosmd/ require a CHANGELOG entry rc=1
   DOC-GATE FAIL: a2a-handlers -- require docs coverage rc=1
   CONTROL DELETE taosmd/http_server.py -> same two failures rc=1
   CONTROL ADD taosmd/_probe_new.py -> DOC-GATE FAIL: changelog rc=1
   GREEN benign rename docs/serve-service.md -> docs/serve-service-renamed.md -> doc-gate: clean rc=0

2. BLOCKER -- red proof absent: PR body claimed "red proofs are in the PR
   body" but none existed in body, commit, or comment. Measured proof added
   to this commit message.

   RED delete taosmd/http_server.py -> DOC-GATE FAIL: changelog rc=1, a2a-handlers rc=1
   GREEN same delete + edit CHANGELOG.md + edit taosmd/docs/a2a-comms.md -> doc-gate: clean rc=0

3. BLOCKER -- changelog convention: changelog.d/ did not exist on master,
   no towncrier or consumer in pyproject.toml, and the changelog rule's
   require_doc was only CHANGELOG.md. Chose to add changelog.d/*.md to
   require_doc (not edit CHANGELOG.md, which doc-gate hard rules forbid for
   new files).

   GREEN new taosmd module + changelog.d/*.md fragment -> doc-gate: clean rc=0
   CONTROL same module + CHANGELOG.md edit -> doc-gate: clean rc=0

4. DEFECT -- Layer A taosmd/ scope: _TOKEN_RE was missing taosmd/. Adding
   it without exclusion produces 9 false positives (taosmd/config.json x3,
   taosmd/archive, taosmd/archive-index.db, taosmd/knowledge-graph.db,
   taosmd/vector-memory.db, taosmd/project.toml, taosmd/_build_info.py --
   all runtime data-dir or generated paths). Added _EXCLUDED_TOKEN_RE to
   filter these before assertion. Fixed docstrings at line 9 and in
   check_referenced_paths.

   RED docs referencing taosmd/NOPE-NOT-REAL.py -> DOC-GATE FAIL rc=1
   GREEN data-dir paths in docs -> doc-gate: clean rc=0
   GREEN invariants clean on real tree -> doc-gate: clean rc=0
   9 false positives measured without _EXCLUDED_TOKEN_RE, 0 with it

5. REQUIRED ADDITION -- conflict-marker invariant: _check_conflict_markers
   greps changed files for unresolved merge-conflict markers via
   `git grep -n -E "^(<<<<<<< |=======$|>>>>>>> )"`.

   RED PR #289 head: 3 markers in taosmd/http_server.py (lines 108, 113, 118)
   RED diff-gate --staged catches them -> conflict-marker failure rc=1
   GREEN master: 0 markers (git grep exit 1)

Files: scripts/check_doc_gate.py docs/doc-gate.toml tests/test_doc_gate.py
docs/pr-verification.md changelog.d/tsk-t2lsre-doc-gate-fixes.md
.github/workflows/doc-gate.yml

_MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085 || _MERGE_BASE=77ab00ffb5266735570dd8f9fe8992084e2df085
Files:
