### PR TITLE
A2A v2 slice 1: kind taxonomy + strict params on every /a2a endpoint

### DIFF
--- a/changelog.d/tsk-tlhkvb-a2a-kinds-strict-params.md
+++ b/changelog.d/tsk-tlhkvb-a2a-kinds-strict-params.md
@@ -1,0 +1,5 @@
+### Added
+
+- `POST /a2a/send` accepts `kind: chat|alarm|ack|digest|receipt|review|system` (default `chat`), stores it on the envelope, and returns it in every read path. Unknown kinds are rejected with 400 naming the allowed set.
+- One-shot migration `a2a_migrate_kinds()` backfills `kind` on historical A2A messages by body-prefix convention (`[AUTOMATED` -> alarm, `[AUTO-ACK]` -> ack, `[REVIEW]` -> review, else chat). Idempotent: re-running yields zero migrated rows.
+- Every `/a2a` GET endpoint now rejects unknown query parameters with 400 listing the valid ones, generalising the existing `since` < 1e9 guard to close the silent-tolerance defect class.

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -341,6 +341,19 @@ class ArchiveStore:
             result["data"] = {}
         return result
 
+    async def update_event_data_json(self, event_id: int, data: dict) -> None:
+        """Update the data_json for an existing index row.
+
+        Used by one-shot migrations that backfill fields (e.g. message kind)
+        onto historical archive events. The JSONL source files are never
+        modified; only the derived index is updated.
+        """
+        self._conn.execute(
+            "UPDATE archive_index SET data_json = ? WHERE id = ?",
+            (json.dumps(data, default=str), event_id),
+        )
+        self._conn.commit()
+
     async def count(
         self,
         event_type: str | None = None,

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -239,10 +239,19 @@ DEFAULT_PORT = 7900
 _A2A_REF_KINDS = frozenset({"doc", "report", "spec", "log"})
 _A2A_MAX_REFS = 8
 _A2A_MAX_MESSAGE_BYTES = 64 * 1024  # 64 KB total (body+refs+blocks)
+_A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "system"})
 
 # Cursor pagination limits for /a2a/threads/{thread}/messages.
 _A2A_MSG_DEFAULT_LIMIT = 50
 _A2A_MSG_MAX_LIMIT = 200
+
+
+def _validate_a2a_params(qs: dict, allowed: frozenset[str]) -> None:
+    unknown = set(qs.keys()) - allowed
+    if unknown:
+        raise _BadRequest(
+            f"unknown query parameters: {sorted(unknown)}; allowed: {sorted(allowed)}"
+        )
 
 
 # `since` on the A2A feed endpoints is an epoch timestamp in seconds, not a
@@ -1059,9 +1068,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 elif method == "POST" and path == "/a2a/send":
                     self._handle_a2a_send()
                 elif method == "GET" and path == "/a2a/channels":
-                    self._handle_a2a_channels()
+                    self._handle_a2a_channels(query)
                 elif method == "GET" and path == "/a2a/census":
-                    self._handle_a2a_census()
+                    self._handle_a2a_census(query)
                 elif method == "GET" and path == "/a2a/members":
                     self._handle_a2a_members(query)
                 elif method == "GET" and path == "/a2a/messages":
@@ -1529,15 +1538,18 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, result)
 
-        def _handle_a2a_channels(self) -> None:
+        def _handle_a2a_channels(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset())
             channels = runner.run(service.a2a_channels(data_dir=data_dir))
             self._send_json(200, {"channels": channels})
 
-        def _handle_a2a_census(self) -> None:
+        def _handle_a2a_census(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset())
             census = runner.run(service.a2a_sender_census(data_dir=data_dir))
             self._send_json(200, {"census": census})
 
         def _handle_a2a_members(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset({"channel"}))
             channel = (qs.get("channel") or [None])[0]
             if not channel:
                 raise _BadRequest("'channel' query parameter is required")
@@ -1552,8 +1564,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             reply_to = body.get("reply_to")
             refs = body.get("refs")
             blocks = body.get("blocks")
+            kind = body.get("kind", "chat") or "chat"
             if not isinstance(from_, str) or not from_:
                 raise _BadRequest("'from' (non-empty string) is required")
+            if not isinstance(kind, str) or kind not in _A2A_KINDS:
+                raise _BadRequest(
+                    "'kind' must be one of "
+                    f"{sorted(_A2A_KINDS)}; got {kind!r}"
+                )
             # --- Envelope field validation (taOSmd #211) ---
             # refs: optional list of dicts, <=8 items, kind in the enum.
             if refs is not None:
@@ -1564,8 +1582,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 for i, ref in enumerate(refs):
                     if not isinstance(ref, dict):
                         raise _BadRequest(f"'refs[{i}]' must be an object")
-                    kind = ref.get("kind")
-                    if kind not in _A2A_REF_KINDS:
+                    ref_kind = ref.get("kind")
+                    if ref_kind not in _A2A_REF_KINDS:
                         raise _BadRequest(
                             f"'refs[{i}].kind' must be one of {sorted(_A2A_REF_KINDS)}"
                         )
@@ -1660,13 +1678,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 service.a2a_send(
                     sender=from_, body=body_text,
                     thread=thread, reply_to=reply_to,
-                    refs=refs, blocks=blocks,
+                    refs=refs, blocks=blocks, kind=kind,
                     data_dir=data_dir,
                 )
             )
             self._send_json(200, result)
 
         def _handle_a2a_messages(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset({"thread", "since", "limit", "fields", "format"}))
             thread = (qs.get("thread") or [None])[0]
             since_raw = (qs.get("since") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
@@ -1705,6 +1724,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"messages": messages})
 
         def _handle_a2a_mentions(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset({"since", "limit", "reader"}))
             since_raw = (qs.get("since") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
             try:
@@ -1776,6 +1796,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             subscribers that carry no identifying token produce no delivered
             mark.
             """
+            _validate_a2a_params(qs, frozenset({"thread", "since"}))
             thread = (qs.get("thread") or [None])[0]
             since_raw = (qs.get("since") or [None])[0]
             last_ts = _parse_since(since_raw)
@@ -1825,6 +1846,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 return
 
         def _handle_a2a_threads(self, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset({"principal"}))
             principal = (qs.get("principal") or [None])[0]
             threads = runner.run(
                 service.a2a_threads(principal=principal, data_dir=data_dir)
@@ -1832,6 +1854,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"threads": threads})
 
         def _handle_a2a_thread_messages(self, thread: str, qs: dict) -> None:
+            _validate_a2a_params(qs, frozenset({"before", "after", "limit"}))
             before_raw = (qs.get("before") or [None])[0]
             after_raw = (qs.get("after") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1564,7 +1564,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             reply_to = body.get("reply_to")
             refs = body.get("refs")
             blocks = body.get("blocks")
-            kind = body.get("kind", "chat") or "chat"
+            kind = body.get("kind", "chat")
+            if kind is None:
+                kind = "chat"
             if not isinstance(from_, str) or not from_:
                 raise _BadRequest("'from' (non-empty string) is required")
             if not isinstance(kind, str) or kind not in _A2A_KINDS:

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -404,6 +404,9 @@ async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
     }
 
 
+_A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "system"})
+
+
 async def a2a_send(
     sender: str,
     body: str,
@@ -413,6 +416,7 @@ async def a2a_send(
     refs: list | None = None,
     blocks: list | None = None,
     recipient: str | None = None,
+    kind: str = "chat",
     data_dir=None,
 ) -> dict:
     """Post a message onto the agent-to-agent bus.
@@ -423,6 +427,10 @@ async def a2a_send(
     ``thread`` defaults to ``"general"``; ``reply_to`` is optional and
     should be the string ID of the message being replied to.
 
+    ``kind`` is one of ``chat``, ``alarm``, ``ack``, ``digest``,
+    ``receipt``, ``review``, ``system`` (default ``chat``). It is stored
+    on the envelope and returned in every read path.
+
     ``refs`` and ``blocks`` are optional first-class envelope fields
     (taOSmd #211). When provided they are stored verbatim in the archive
     payload and echoed back in the receipt and on feed/SSE reads. When
@@ -432,8 +440,8 @@ async def a2a_send(
     is stored in the archive payload and indexed as a mention so the
     recipient can retrieve it via GET /a2a/mentions.
 
-    Returns ``{"id", "from", "thread", "reply_to"}`` plus ``refs`` and/or
-    ``blocks`` when those were supplied.
+    Returns ``{"id", "from", "thread", "reply_to", "kind"}`` plus ``refs``
+    and/or ``blocks`` when those were supplied.
 
     When a remote server URL is configured the call is forwarded to
     :class:`~taosmd.remote.RemoteClient` transparently.
@@ -442,11 +450,15 @@ async def a2a_send(
         raise ValueError("sender must be a non-empty string")
     if not isinstance(body, str) or not body:
         raise ValueError("body must be a non-empty string")
+    if kind not in _A2A_KINDS:
+        raise ValueError(
+            f"'kind' must be one of {sorted(_A2A_KINDS)}; got {kind!r}"
+        )
     remote = _get_remote(data_dir)
     if remote is not None:
         return await remote.a2a_send(
             sender, body, thread=thread, reply_to=reply_to,
-            refs=refs, blocks=blocks, recipient=recipient,
+            refs=refs, blocks=blocks, recipient=recipient, kind=kind,
         )
     stores = await _api._ensure_stores(data_dir)
     archive = stores["archive"]
@@ -456,7 +468,7 @@ async def a2a_send(
         from .admin import A2AAdminState  # noqa: PLC0415
         _admin = A2AAdminState(data_dir)
         thread = _admin.resolve_channel(thread)
-    data = {"from": sender, "body": body, "thread": thread, "reply_to": reply_to}
+    data = {"from": sender, "body": body, "thread": thread, "reply_to": reply_to, "kind": kind}
     if recipient is not None:
         data["recipient"] = recipient
     if refs is not None:
@@ -470,7 +482,7 @@ async def a2a_send(
         app_id=thread,
         summary=body[:200],
     )
-    receipt = {"id": row_id, "from": sender, "thread": thread, "reply_to": reply_to}
+    receipt = {"id": row_id, "from": sender, "thread": thread, "reply_to": reply_to, "kind": kind}
     if recipient is not None:
         receipt["recipient"] = recipient
     if refs is not None:
@@ -585,6 +597,7 @@ async def a2a_feed(
             "body": data.get("body"),
             "thread": msg_thread,
             "reply_to": data.get("reply_to"),
+            "kind": data.get("kind") or "chat",
         }
         # First-class envelope fields (taOSmd #211): stored verbatim,
         # omitted from output when absent (no null noise).
@@ -739,6 +752,44 @@ async def a2a_sender_census(*, data_dir=None) -> dict:
     return dict(
         sorted(census.items(), key=lambda item: item[1]["total"], reverse=True)
     )
+
+
+async def a2a_migrate_kinds(*, data_dir=None) -> dict:
+    """One-shot migration: backfill ``kind`` on historical A2A messages.
+
+    Messages that already have a ``kind`` field are left untouched. Messages
+    without one are tagged by their body-prefix convention:
+    ``[AUTOMATED`` -> ``alarm``, ``[AUTO-ACK]`` -> ``ack``,
+    ``[REVIEW]`` -> ``review``, everything else -> ``chat``.
+
+    Returns ``{"migrated": int, "alarm": int, "ack": int, "review": int,
+    "chat": int}``. Idempotent: running twice yields ``migrated == 0``.
+    """
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    rows = await archive.query(event_type=EVENT_A2A, limit=100_000)
+    counts = {"migrated": 0, "alarm": 0, "ack": 0, "review": 0, "chat": 0}
+    for row in rows:
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        if data.get("kind"):
+            continue
+        body = data.get("body", "") or ""
+        if body.startswith("[AUTOMATED"):
+            kind = "alarm"
+        elif body.startswith("[AUTO-ACK]"):
+            kind = "ack"
+        elif body.startswith("[REVIEW]"):
+            kind = "review"
+        else:
+            kind = "chat"
+        data["kind"] = kind
+        await archive.update_event_data_json(row["id"], data)
+        counts[kind] += 1
+        counts["migrated"] += 1
+    return counts
 
 
 async def a2a_members(*, channel: str, data_dir=None) -> list[str]:
@@ -905,6 +956,7 @@ async def a2a_thread_messages(
             "body": data.get("body"),
             "thread": msg_thread,
             "reply_to": data.get("reply_to"),
+            "kind": data.get("kind") or "chat",
         }
         if "refs" in data:
             msg["refs"] = data["refs"]
@@ -1034,6 +1086,7 @@ async def a2a_mentions_feed(
             "thread": data.get("thread") or row.get("app_id") or "general",
             "reply_to": data.get("reply_to"),
             "thread_root": thread_roots.get(row["id"]),
+            "kind": data.get("kind") or "chat",
         }
         result.append(msg)
 
@@ -1586,7 +1639,7 @@ async def collections_archive(collection_id: str, *, data_dir=None) -> dict:
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
            "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
-           "a2a_mentions_feed", "can_read",
+           "a2a_mentions_feed", "a2a_migrate_kinds", "can_read",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -167,6 +167,16 @@ def test_http_a2a_send_kind_system_roundtrips(live_server):
     assert body["messages"][0]["kind"] == "system"
 
 
+def test_http_a2a_send_empty_kind_returns_400(live_server):
+    """An explicit empty-string kind is invalid, never silently coerced to chat."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "agentA", "body": "msg", "thread": "kind-empty", "kind": ""},
+    )
+    assert status == 400, body
+    assert "kind" in body["error"].lower()
+
+
 def test_http_a2a_send_unknown_kind_returns_400(live_server):
     """POST /a2a/send with an unknown kind must 400 naming the allowed set."""
     status, body = _post(

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -1,0 +1,361 @@
+"""Tests for A2A v2 slice 1: kind taxonomy + strict params on every /a2a endpoint.
+
+Covers:
+- POST /a2a/send accepts kind and returns it in the envelope
+- kind round-trips through GET /a2a/messages and SSE /a2a/stream
+- Every /a2a GET endpoint rejects unknown query params with 400
+- One-shot migration tags historical messages by body-prefix conventions
+  and is idempotent
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+from taosmd.archive import EVENT_A2A
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-v2"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-v2-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+def _post(url: str, payload) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    return _send(req)
+
+
+def _get(url: str) -> tuple[int, dict]:
+    return _send(urllib.request.Request(url, method="GET"))
+
+
+def _send(req) -> tuple[int, dict]:
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): unknown query param on /a2a/messages must 400
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_unknown_param_returns_400(live_server):
+    """Unknown query params on /a2a/messages must 400, not silently page."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "strict-test"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=strict-test&bogus_param=1")
+    assert status == 400, body
+    assert "bogus_param" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# Gate (b): kind round-trips send -> messages -> stream
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_send_kind_default_chat(live_server):
+    """Default kind is chat and is returned in the send receipt."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "agentA", "body": "chat msg", "thread": "kind-test"},
+    )
+    assert status == 200, body
+    assert body.get("kind") == "chat"
+
+
+def test_http_a2a_send_kind_alarm_roundtrips(live_server):
+    """POST with kind=alarm -> GET /a2a/messages returns kind=alarm."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "agentA", "body": "alarm msg", "thread": "kind-alarm", "kind": "alarm"},
+    )
+    assert status == 200, body
+    assert body["kind"] == "alarm"
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=kind-alarm")
+    assert status == 200, body
+    msgs = body["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["kind"] == "alarm"
+
+
+def test_http_a2a_send_kind_system_roundtrips(live_server):
+    """POST with kind=system -> GET /a2a/messages returns kind=system."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "sys", "body": "sys msg", "thread": "kind-sys", "kind": "system"},
+    )
+    assert status == 200, body
+    assert body["kind"] == "system"
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=kind-sys")
+    assert status == 200, body
+    assert body["messages"][0]["kind"] == "system"
+
+
+def test_http_a2a_send_unknown_kind_returns_400(live_server):
+    """POST /a2a/send with an unknown kind must 400 naming the allowed set."""
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "agentA", "body": "msg", "thread": "kind-bad", "kind": "teleport"},
+    )
+    assert status == 400, body
+    err = body["error"].lower()
+    assert "chat" in err and "alarm" in err
+
+
+def test_http_a2a_stream_includes_kind(live_server):
+    """SSE frames include the kind field."""
+    parsed = urllib.parse.urlsplit(live_server)
+    host = parsed.hostname
+    port = parsed.port
+    thread = "sse-kind"
+    frames_received = []
+    error_holder = []
+
+    def _stream_reader():
+        try:
+            result = _read_sse_frames(host, port, f"/a2a/stream?thread={thread}", timeout=8.0)
+            frames_received.extend(result)
+        except Exception as exc:
+            error_holder.append(exc)
+
+    reader = threading.Thread(target=_stream_reader, daemon=True)
+    reader.start()
+    time.sleep(1.5)
+
+    status, body = _post(
+        live_server + "/a2a/send",
+        {"from": "sse-sender", "body": "sse kind payload", "thread": thread, "kind": "review"},
+    )
+    assert status == 200, f"send failed: {body}"
+
+    reader.join(timeout=10)
+    assert not error_holder, f"SSE reader raised: {error_holder[0]}"
+    assert frames_received, "expected at least one SSE data: frame"
+    payloads = [json.loads(f) for f in frames_received]
+    matching = [p for p in payloads if p.get("body") == "sse kind payload"]
+    assert matching, "expected the posted message in SSE frames"
+    assert matching[0]["kind"] == "review"
+
+
+# ---------------------------------------------------------------------------
+# Gate (c): one-shot migration tags historical messages by body prefix
+# ---------------------------------------------------------------------------
+
+def _seed_historical_message(stores, body, thread="migrate-test"):
+    """Write a raw A2A event directly to the archive without kind."""
+    archive = stores["archive"]
+    data = {"from": "hist", "body": body, "thread": thread}
+    row_id = asyncio.run(archive.record(
+        event_type=EVENT_A2A,
+        data=data,
+        agent_name="hist",
+        app_id=thread,
+        summary=body[:200],
+    ))
+    return row_id
+
+
+def test_a2a_migrate_kinds_idempotent_and_correct(isolated_data_dir):
+    """Migration tags [AUTOMATED, [AUTO-ACK], [REVIEW] prefixes and is idempotent."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    _seed_historical_message(_setup_stores(isolated_data_dir), "[AUTOMATED check complete]", "mig1")
+    _seed_historical_message(_setup_stores(isolated_data_dir), "[AUTO-ACK] received", "mig2")
+    _seed_historical_message(_setup_stores(isolated_data_dir), "[REVIEW] please check", "mig3")
+    _seed_historical_message(_setup_stores(isolated_data_dir), "plain chat message", "mig4")
+
+    result = asyncio.run(service.a2a_migrate_kinds(data_dir=dd))
+    assert result["migrated"] == 4
+    assert result["alarm"] == 1
+    assert result["ack"] == 1
+    assert result["review"] == 1
+    assert result["chat"] == 1
+
+    msgs = asyncio.run(service.a2a_feed(thread="mig1", data_dir=dd))
+    assert msgs[0]["kind"] == "alarm"
+    msgs = asyncio.run(service.a2a_feed(thread="mig2", data_dir=dd))
+    assert msgs[0]["kind"] == "ack"
+    msgs = asyncio.run(service.a2a_feed(thread="mig3", data_dir=dd))
+    assert msgs[0]["kind"] == "review"
+    msgs = asyncio.run(service.a2a_feed(thread="mig4", data_dir=dd))
+    assert msgs[0]["kind"] == "chat"
+
+    result2 = asyncio.run(service.a2a_migrate_kinds(data_dir=dd))
+    assert result2["migrated"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Strict params on other /a2a GET endpoints
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_mentions_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "mention-test"})
+    status, body = _get(f"{live_server}/a2a/mentions?reader=agentA&bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_stream_unknown_param_returns_400(live_server):
+    status = _stream_status_code(live_server, "/a2a/stream?thread=any&bogus=1")
+    assert status == 400
+
+
+def test_http_a2a_threads_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/threads?principal=agentA&bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_thread_messages_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "tm-test"})
+    status, body = _get(f"{live_server}/a2a/threads/tm-test/messages?bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_channels_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/channels?bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_members_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/members?channel=general&bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# SSE helpers
+# ---------------------------------------------------------------------------
+
+def _read_sse_frames(host: str, port: int, path: str, timeout: float = 8.0) -> list[str]:
+    frames: list[str] = []
+    deadline = time.monotonic() + timeout
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode()
+        )
+        buf = b""
+        header_done = False
+        while time.monotonic() < deadline and not frames:
+            sock.settimeout(max(0.1, deadline - time.monotonic()))
+            try:
+                chunk = sock.recv(4096)
+            except (socket.timeout, TimeoutError):
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if not header_done:
+                sep = buf.find(b"\r\n\r\n")
+                if sep != -1:
+                    buf = buf[sep + 4:]
+                    header_done = True
+            if header_done:
+                text = buf.decode("utf-8", errors="replace")
+                for line in text.splitlines():
+                    if line.startswith("data: "):
+                        frames.append(line[6:])
+    return frames
+
+
+def _stream_status_code(live_server: str, path: str, timeout: float = 3.0) -> int:
+    parsed = urllib.parse.urlsplit(live_server)
+    host = parsed.hostname
+    port = parsed.port
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode()
+        )
+        sock.settimeout(timeout)
+        line = b""
+        while b"\r\n" not in line:
+            try:
+                chunk = sock.recv(128)
+            except (socket.timeout, TimeoutError) as exc:
+                raise AssertionError(f"timed out reading stream status line: {exc}") from exc
+            if not chunk:
+                break
+            line += chunk
+    status_line = line.decode("utf-8", "replace").splitlines()[0]
+    return int(status_line.split()[1])


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A v2 slice 1: kind taxonomy + strict params on every /a2a endpoint

Autonomous build of board card tsk-tlhkvb.

POST /a2a/send accepts kind: chat|alarm|ack|digest|receipt|review|system,
default chat, stored and returned in every message envelope. Unknown kinds
are rejected with 400 naming the allowed set.

One-shot migration a2a_migrate_kinds() backfills kind on historical A2A
messages by body-prefix convention ([AUTOMATED -> alarm, [AUTO-ACK] -> ack,
[REVIEW] -> review, else chat). Idempotent: re-running yields zero migrated
rows.

Every /a2a GET endpoint now rejects unknown query parameters with 400
listing the valid ones, generalising the existing since < 1e9 guard to
close the silent-tolerance defect class.

Proof: 13 new tests in tests/test_a2a_kinds_strict_params.py pass, all
115 A2A tests pass.

_MERGE_BASE=d5a7d6c0d4b54e6eefbc2b4075e02f0213e9fe11 || _MERGE_BASE=d5a7d6c0d4b54e6eefbc2b4075e02f0213e9fe11
Files:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validated A2A message kinds, defaulting to `chat` when omitted.
  * Message kinds are preserved and shown in receipts, feeds, threads, mentions, and streams.
  * Added migration support for existing messages.

* **Bug Fixes**
  * A2A endpoints now reject unknown query parameters and unsupported message kinds.
  * Historical message data can be updated without modifying archived source files.

* **Tests**
  * Added comprehensive coverage for message kinds, strict parameters, streaming, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->