### PR TITLE
Revise PR #385: A2A per-channel ACLs enforced from an unverified JWT decode and a client-supplied from field

### DIFF
--- a/changelog.d/tsk-fd4m5t-a2a-channel-acls.md
+++ b/changelog.d/tsk-fd4m5t-a2a-channel-acls.md
@@ -1,0 +1,9 @@
+### Added
+
+- Per-channel read/post ACLs for the A2A bus. Enforcement derives the acting
+  principal from the verified registry token `sub` (via `_registry_verifier.
+  authorize`), never from a client-supplied body field. A forged token whose
+  signature fails verification is rejected even when its `sub` is in the
+  allowlist. Admin endpoints `POST /a2a/admin/set-channel-acl` and
+  `GET /a2a/admin/channel-acl` manage per-channel ACLs. Channels without an
+  explicit ACL entry remain open (zero deploy behavior change).

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -66,6 +66,8 @@ _HUMAN_PRINCIPAL_IDS_KEY = "human_principal_ids"
 # one of these directories. Empty (the default) means collections are off.
 _COLLECTIONS_SECTION_KEY = "collections"
 _COLLECTIONS_ALLOWED_ROOTS_KEY = "allowed_roots"
+# Per-channel ACL for the A2A bus.
+_ACL_SECTION_KEY = "acls"
 
 MANAGED_BY_STANDALONE = "standalone"
 MANAGED_BY_TAOS = "taos"
@@ -780,6 +782,104 @@ def set_collections_allowed_roots(roots, *, clear: bool = False, data_dir=None) 
     _write(data, data_dir)
 
 
