### PR TITLE
registry auth: registry_url set without registry_token silently fails ALL sends closed - make the half-configuration loud

### DIFF
--- a/changelog.d/tsk-lx7uom-registry-auth-half-config.md
+++ b/changelog.d/tsk-lx7uom-registry-auth-half-config.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- When `registry_url` is configured but `registry_token` is not, `taosmd serve`
+  now emits a clear startup diagnostic naming both keys, and rejected
+  `/a2a/send` requests return an error that explicitly mentions the missing
+  `registry_token` instead of a bare revocation-feed failure. `taosmd config
+  show` also reports both keys and warns on the half-configuration.

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -246,10 +246,21 @@ def _config_show() -> int:
     token = config.get_server_token()
     admin_token = config.get_admin_token()
     model = config.get_memory_model()
+    registry_url = config.get_registry_url()
+    registry_token = config.get_registry_token()
     print(f"server_url   : {url or '(unset, local mode)'}")
     print(f"server_token : {'(set)' if token else '(unset)'}")
     print(f"admin_token  : {'(set)' if admin_token else '(unset, falls back to server_token)'}")
     print(f"memory_model : {model or '(default)'}")
+    print(f"registry_url : {registry_url or '(unset)'}")
+    print(f"registry_token : {'(set)' if registry_token else '(unset)'}")
+    if registry_url is not None and registry_token is None:
+        print(
+            "WARNING: registry_url is set but registry_token is unset; "
+            "sends will be rejected. Set it with "
+            "`taosmd config set-registry-token ...` or clear registry_url.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -487,16 +487,18 @@ If neither token is set, the admin surface fails closed (403).
 `POST /a2a/send` can verify sender identity against a taOS registry. Three
 config keys control it (`taosmd/config.py`): `registry_url` (the registry base
 URL; without it the verifier is dormant and every message is accepted as
-before), `registry_token` (the token used to poll the auth-gated revoked
-feed), and `a2a_auth_enforce` (mode flip). The mode can also be set with the
-`TAOSMD_A2A_AUTH_ENFORCE` environment variable (`1`, `true`, or `yes` enable
-enforce; the env var wins over the config key). Default is verify-and-warn:
-an auth failure is logged as a warning and the message is still accepted, so
-a deployment can observe violations before flipping enforcement. In enforce
-mode a missing token returns `401` and a bad token or missing grant returns
-`403`, and the message is dropped. Independent of registry auth, when the
-server has `server_token` configured every `/a2a/*` endpoint requires a
-matching `Authorization: Bearer <token>` header.
+before) and `registry_token` (the token used to poll the auth-gated revoked
+feed) are a pair -- set `registry_url` without `registry_token` and sends will
+fail at runtime because the revocation feed cannot be fetched. The third key,
+`a2a_auth_enforce`, flips between verify-and-warn and enforce mode. The mode
+can also be set with the `TAOSMD_A2A_AUTH_ENFORCE` environment variable (`1`,
+`true`, or `yes` enable enforce; the env var wins over the config key). Default
+is verify-and-warn: an auth failure is logged as a warning and the message is
+still accepted, so a deployment can observe violations before flipping
+enforcement. In enforce mode a missing token returns `401` and a bad token or
+missing grant returns `403`, and the message is dropped. Independent of registry
+auth, when the server has `server_token` configured every `/a2a/*` endpoint
+requires a matching `Authorization: Bearer <token>` header.
 
 Each message in `/a2a/messages` and the SSE stream has shape:
 `{"id", "ts", "from", "body", "thread", "reply_to"}`

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -188,6 +188,7 @@ import json
 import logging
 import math
 import mimetypes
+import sys
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -1659,11 +1660,22 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     except registry_auth.AuthError as exc:
                         # Class 2: presented-credential failure. Always reject,
                         # even in warn mode -- see the comment block above.
+                        _registry_url_cfg = _config.get_registry_url(data_dir)
+                        _registry_token_cfg = _config.get_registry_token(data_dir)
+                        if _registry_url_cfg is not None and _registry_token_cfg is None:
+                            msg = (
+                                "registry auth: registry_token is unset "
+                                "(registry_url is set without registry_token; "
+                                "set it with `taosmd config set-registry-token ...` "
+                                "or clear registry_url)"
+                            )
+                        else:
+                            msg = f"registry auth: {exc}"
                         logger.warning(
                             "a2a auth: rejecting presented-credential failure "
-                            "from %r (regardless of enforce mode): %s", from_, exc,
+                            "from %r (regardless of enforce mode): %s", from_, msg,
                         )
