### PR TITLE
deploy path omits the [registry] extra: pyjwt/cryptography unimportable for the service user when registry auth is configured

### DIFF
--- a/changelog.d/tsk-ds6ci6-registry-extra-import-guard.md
+++ b/changelog.d/tsk-ds6ci6-registry-extra-import-guard.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- When `registry_url` is configured but the optional `pyjwt` and `cryptography`
+  packages are missing, the server now fails loudly at startup with an actionable
+  error naming `taosmd[registry]`, instead of starting silently and degrading on
+  the first auth-gated request.
+- The deploy scripts (`scripts/setup.sh` and `scripts/install-server.sh`) now
+  install `taosmd[registry]` so fleet service installs include the crypto extra
+  required for registry auth.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -32,7 +32,7 @@ echo "  Host: $HOST   Port: $PORT"
 # --- Step 1: install taosmd --------------------------------------------------
 echo ""
 echo "Step 1: Installing taosmd..."
-pip install --quiet --upgrade taosmd
+pip install --quiet --upgrade "taosmd[registry]"
 echo "  taosmd $(taosmd --version 2>/dev/null || python -c "import taosmd; print(taosmd.__version__)") installed."
 
 # --- Step 2: install and start the background service -----------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,9 +44,9 @@ else
     cd "$INSTALL_DIR"
 fi
 
-# Install Python dependencies
+# Install Python dependencies (core + registry auth extra for fleet installs)
 echo "→ Installing dependencies..."
-pip install -e . --quiet 2>/dev/null || pip3 install -e . --quiet
+pip install -e ".[registry]" --quiet 2>/dev/null || pip3 install -e ".[registry]" --quiet
 
 # Install ONNX Runtime (for fast embeddings)
 pip install onnxruntime numpy --quiet 2>/dev/null || pip3 install onnxruntime numpy --quiet

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -30,6 +30,12 @@ If neither succeeds, install it from PyPI:
 pip install taosmd
 ```
 
+If you plan to use registry auth (set `registry_url`), install the extra instead:
+
+```
+pip install "taosmd[registry]"
+```
+
 or, for the latest unreleased changes, from GitHub:
 
 ```
@@ -494,7 +500,12 @@ enforce; the env var wins over the config key). Default is verify-and-warn:
 an auth failure is logged as a warning and the message is still accepted, so
 a deployment can observe violations before flipping enforcement. In enforce
 mode a missing token returns `401` and a bad token or missing grant returns
-`403`, and the message is dropped. Independent of registry auth, when the
+`403`, and the message is dropped.
+
+Registry auth requires the `pyjwt` and `cryptography` packages, which are not
+installed by default. If you set `registry_url`, install the `[registry]` extra:
+`pip install "taosmd[registry]"`. The server will fail loudly at startup if the
+extra is missing. Independent of registry auth, when the
 server has `server_token` configured every `/a2a/*` endpoint requires a
 matching `Authorization: Bearer <token>` header.
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -693,6 +693,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         _registry_url = _config.get_registry_url(data_dir)
         if _registry_url:
             from . import registry_auth  # noqa: PLC0415 - optional path
+            registry_auth._require_jwt()
             # The revoked and grants feeds are admin-gated (#710/#719): send the
             # configured taOS local token on them; pin the issuer.
             _registry_admin_token = _config.get_registry_token(data_dir)

--- a/tests/test_http_server_registry_import_guard.py
+++ b/tests/test_http_server_registry_import_guard.py
@@ -1,0 +1,29 @@
+"""Startup import guard for registry auth deps.
+
+When ``registry_url`` is configured but the optional crypto stack
+(``pyjwt`` + ``cryptography``) is missing, the server must fail at startup
+with an actionable error naming ``taosmd[registry]`` -- not start silently
+and blow up on the first auth-gated request.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from taosmd import config, http_server
+
+
+@pytest.fixture
+def data_dir_with_registry(tmp_path, monkeypatch):
+    monkeypatch.delenv("TAOSMD_REGISTRY_URL", raising=False)
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    config.set_registry_url("http://reg.test", data_dir=str(data_dir))
+    return str(data_dir)
+
+
+def test_missing_jwt_fails_at_startup(data_dir_with_registry, monkeypatch):
+    monkeypatch.setitem(sys.modules, "jwt", None)
+    with pytest.raises(Exception, match=r"taosmd\[registry\]"):
+        http_server.make_server("127.0.0.1", 0, data_dir=data_dir_with_registry)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deploy path omits the [registry] extra: pyjwt/cryptography unimportable for the service user when registry auth is configured

Autonomous build of board card tsk-ds6ci6.

The deploy path (setup.sh and install-server.sh) now installs taosmd[registry]
so fleet service installs include the pyjwt and cryptography packages required
for registry auth. When registry_url is configured but the optional crypto
stack is absent, _make_handler now calls registry_auth._require_jwt() at
startup and raises AuthError with an actionable message naming
taosmd[registry], instead of starting silently and failing on the first
auth-gated request.

Red test (test_http_server_registry_import_guard.py) proved the unpatched
tree did not raise at startup when jwt was missing. After the fix, the test
passes. Full suite: 1687 passed, 12 skipped.

Files:
 .../tsk-ds6ci6-registry-extra-import-guard.md      |  9 +++++++
 scripts/install-server.sh                          |  2 +-
 scripts/setup.sh                                   |  4 +--
 taosmd/docs/a2a-comms.md                           | 13 +++++++++-
 taosmd/http_server.py                              |  1 +
 tests/test_http_server_registry_import_guard.py    | 29 ++++++++++++++++++++++
 6 files changed, 54 insertions(+), 4 deletions(-)