### PR TITLE
A2A v2 slice 2a: consumer cursor state + inbox query (service layer only, spec section 2)

### DIFF
--- a/changelog.d/tsk-s5doj3-a2a-inbox-cursors.md
+++ b/changelog.d/tsk-s5doj3-a2a-inbox-cursors.md
@@ -1,0 +1,3 @@
+### Added
+
+- `taosmd.service.a2a_inbox` and `a2a_inbox_advance`: server-side consumer cursors and inbox query for the A2A bus, with persisted cursor state in the archive store and default exclusion of alarm, ack, receipt, and digest kinds.

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -142,6 +142,23 @@ class ArchiveStore:
         )
         self._conn.commit()
 
+    async def get_a2a_inbox_cursor(self, consumer: str) -> int:
+        """Return the last-seen message id for ``consumer``'s inbox, or 0."""
+        row = self._conn.execute(
+            "SELECT value FROM archive_settings WHERE key = ?",
+            (f"a2a_inbox_cursor_{consumer}",),
+        ).fetchone()
+        return int(row["value"]) if row else 0
+
+    async def set_a2a_inbox_cursor(self, consumer: str, cursor_id: int) -> None:
+        """Persist ``consumer``'s inbox cursor to ``cursor_id``."""
+        self._conn.execute(
+            """INSERT INTO archive_settings (key, value) VALUES (?, ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+            (f"a2a_inbox_cursor_{consumer}", str(cursor_id)),
+        )
+        self._conn.commit()
+
     # ------------------------------------------------------------------
     # Recording
     # ------------------------------------------------------------------

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -29,6 +29,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 import time
 
 from . import api as _api
@@ -1133,6 +1134,111 @@ async def can_read(reader: str, msg: dict, data_dir=None) -> bool:
     return True
 
 
+async def a2a_inbox(
+    consumer: str,
+    *,
+    limit: int = 50,
+    include_kinds: list | None = None,
+    data_dir=None,
+) -> list[dict]:
+    """Return messages past ``consumer``'s cursor that are addressed to it.
+
+    A message is addressed when at least one of:
+    - the consumer's handle is mentioned in the body
+    - the message is in a thread owned by the consumer (thread name == consumer)
+    - the message has a direct ``recipient`` matching the consumer
+
+    The consumer's own posts are always excluded.  By default kinds
+    ``alarm``, ``ack``, ``receipt``, and ``digest`` are excluded; pass
+    ``include_kinds`` to widen the set.  Results are oldest-first.  Reading
+    does NOT advance the cursor.
+    """
+    if not isinstance(consumer, str) or not consumer:
+        raise ValueError("consumer must be a non-empty string")
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    cursor = await archive.get_a2a_inbox_cursor(consumer)
+
+    rows = await archive.query(event_type=EVENT_A2A, limit=100_000)
+
+    excluded_kinds = {"alarm", "ack", "receipt", "digest"}
+    if include_kinds is not None:
+        excluded_kinds -= set(include_kinds)
+    allowed_kinds = _A2A_KINDS - excluded_kinds
+
+    norm_consumer = _normalise_handle(consumer)
+    mention_re = re.compile(r'(?<![\w/])@([a-zA-Z0-9_-]+)')
+
+    result = []
+    for row in rows:
+        if row["id"] <= cursor:
+            continue
+        try:
+            data = json.loads(row.get("data_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        sender = data.get("from") or ""
+        if sender == consumer:
+            continue
+        kind = data.get("kind") or "chat"
+        if kind not in allowed_kinds:
+            continue
+        body = data.get("body") or ""
+        thread = data.get("thread") or row.get("app_id") or "general"
+        recipient = data.get("recipient")
+        addressed = False
+        if recipient == consumer:
+            addressed = True
+        elif thread == consumer:
+            addressed = True
+        else:
+            for m in mention_re.finditer(body):
+                if _normalise_handle(m.group(1)) == norm_consumer:
+                    addressed = True
+                    break
+        if not addressed:
+            continue
+        msg = {
+            "id": row["id"],
+            "ts": row["timestamp"],
+            "from": sender,
+            "body": body,
+            "thread": thread,
+            "reply_to": data.get("reply_to"),
+            "kind": kind,
+        }
+        if "refs" in data:
+            msg["refs"] = data["refs"]
+        if "blocks" in data:
+            msg["blocks"] = data["blocks"]
+        result.append(msg)
+
+    result.sort(key=lambda m: (m["ts"], m["id"]))
+    limit_i = max(1, min(limit, 1000))
+    return result[:limit_i]
+
+
+async def a2a_inbox_advance(
+    consumer: str,
+    to_id: int,
+    *,
+    data_dir=None,
+) -> dict:
+    """Advance ``consumer``'s inbox cursor to ``to_id``.
+
+    The cursor is persisted in the archive store so it survives restarts
+    and is visible to every process sharing the same data dir.
+    """
+    if not isinstance(consumer, str) or not consumer:
+        raise ValueError("consumer must be a non-empty string")
+    if not isinstance(to_id, int) or to_id < 0:
+        raise ValueError("to_id must be a non-negative integer")
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    await archive.set_a2a_inbox_cursor(consumer, to_id)
+    return {"ok": True}
+
+
 async def a2a_record_delivered(
     message_id: int, agent_id: str, *, ts: float | None = None, data_dir=None
 ) -> dict:
@@ -1640,6 +1746,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "can_read",
+           "a2a_inbox", "a2a_inbox_advance",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_a2a_inbox_cursors.py
+++ b/tests/test_a2a_inbox_cursors.py
@@ -1,0 +1,172 @@
+"""Tests for a2a_inbox and a2a_inbox_advance (service layer).
+
+Gates:
+  (a) inbox excludes self-posts and alarm-kind by default
+  (b) fetch does not advance the cursor, advance does
+  (c) the cursor survives a fresh stores cache (persistence)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def inbox_data_dir(tmp_path, monkeypatch):
+    """Isolated data dir with a clean stores cache for each test."""
+    data_dir = tmp_path / "taosmd-inbox"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _seed_inbox_fixture(data_dir):
+    """Create 20 messages: 4 addressed to alice, rest not addressed or excluded."""
+    dd = str(data_dir)
+    consumer = "alice"
+
+    messages = [
+        # (sender, body, thread, recipient, kind)
+        ("bob", "hey @alice", "general", None, "chat"),           # 1: mention -> ADDRESSED
+        ("alice", "self post", "general", None, "chat"),          # 2: self-post -> EXCLUDED
+        ("bob", "in your thread", "alice", None, "chat"),         # 3: owned thread -> ADDRESSED
+        ("bob", "for alice", "general", "alice", "chat"),         # 4: direct recipient -> ADDRESSED
+        ("bob", "alarm!", "general", None, "alarm"),              # 5: alarm-kind -> EXCLUDED
+        ("bob", "ack this", "general", None, "ack"),              # 6: ack-kind -> EXCLUDED
+        ("bob", "receipt", "general", None, "receipt"),           # 7: receipt-kind -> EXCLUDED
+        ("bob", "digest", "general", None, "digest"),             # 8: digest-kind -> EXCLUDED
+        ("bob", "random chat", "general", None, "chat"),          # 9: not addressed
+        ("bob", "another chat", "general", None, "chat"),         # 10: not addressed
+        ("charlie", "hey @bob", "general", None, "chat"),         # 11: mentions bob, not alice
+        ("bob", "bob thread", "bob", None, "chat"),               # 12: bob's thread, not alice
+        ("bob", "to charlie", "general", "charlie", "chat"),      # 13: recipient is charlie
+        ("alice", "my thread", "alice", None, "chat"),            # 14: self-post on owned thread
+        ("bob", "system msg", "general", None, "system"),         # 15: not addressed
+        ("bob", "review", "general", None, "review"),             # 16: not addressed
+        ("charlie", "@alice hi", "general", None, "chat"),        # 17: mention -> ADDRESSED
+        ("bob", "plain", "general", None, "chat"),                # 18: not addressed
+        ("bob", "plain2", "general", None, "chat"),               # 19: not addressed
+        ("bob", "plain3", "general", None, "chat"),               # 20: not addressed
+    ]
+
+    ids = []
+    for sender, body, thread, recipient, kind in messages:
+        receipt = asyncio.run(service.a2a_send(
+            sender, body, thread=thread, recipient=recipient, kind=kind, data_dir=dd,
+        ))
+        ids.append(receipt["id"])
+    return ids, consumer
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): inbox excludes self-posts and alarm-kind
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_excludes_self_and_alarm_kind(inbox_data_dir):
+    """Exactly 4 of 20 messages are addressed to alice; self-posts and alarm
+    kinds are excluded by default."""
+    _setup_stores(inbox_data_dir)
+    dd = str(inbox_data_dir)
+    _seed_inbox_fixture(inbox_data_dir)
+
+    msgs = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+
+    assert len(msgs) == 4
+    bodies = {m["body"] for m in msgs}
+    assert "hey @alice" in bodies
+    assert "in your thread" in bodies
+    assert "for alice" in bodies
+    assert "@alice hi" in bodies
+
+    senders = {m["from"] for m in msgs}
+    assert "alice" not in senders
+
+    kinds = {m["kind"] for m in msgs}
+    assert "alarm" not in kinds
+    assert "ack" not in kinds
+    assert "receipt" not in kinds
+    assert "digest" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# Gate (b): fetch does not advance the cursor, advance does
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_fetch_does_not_advance_cursor(inbox_data_dir):
+    """Reading the inbox does not advance the cursor; a2a_inbox_advance does."""
+    _setup_stores(inbox_data_dir)
+    dd = str(inbox_data_dir)
+    _seed_inbox_fixture(inbox_data_dir)
+
+    first_read = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+    assert len(first_read) == 4
+
+    # Second read without advance must return the same messages
+    second_read = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+    assert len(second_read) == 4
+    assert [m["id"] for m in second_read] == [m["id"] for m in first_read]
+
+    # Advance cursor to the last seen id
+    last_id = first_read[-1]["id"]
+    asyncio.run(service.a2a_inbox_advance("alice", last_id, data_dir=dd))
+
+    # Subsequent read must be empty (cursor moved past all messages)
+    third_read = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+    assert len(third_read) == 0
+
+
+# ---------------------------------------------------------------------------
+# Gate (c): cursor survives a fresh stores cache (persistence)
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_cursor_survives_stores_cache_reset(inbox_data_dir):
+    """Cursor is persisted in the store, not module-global memory."""
+    _setup_stores(inbox_data_dir)
+    dd = str(inbox_data_dir)
+    _seed_inbox_fixture(inbox_data_dir)
+
+    first_read = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+    assert len(first_read) == 4
+
+    last_id = first_read[-1]["id"]
+    asyncio.run(service.a2a_inbox_advance("alice", last_id, data_dir=dd))
+
+    # Simulate a fresh process: clear the stores cache and re-initialise
+    taosmd_api._stores_cache.clear()
+    _setup_stores(inbox_data_dir)
+
+    # Cursor must still be at last_id, so inbox returns empty
+    fresh_read = asyncio.run(service.a2a_inbox("alice", limit=50, data_dir=dd))
+    assert len(fresh_read) == 0


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A v2 slice 2a: consumer cursor state + inbox query (service layer only, spec section 2)

Autonomous build of board card tsk-s5doj3.



Files:
 changelog.d/tsk-s5doj3-a2a-inbox-cursors.md |   3 +
 taosmd/archive.py                           |  17 +++
 taosmd/service.py                           | 107 +++++++++++++++++
 tests/test_a2a_inbox_cursors.py             | 172 ++++++++++++++++++++++++++++
 4 files changed, 299 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an A2A inbox for retrieving relevant messages addressed to a consumer.
  - Added persistent inbox cursors so consumers can resume from their last-read message.
  - Added controls for advancing cursors and optionally including additional message types.
  - Inbox results exclude the consumer’s own posts and system-generated messages by default.

- **Tests**
  - Added coverage for inbox filtering, cursor advancement, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->