-                        self._send_json(403, {"error": f"registry auth: {exc}"})
+                        self._send_json(403, {"error": msg})
                         return
 
                 # Grant check: token proves identity; grant proves permission.
@@ -2501,12 +2513,20 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     bound_host, bound_port = httpd.server_address[:2]
     _enforce = _config.get_a2a_auth_enforce(data_dir)
     _registry_url = _config.get_registry_url(data_dir)
+    _registry_token = _config.get_registry_token(data_dir)
     if _registry_url is None:
         mode = "OFF (no registry_url: senders are self-claimed)"
     elif _enforce:
         mode = "ENFORCE"
     else:
         mode = "WARN (verify-and-warn)"
+    if _registry_url is not None and _registry_token is None:
+        print(
+            "WARNING: registry_url is set but registry_token is unset; "
+            "sends will be rejected. Set it with "
+            "`taosmd config set-registry-token ...` or clear registry_url.",
+            file=sys.stderr,
+        )
     where = "localhost only" if bound_host in {"127.0.0.1", "::1"} else "LAN-reachable (no auth)"
     if _registry_url is not None and _enforce:
         where = where.replace(" (no auth)", "")

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -792,6 +792,22 @@ def test_banner_lan_enforce_strips_no_auth(tmp_path):
     assert "(no auth)" not in listening
 
 
+def test_banner_half_config_warns_about_missing_registry_token(tmp_path):
+    """registry_url set without registry_token -> startup diagnostic names both keys."""
+    lines = _serve_banner("127.0.0.1", tmp_path, {
+        "TAOSMD_REGISTRY_URL": "http://reg.test",
+    })
+    _require_provenance(lines)
+    half_config_lines = [
+        l for l in lines
+        if "registry_token" in l.lower() and "registry_url" in l.lower()
+    ]
+    assert half_config_lines, (
+        "expected half-config diagnostic naming registry_url and registry_token, "
+        f"got banner lines: {lines}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Task graph HTTP tests
 # ---------------------------------------------------------------------------

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -200,6 +200,45 @@ def test_server_builds_verifier_with_token_and_pinned_issuer(tmp_path, monkeypat
         httpd.server_close()
 
 
+def test_half_config_send_error_mentions_registry_token(tmp_path, monkeypatch):
+    """registry_url set without registry_token -> send error names registry_token."""
+    from taosmd import config
+
+    data_dir = tmp_path / "half-cfg"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    config.set_registry_url("http://reg.test", data_dir=str(data_dir))
+    # registry_token intentionally unset
+
+    class HalfConfigVerifier:
+        def authorize(self, token, claimed_from):
+            raise registry_auth.AuthError("revocation feed unavailable")
+        def is_human(self, canonical_id):
+            return False
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir),
+                                    verifier=HalfConfigVerifier())
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://{host}:{port}"
+        token = pyjwt.encode({"sub": "agent-1"}, PRIV_PEM, algorithm="EdDSA")
+        status, body = _post_send(base, "agent-1", "hello", token=token)
+        assert status == 403
+        error_msg = body.get("error", "")
+        assert "registry_token" in error_msg.lower(), (
+            f"expected error to mention registry_token, got: {error_msg}"
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
 # ---------------------------------------------------------------------------
 # Project-scoped grant binding (taOS#744)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): registry auth: registry_url set without registry_token silently fails ALL sends closed - make the half-configuration loud

Autonomous build of board card tsk-lx7uom.

When registry_url is set without registry_token, taosmd serve now emits a
startup diagnostic naming both keys, and the send-path AuthError mentions
registry_token instead of a bare revocation-feed failure. taosmd config
show also reports both keys and warns on the half-configuration. Docs state
the two keys are a pair.

Proof: 1688 passed, 12 skipped (baseline was 1686 passed, 12 skipped;
2 new tests added).

Files:
 .../tsk-lx7uom-registry-auth-half-config.md        |  7 ++++
 taosmd/cli.py                                      | 11 ++++++
 taosmd/docs/a2a-comms.md                           | 22 ++++++------
 taosmd/http_server.py                              | 24 +++++++++++--
 tests/test_http_server.py                          | 16 +++++++++
 tests/test_http_server_registry_auth.py            | 39 ++++++++++++++++++++++
 6 files changed, 107 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when registry authentication is only partially configured.
  * Server startup now warns when a registry URL is set without a registry token.
  * A2A requests return a clear configuration error instead of a generic authentication failure.

* **New Features**
  * `config show` now displays the registry URL and registry-token status.

* **Documentation**
  * Clarified that registry URLs and tokens must be configured together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->