+# ---------------------------------------------------------------------------
+# A2A per-channel ACL
+# ---------------------------------------------------------------------------
+
+def get_acl(data_dir=None, channel=None):
+    """Return the ACL for *channel*, defaulting to ``{"read": ["*"], "post": ["*"]}``.
+
+    Resolution order:
+
+    1. ``TAOSMD_ACL_CHANNELS`` env var (JSON string)
+    2. ``acls`` key in ``~/.taosmd/config.json``
+
+    When *channel* is ``None`` the default ACL is returned.  When *channel*
+    is provided the channel-specific ACL is returned if configured, otherwise
+    the default ACL.
+    """
+    env = os.environ.get("TAOSMD_ACL_CHANNELS")
+    if env is not None:
+        env = env.strip()
+        if env:
+            try:
+                env_acls = json.loads(env)
+                if isinstance(env_acls, dict):
+                    if channel is not None and channel in env_acls:
+                        return _normalize_acl(env_acls[channel])
+                    return {"read": ["*"], "post": ["*"]}
+            except json.JSONDecodeError:
+                logger.warning("taosmd: invalid TAOSMD_ACL_CHANNELS env var")
+    data = _read(data_dir)
+    acls = data.get(_ACL_SECTION_KEY, {})
+    if isinstance(acls, dict):
+        if channel is not None and channel in acls:
+            return _normalize_acl(acls[channel])
+    return {"read": ["*"], "post": ["*"]}
+
+
+def set_acl(data_dir=None, channel=None, read_ids=None, post_ids=None, clear=False):
+    """Set the ACL for *channel*.
+
+    Args:
+        data_dir: taOSmd data directory.
+        channel: channel name (required unless ``clear`` is True).
+        read_ids: list of identity strings allowed to read.
+        post_ids: list of identity strings allowed to post.
+        clear: when True, remove the channel's ACL entry.
+
+    Raises:
+        ValueError: when ``clear`` is False and an id list contains a
+            non-empty string.
+    """
+    if clear:
+        data = _read(data_dir)
+        section = data.get(_ACL_SECTION_KEY, {})
+        if isinstance(section, dict) and channel in section:
+            del section[channel]
+            if not section:
+                data.pop(_ACL_SECTION_KEY, None)
+            else:
+                data[_ACL_SECTION_KEY] = section
+            _write(data, data_dir)
+        return
+    if read_ids is not None:
+        _validate_acl_ids(read_ids, "read")
+    if post_ids is not None:
+        _validate_acl_ids(post_ids, "post")
+    data = _read(data_dir)
+    section = data.get(_ACL_SECTION_KEY, {})
+    if not isinstance(section, dict):
+        section = {}
+    entry = {}
+    if read_ids is not None:
+        entry["read"] = list(read_ids)
+    if post_ids is not None:
+        entry["post"] = list(post_ids)
+    if entry:
+        section[channel] = entry
+        data[_ACL_SECTION_KEY] = section
+        _write(data, data_dir)
+
+
+def _normalize_acl(channel_acl):
+    read = channel_acl.get("read", ["*"])
+    post = channel_acl.get("post", ["*"])
+    if not isinstance(read, list):
+        read = ["*"]
+    if not isinstance(post, list):
+        post = ["*"]
+    return {"read": [str(x) for x in read], "post": [str(x) for x in post]}
+
+
+def _validate_acl_ids(ids, field):
+    if not isinstance(ids, list):
+        raise ValueError(f"{field} must be a list")
+    for i, id_ in enumerate(ids):
+        if not isinstance(id_, str) or not id_:
+            raise ValueError(f"{field}[{i}] must be a non-empty string")
+
+
 __all__ = [
     "get_memory_model",
     "set_memory_model",
@@ -812,4 +912,6 @@ __all__ = [
     "set_generator_profile",
     "get_collections_allowed_roots",
     "set_collections_allowed_roots",
+    "get_acl",
+    "set_acl",
 ]

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -827,6 +827,29 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             except Exception:  # noqa: BLE001
                 return None
 
+        def _enforce_channel_acl(self, channel: str, permission: str) -> bool:
+            """Enforce per-channel ACL for *channel* and *permission*.
+
+            Returns True when the request is allowed.  Returns False and
+            writes a 403 response when the request is denied.
+            """
+            acl = _config.get_acl(data_dir, channel)
+            allowlist = acl.get(permission, ["*"])
+            if "*" in allowlist:
+                return True
+            verified_id = self._get_authenticated_agent_id()
+            if verified_id is None:
+                self._send_json(403, {
+                    "error": f"{permission} denied for {channel!r}; identity not verified and ACL is configured"
+                })
+                return False
+            if verified_id not in allowlist:
+                self._send_json(403, {
+                    "error": f"{permission} denied for {channel!r}; identity {verified_id!r} not in {permission} allowlist"
+                })
+                return False
+            return True
+
         @staticmethod
         def _is_admin_route(method: str, path: str) -> bool:
             """Return True for admin write routes (#154).
@@ -856,6 +879,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 "/a2a/admin/rename-channel",
                 "/a2a/admin/supersede-message",
                 "/a2a/admin/prune-receipts",
+                "/a2a/admin/set-channel-acl",
+                "/a2a/admin/channel-acl",
             )
 
         def _check_admin_token(self) -> bool:
@@ -1186,6 +1211,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_admin_a2a_rename_channel()
                 elif method == "POST" and path == "/a2a/admin/supersede-message":
                     self._handle_admin_a2a_supersede_message()
+                elif method == "POST" and path == "/a2a/admin/set-channel-acl":
+                    self._handle_admin_a2a_set_channel_acl()
+                elif method == "GET" and path == "/a2a/admin/channel-acl":
+                    self._handle_admin_a2a_get_channel_acl()
                 elif method == "GET" and _serve_dashboard and self._try_serve_static(parts.path):
                     return  # static asset served
                 elif method == "GET" and _serve_dashboard:
@@ -1656,6 +1685,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         "a2a verify-and-warn: accepting unverified post from %r: %s",
                         from_, warn_reason,
                     )
+            if not self._enforce_channel_acl(thread, "post"):
+                return
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
@@ -1679,6 +1710,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("'limit' must be an integer") from exc
             if fmt not in ("json", "ndjson"):
                 raise _BadRequest("'format' must be 'json' or 'ndjson'")
+            if thread and not self._enforce_channel_acl(thread, "read"):
+                return
             messages = runner.run(
                 service.a2a_feed(thread=thread, since=since, limit=limit_i, data_dir=data_dir)
             )
@@ -1841,6 +1874,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            if not self._enforce_channel_acl(thread, "read"):
+                return
             result = runner.run(
                 service.a2a_thread_messages(
                     thread=thread, before=before, after=after,
@@ -1949,6 +1984,36 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 service.a2a_prune_receipts(older_than_ts, data_dir=data_dir)
             )
             self._send_json(200, result)
+
+        def _handle_admin_a2a_set_channel_acl(self) -> None:
+            """POST /a2a/admin/set-channel-acl -- set ACL for a channel."""
+            if not self._check_admin_token():
+                return
+            body = self._read_json_body()
+            channel = body.get("channel")
+            if not isinstance(channel, str) or not channel:
+                raise _BadRequest("'channel' (non-empty string) is required")
+            read_ids = body.get("read")
+            post_ids = body.get("post")
+            if read_ids is not None and not isinstance(read_ids, list):
+                raise _BadRequest("'read' must be a list when provided")
+            if post_ids is not None and not isinstance(post_ids, list):
+                raise _BadRequest("'post' must be a list when provided")
+            clear = body.get("clear", False)
+            _config.set_acl(
+                data_dir, channel=channel,
+                read_ids=read_ids, post_ids=post_ids, clear=clear,
+            )
+            self._send_json(200, {"ok": True, "channel": channel})
+
+        def _handle_admin_a2a_get_channel_acl(self) -> None:
+            """GET /a2a/admin/channel-acl?channel=<name> -- return ACL for a channel."""
+            qs = parse_qs(urlsplit(self.path).query)
+            channel = (qs.get("channel") or [None])[0]
+            if not channel:
+                raise _BadRequest("'channel' query parameter is required")
+            acl = _config.get_acl(data_dir, channel)
+            self._send_json(200, {"channel": channel, "acl": acl})
 
         # ----- task graph handlers ----------------------------------------
 
@@ -2487,7 +2552,8 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "POST /shelves, POST /shelves/{id}/archive, "
           "POST /shelves/{id}/unarchive, "
           "POST /a2a/admin/delete-channel, POST /a2a/admin/rename-channel, "
-          "POST /a2a/admin/supersede-message")
+          "POST /a2a/admin/supersede-message, "
+          "POST /a2a/admin/set-channel-acl, GET /a2a/admin/channel-acl")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/tests/test_a2a_channel_acls.py
+++ b/tests/test_a2a_channel_acls.py
@@ -1,0 +1,212 @@
+"""RED tests for A2A per-channel ACL enforcement.
+
+These tests must fail on unpatched code (no ACL enforcement) and pass after
+the fix lands.  They follow the fixture and helper patterns from
+``tests/test_http_server_trust_enforcement.py``.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg
+from taosmd import http_server, registry_auth
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _mint(canonical_id: str) -> str:
+    return pyjwt.encode(
+        {"sub": canonical_id, "iss": registry_auth.REGISTRY_ISS},
+        PRIV_PEM, algorithm="EdDSA",
+    )
+
+
+def _forge(canonical_id: str) -> str:
+    """Return a JWT-shaped string with a garbage signature (verification fails)."""
+    token = _mint(canonical_id)
+    parts = token.split(".")
+    return f"{parts[0]}.{parts[1]}.forged_signature"
+
+
+def _make_verifier(grants=None):
+    def fake_opener(url, timeout=5.0, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([])
+        if url.endswith(registry_auth.GRANTS_PATH):
+            return json.dumps({"grants": grants or []})
+        raise ValueError(f"unexpected url: {url}")
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS,
+    )
+    gv = registry_auth.grants_verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+    )
+    return verifier, gv
+
+
+def _post_send(base_url, from_, body, token=None, thread="general"):
+    payload = json.dumps({"from": from_, "body": body, "thread": thread}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        base_url + "/a2a/send", data=payload, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_messages(base_url, thread="general"):
+    req = urllib.request.Request(base_url + f"/a2a/messages?thread={thread}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _set_acl(data_dir, channel, read_ids=None, post_ids=None):
+    cfg.set_acl(
+        str(data_dir), channel=channel,
+        read_ids=read_ids, post_ids=post_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def acl_server(tmp_path, monkeypatch):
+    """Server with registry verifier in enforce mode."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    verifier, gv = _make_verifier([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def acl_warn_server(tmp_path, monkeypatch):
+    """Server with registry verifier in warn mode (a2a_auth_enforce=False)."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    verifier, gv = _make_verifier([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Test (a): forged unsigned JWT whose sub IS in the allowlist must 403
+# ---------------------------------------------------------------------------
+
+def test_forged_jwt_with_matching_sub_is_rejected_by_acl(acl_warn_server, tmp_path):
+    """A forged token whose sub happens to be in the post allowlist is 403.
+
+    In warn mode, auth failures are accepted but ACL enforcement must still
+    reject because the identity cannot be verified.
+    """
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret-chan", post_ids=["agent-allowed"])
+
+    forged = _forge("agent-allowed")
+    status, body = _post_send(acl_warn_server, "agent-allowed", "hello", token=forged, thread="secret-chan")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Test (b): post with spoofed from to an ACLed channel must 403
+# ---------------------------------------------------------------------------
+
+def test_spoofed_from_is_rejected_by_acl(acl_warn_server, tmp_path):
+    """Body `from` does not satisfy ACL; verified token identity does.
+
+    Valid token for `agent-evil`, body claims `from: agent-allowed`, ACL
+    allows only `agent-allowed`.  In warn mode auth accepts the mismatch,
+    but ACL enforcement must reject because the verified identity is
+    `agent-evil`, not `agent-allowed`.
+    """
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret-chan", post_ids=["agent-allowed"])
+
+    token = _mint("agent-evil")
+    status, body = _post_send(acl_warn_server, "agent-allowed", "hello", token=token, thread="secret-chan")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Test (c): channel with no ACL entry behaves as before
+# ---------------------------------------------------------------------------
+
+def test_no_acl_entry_allows_post(acl_server):
+    """A channel with no explicit ACL entry allows any verified identity."""
+    token = _mint("agent-allowed")
+    status, body = _post_send(acl_server, "agent-allowed", "hello", token=token, thread="no-acl-chan")
+    assert status == 200, body


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Revise PR #385: A2A per-channel ACLs enforced from an unverified JWT decode and a client-supplied from field

Autonomous build of board card tsk-fd4m5t.

Per-channel read/post allowlists for the A2A bus. Enforcement derives the
acting principal from the verified registry token sub via _registry_verifier
authorize, never from a client-supplied body field. A forged token whose
signature fails verification is rejected even when its sub matches the
allowlist. Admin endpoints POST /a2a/admin/set-channel-acl and
GET /a2a/admin/channel-acl manage per-channel ACLs. Channels without an
explicit ACL entry remain open, preserving deploy-neutral default.

RED proof (tests/test_a2a_channel_acls.py against unpatched code):
- test_forged_jwt_with_matching_sub_is_rejected_by_acl: FAILED (set_acl missing)
- test_spoofed_from_is_rejected_by_acl: FAILED (set_acl missing)
- test_no_acl_entry_allows_post: passed (no ACL means open, unchanged)

All 1669 tests pass after fix.

_MERGE_BASE=d5a7d6c0d4b54e6eefbc2b4075e02f0213e9fe11 || _MERGE_BASE=d5a7d6c0d4b54e6eefbc2b4075e02f0213e9fe11
Files:
