### PR TITLE
A2A v2 slice 2b: acks as server state, not traffic (service layer only, spec section 3)

### DIFF
--- a/changelog.d/tsk-ta4ftl-a2a-ack-state.md
+++ b/changelog.d/tsk-ta4ftl-a2a-ack-state.md
@@ -1,0 +1,3 @@
+### Added
+
+- `a2a_ack(message_id, by, *, data_dir=None)` records an acknowledgement as server-side state on the message envelope (`acked_by` list via `archive.update_event_data_json`), never as a new bus message. Acks are surfaced by the existing `a2a_feed` and `a2a_thread_messages` read paths and are idempotent per principal.

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -605,6 +605,8 @@ async def a2a_feed(
             msg["refs"] = data["refs"]
         if "blocks" in data:
             msg["blocks"] = data["blocks"]
+        if "acked_by" in data:
+            msg["acked_by"] = data["acked_by"]
         result.append(msg)
     return result
 
@@ -962,6 +964,8 @@ async def a2a_thread_messages(
             msg["refs"] = data["refs"]
         if "blocks" in data:
             msg["blocks"] = data["blocks"]
+        if "acked_by" in data:
+            msg["acked_by"] = data["acked_by"]
         messages.append(msg)
 
     def _cursor_val(cursor):
@@ -1229,6 +1233,43 @@ async def a2a_prune_receipts(
     receipt_store = stores["receipts"]
     n = await receipt_store.prune(older_than_ts)
     return {"pruned": n}
+
+
+async def a2a_ack(message_id: int, by: str, *, data_dir=None) -> dict:
+    """Record that a principal has acknowledged a message, as server state.
+
+    Per the A2A delivery contract v2 (section 3), an acknowledgement is
+    never a new bus message: it mutates the message envelope in place by
+    appending ``by`` to an ``acked_by`` list on the archived event, via
+    :meth:`taosmd.archive.ArchiveStore.update_event_data_json`. The JSONL
+    source files are never touched; only the derived index is updated.
+
+    Idempotent: acking the same message twice by the same principal leaves
+    exactly one entry in ``acked_by``. The ``acked_by`` list is surfaced
+    on the envelope by the existing read paths (``a2a_feed`` and
+    ``a2a_thread_messages``).
+
+    The composed "unhandled for X" query (mentions past X's cursor minus
+    acks) is deferred to slice 2c, which needs 2a's server-side cursor.
+
+    Returns ``{"id", "acked_by", "ok"}``.
+    """
+    if not isinstance(by, str) or not by:
+        raise ValueError("by must be a non-empty string")
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    stored = await archive.get_event(message_id)
+    if stored is None:
+        raise ValueError(f"message {message_id} not found")
+    data = dict(stored.get("data") or {})
+    acked_by = data.get("acked_by")
+    if not isinstance(acked_by, list):
+        acked_by = []
+    if by not in acked_by:
+        acked_by = [*acked_by, by]
+    data["acked_by"] = acked_by
+    await archive.update_event_data_json(message_id, data)
+    return {"id": message_id, "acked_by": acked_by, "ok": True}
 
 
 async def task_create(
@@ -1646,7 +1687,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",
            "admin_a2a_supersede_message",
            "a2a_record_delivered", "a2a_record_seen", "a2a_get_receipts",
-           "a2a_get_receipt", "a2a_prune_receipts",
+           "a2a_get_receipt", "a2a_prune_receipts", "a2a_ack",
            "collections_create", "collections_list", "collections_get",
            "collections_index_start", "collections_index_run",
            "collections_index_background", "collections_link",

--- a/tests/test_a2a_ack_state.py
+++ b/tests/test_a2a_ack_state.py
@@ -1,0 +1,162 @@
+"""Tests for A2A v2 slice 2b: acks as server state, not traffic.
+
+Service-layer only -- no HTTP endpoints (those are slice 2c). Covers:
+
+  (a) a2a_ack generates NO new bus message: the total A2A event count is
+      unchanged after an ack;
+  (b) acked_by is visible on the envelope in the existing read paths
+      (a2a_feed and a2a_thread_messages);
+  (c) double-ack by the same principal leaves exactly one entry in
+      acked_by (idempotent).
+
+The composed "unhandled for X" query (mentions past X's cursor minus acks)
+is deferred to slice 2c -- it needs 2a's server-side cursor.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import service
+from taosmd.archive import EVENT_A2A
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    """Deterministic 8-dim hash embedder -- no ONNX/QMD model required."""
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Isolated data dir with a clean stores cache for each test."""
+    data_dir = tmp_path / "taosmd-a2a-ack"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _send_message(data_dir, body: str = "ack me", thread: str = "acks") -> int:
+    """Send a message and return its id."""
+    receipt = asyncio.run(service.a2a_send(
+        "agentA", body, thread=thread, data_dir=str(data_dir),
+    ))
+    return receipt["id"]
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): ack generates NO new bus message
+# ---------------------------------------------------------------------------
+
+def test_a2a_ack_creates_no_new_message(isolated_data_dir):
+    """Acknowledging a message must never create a new bus event."""
+    stores = _setup_stores(isolated_data_dir)
+    archive = stores["archive"]
+    dd = str(isolated_data_dir)
+
+    msg_id = _send_message(isolated_data_dir)
+
+    before = asyncio.run(archive.count(event_type=EVENT_A2A))
+    assert before == 1
+
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+
+    after = asyncio.run(archive.count(event_type=EVENT_A2A))
+    assert after == before, "ack must not create a new bus message"
+
+
+# ---------------------------------------------------------------------------
+# Gate (b): acked_by visible on the envelope in the read path
+# ---------------------------------------------------------------------------
+
+def test_a2a_ack_visible_in_feed(isolated_data_dir):
+    """acked_by appears on the envelope returned by a2a_feed."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    msg_id = _send_message(isolated_data_dir, thread="acks")
+
+    # Before any ack: acked_by is omitted from the envelope (no null noise).
+    msgs = asyncio.run(service.a2a_feed(thread="acks", data_dir=dd))
+    assert len(msgs) == 1
+    assert "acked_by" not in msgs[0]
+
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+
+    msgs = asyncio.run(service.a2a_feed(thread="acks", data_dir=dd))
+    assert msgs[0]["acked_by"] == ["agentB"]
+
+
+def test_a2a_ack_visible_in_thread_messages(isolated_data_dir):
+    """acked_by appears on the envelope returned by a2a_thread_messages."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    msg_id = _send_message(isolated_data_dir, thread="acks")
+
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+
+    result = asyncio.run(service.a2a_thread_messages(thread="acks", data_dir=dd))
+    msgs = result["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["acked_by"] == ["agentB"]
+
+
+# ---------------------------------------------------------------------------
+# Gate (c): idempotent double-ack by the same principal
+# ---------------------------------------------------------------------------
+
+def test_a2a_ack_double_ack_is_idempotent(isolated_data_dir):
+    """A second ack by the same principal does not duplicate the entry."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    msg_id = _send_message(isolated_data_dir)
+
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+
+    msgs = asyncio.run(service.a2a_feed(thread="acks", data_dir=dd))
+    assert len(msgs) == 1
+    assert msgs[0]["acked_by"] == ["agentB"]
+    assert len(msgs[0]["acked_by"]) == 1
+
+
+def test_a2a_ack_distinct_principals_both_recorded(isolated_data_dir):
+    """Two distinct principals each get their own acked_by entry."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    msg_id = _send_message(isolated_data_dir)
+
+    asyncio.run(service.a2a_ack(msg_id, "agentB", data_dir=dd))
+    asyncio.run(service.a2a_ack(msg_id, "agentC", data_dir=dd))
+
+    msgs = asyncio.run(service.a2a_feed(thread="acks", data_dir=dd))
+    assert len(msgs) == 1
+    assert set(msgs[0]["acked_by"]) == {"agentB", "agentC"}
+    assert len(msgs[0]["acked_by"]) == 2


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A v2 slice 2b: acks as server state, not traffic (service layer only, spec section 3)

Autonomous build of board card tsk-ta4ftl.

a2a_ack(message_id, by, *, data_dir=None) records an acknowledgement as
server-side state on the message envelope -- an acked_by list persisted via
archive.update_event_data_json -- rather than as a new bus message. The
acked_by field is surfaced on the envelope by the existing a2a_feed and
a2a_thread_messages read paths (omitted when absent, no null noise).
Acks are idempotent per principal: a second ack by the same principal
leaves exactly one entry.

The composed "unhandled for X" query (mentions past X's cursor minus
acks) is deferred to slice 2c, which needs 2a's server-side cursor.

Proof (RED-first): tests/test_a2a_ack_state.py
  RED:  5 failed, exit 1 (AttributeError: module 'taosmd.service' has no attribute 'a2a_ack')
  GREEN: 5 passed, exit 0

Refs: tsk-ta4ftl, docs/specs/a2a-delivery-v2.md (section 3)

Files:
 changelog.d/tsk-ta4ftl-a2a-ack-state.md |   3 +
 taosmd/service.py                       |  43 ++++++++-
 tests/test_a2a_ack_state.py             | 162 ++++++++++++++++++++++++++++++++
 3 files changed, 207 insertions(+), 1 deletion(-)