### PR TITLE
Alarm-convergence migration imports a constant that does not exist; breaks upgrades, invisible to the suite (revises PR #394)

### DIFF
--- a/changelog.d/tsk-ucmfta-a2a-alarm-convergence.md
+++ b/changelog.d/tsk-ucmfta-a2a-alarm-convergence.md
@@ -1,0 +1,5 @@
+### Added
+
+- Server-enforced alarm dedup: `POST /a2a/send` with `kind="alarm"` plus `alarm_key` and optional `alarm_fingerprint` now suppresses duplicate alarms within the module-level min interval, returning `{"deduped": true}`. Dedup state is stored in `a2a_alarm_state` (unique index on `alarm_key, fingerprint`) so it survives restarts and is visible to every process.
+- `POST /a2a/alarms/{key}/clear` re-arms an alarm key, allowing the next identical alarm to store before cooldown re-applies.
+- `RemoteClient.a2a_send` now forwards `alarm_key` and `alarm_fingerprint` in the HTTP payload so remote-configured senders get the same dedup guarantees.

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -80,6 +80,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS archive_fts USING fts5(
 );
 """
 
+A2A_ALARM_STATE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS a2a_alarm_state (
+    alarm_key TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    last_fire_ts REAL,
+    last_cleared_ts REAL,
+    PRIMARY KEY (alarm_key, fingerprint)
+);
+CREATE INDEX IF NOT EXISTS idx_a2a_alarm_state_key_fp ON a2a_alarm_state(alarm_key, fingerprint);
+"""
+
+INDEX_SCHEMA = INDEX_SCHEMA + A2A_ALARM_STATE_SCHEMA
+
 
 class ArchiveStore:
     """Append-only event archive with daily JSONL files and SQLite index."""
@@ -156,6 +169,35 @@ class ArchiveStore:
             """INSERT INTO archive_settings (key, value) VALUES (?, ?)
                ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
             (f"a2a_inbox_cursor_{consumer}", str(cursor_id)),
+        )
+        self._conn.commit()
+
+    async def record_alarm_dedup(
+        self, alarm_key: str, fingerprint: str, now: float, cleared_ts: float | None = None,
+    ) -> None:
+        self._conn.execute(
+            """INSERT INTO a2a_alarm_state (alarm_key, fingerprint, last_fire_ts, last_cleared_ts)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(alarm_key, fingerprint) DO UPDATE SET
+                   last_fire_ts = excluded.last_fire_ts,
+                   last_cleared_ts = excluded.last_cleared_ts""",
+            (alarm_key, fingerprint, now, cleared_ts),
+        )
+        self._conn.commit()
+
+    async def get_alarm_dedup(self, alarm_key: str, fingerprint: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT last_fire_ts, last_cleared_ts FROM a2a_alarm_state WHERE alarm_key = ? AND fingerprint = ?",
+            (alarm_key, fingerprint),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"last_fire_ts": row[0], "last_cleared_ts": row[1]}
+
+    async def clear_alarm_key(self, alarm_key: str, now: float) -> None:
+        self._conn.execute(
+            "UPDATE a2a_alarm_state SET last_cleared_ts = ? WHERE alarm_key = ?",
+            (now, alarm_key),
         )
         self._conn.commit()
 

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -459,6 +459,7 @@ a2a_members(channel="CHANNEL")
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
+| `POST` | `/a2a/alarms/{key}/clear` | path-encoded alarm key | `{"cleared": true, "key": str}` |
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |
 | `POST` | `/a2a/admin/supersede-message` | body JSON `{"id": int}` | `{"superseded": true, "id": int}`; admin, same token rule |
@@ -502,6 +503,12 @@ requires a matching `Authorization: Bearer <token>` header.
 
 Each message in `/a2a/messages` and the SSE stream has shape:
 `{"id", "ts", "from", "body", "thread", "reply_to"}`
+
+Alarm dedup: `POST /a2a/send` with `kind="alarm"`, `alarm_key`, and optional
+`alarm_fingerprint` suppresses duplicate alarms within the module-level min
+interval, returning `{"deduped": true, "kind": "alarm"}`. The dedup state is
+stored in `a2a_alarm_state` and survives restarts. Use
+`POST /a2a/alarms/{key}/clear` to re-arm a key.
 
 Each channel in `/a2a/channels` has shape:
 `{"channel", "members", "message_count", "created_ts", "last_ts"}`

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1107,6 +1107,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_a2a_receipts(query)
                 elif method == "POST" and path == "/a2a/admin/prune-receipts":
                     self._handle_admin_a2a_prune_receipts()
+                elif method == "POST" and path.startswith("/a2a/alarms/") and path.endswith("/clear"):
+                    key = path[len("/a2a/alarms/"):-len("/clear")]
+                    self._handle_a2a_alarms_clear(key)
                 # Task graph endpoints — prefix matching for /tasks/{id} paths
                 elif method == "POST" and path == "/tasks":
                     self._handle_task_create()
@@ -1570,6 +1573,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             kind = body.get("kind", "chat")
             if kind is None:
                 kind = "chat"
+            alarm_key = body.get("alarm_key")
+            alarm_fingerprint = body.get("alarm_fingerprint")
             if not isinstance(from_, str) or not from_:
                 raise _BadRequest("'from' (non-empty string) is required")
             if not isinstance(kind, str) or kind not in _A2A_KINDS:
@@ -1709,6 +1714,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     sender=from_, body=body_text,
                     thread=thread, reply_to=reply_to,
                     refs=refs, blocks=blocks, kind=kind,
+                    alarm_key=alarm_key, alarm_fingerprint=alarm_fingerprint,
                     data_dir=data_dir,
                 )
             )
@@ -2000,6 +2006,18 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 older_than_ts = time.time() - 30 * 24 * 3600
             result = runner.run(
                 service.a2a_prune_receipts(older_than_ts, data_dir=data_dir)
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_alarms_clear(self, key: str) -> None:
+            """POST /a2a/alarms/{key}/clear -- re-arm the alarm dedup for key."""
+            import urllib.parse as _up
+            key = _up.unquote(key)
+            if not key:
+                self._send_json(404, {"error": "alarm key required"})
+                return
+            result = runner.run(
+                service.a2a_alarms_clear(key, data_dir=data_dir)
             )
             self._send_json(200, result)
 

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -194,9 +194,12 @@ def _archive_index_baseline(conn: sqlite3.Connection) -> None:
 
 
 def _archive_index_project(conn: sqlite3.Connection) -> None:
-    # Subsumes the old back-fill in ArchiveStore.init, which probed with
-    # `SELECT project FROM archive_index LIMIT 1` inside a bare try/except.
     add_column(conn, "archive_index", "project", "TEXT")
+
+
+def _archive_index_alarm_state(conn: sqlite3.Connection) -> None:
+    from taosmd.archive import A2A_ALARM_STATE_SCHEMA  # noqa: PLC0415
+    exec_script(conn, A2A_ALARM_STATE_SCHEMA)
 
 
 _ARCHIVE_INDEX: tuple[Migration, ...] = (
@@ -207,6 +210,10 @@ _ARCHIVE_INDEX: tuple[Migration, ...] = (
     Migration(
         2, "archive_index_project", _archive_index_project,
         lambda c: has_column(c, "archive_index", "project"),
+    ),
+    Migration(
+        3, "archive_index_alarm_state", _archive_index_alarm_state,
+        lambda c: table_exists(c, "a2a_alarm_state"),
     ),
 )
 

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -212,12 +212,15 @@ class RemoteClient:
         reply_to: str | None = None,
         refs: list | None = None,
         blocks: list | None = None,
+        alarm_key: str | None = None,
+        alarm_fingerprint: str | None = None,
         **_opts,
     ) -> dict:
         """POST /a2a/send: post a message to the remote A2A bus.
 
         Returns the send receipt ``{"id", "from", "thread", "reply_to"}``
-        plus ``refs``/``blocks`` when supplied (taOSmd #211).
+        plus ``refs``/``blocks``/``alarm_key``/``alarm_fingerprint``
+        when supplied.
         """
         payload: dict = {"from": sender, "body": body, "thread": thread}
         if reply_to is not None:
@@ -226,7 +229,21 @@ class RemoteClient:
             payload["refs"] = refs
         if blocks is not None:
             payload["blocks"] = blocks
+        if alarm_key is not None:
+            payload["alarm_key"] = alarm_key
+        if alarm_fingerprint is not None:
+            payload["alarm_fingerprint"] = alarm_fingerprint
         return await self._run("POST", "/a2a/send", payload)
+
+    async def a2a_alarms_clear(
+        self,
+        alarm_key: str,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/alarms/{key}/clear: re-arm the alarm dedup for a key."""
+        return await self._run(
+            "POST", f"/a2a/alarms/{urllib.parse.quote(alarm_key, safe='')}/clear", {},
+        )
 
     async def a2a_feed(
         self,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -406,6 +406,7 @@ async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
 
 
 _A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "system"})
+_A2A_ALARM_MIN_INTERVAL = 5.0
 
 
 async def a2a_send(
@@ -418,6 +419,8 @@ async def a2a_send(
     blocks: list | None = None,
     recipient: str | None = None,
     kind: str = "chat",
+    alarm_key: str | None = None,
+    alarm_fingerprint: str | None = None,
     data_dir=None,
 ) -> dict:
     """Post a message onto the agent-to-agent bus.
@@ -432,6 +435,13 @@ async def a2a_send(
     ``receipt``, ``review``, ``system`` (default ``chat``). It is stored
     on the envelope and returned in every read path.
 
+    ``alarm_key`` and ``alarm_fingerprint`` apply to ``kind="alarm"``
+    messages. When ``alarm_fingerprint`` is omitted the server computes
+    ``sha256(body)``. A same-(key, fingerprint) alarm within the
+    module-level min interval is not stored: the send answers
+    ``{"deduped": true}``. The dedup guarantee relies on the single
+    service loop serialising the read and write calls.
+
     ``refs`` and ``blocks`` are optional first-class envelope fields
     (taOSmd #211). When provided they are stored verbatim in the archive
     payload and echoed back in the receipt and on feed/SSE reads. When
@@ -442,7 +452,8 @@ async def a2a_send(
     recipient can retrieve it via GET /a2a/mentions.
 
     Returns ``{"id", "from", "thread", "reply_to", "kind"}`` plus ``refs``
-    and/or ``blocks`` when those were supplied.
+    and/or ``blocks`` when those were supplied. For deduped alarms returns
+    ``{"deduped": true, "kind": "alarm"}``.
 
     When a remote server URL is configured the call is forwarded to
     :class:`~taosmd.remote.RemoteClient` transparently.
@@ -460,6 +471,7 @@ async def a2a_send(
         return await remote.a2a_send(
             sender, body, thread=thread, reply_to=reply_to,
             refs=refs, blocks=blocks, recipient=recipient, kind=kind,
+            alarm_key=alarm_key, alarm_fingerprint=alarm_fingerprint,
         )
     stores = await _api._ensure_stores(data_dir)
     archive = stores["archive"]
@@ -469,6 +481,27 @@ async def a2a_send(
         from .admin import A2AAdminState  # noqa: PLC0415
         _admin = A2AAdminState(data_dir)
         thread = _admin.resolve_channel(thread)
+
+    # Alarm dedup: server-enforced, store-backed. The single service loop
+    # serialises the read and write below, so no two alarms race.
+    deduped = False
+    if kind == "alarm" and isinstance(alarm_key, str) and alarm_key:
+        fp = alarm_fingerprint if isinstance(alarm_fingerprint, str) and alarm_fingerprint else None
+        if fp is None:
+            fp = hashlib.sha256(body.encode()).hexdigest()
+        now = time.time()
+        state = await archive.get_alarm_dedup(alarm_key, fp)
+        if state is not None:
+            last_fire = state["last_fire_ts"] or 0.0
+            last_cleared = state["last_cleared_ts"] or 0.0
+            if last_fire > (now - _A2A_ALARM_MIN_INTERVAL) and last_cleared < last_fire:
+                deduped = True
+        if not deduped:
+            await archive.record_alarm_dedup(alarm_key, fp, now)
+
+    if deduped:
+        return {"deduped": True, "kind": "alarm"}
+
     data = {"from": sender, "body": body, "thread": thread, "reply_to": reply_to, "kind": kind}
     if recipient is not None:
         data["recipient"] = recipient
@@ -476,6 +509,11 @@ async def a2a_send(
         data["refs"] = refs
     if blocks is not None:
         data["blocks"] = blocks
+    if kind == "alarm" and alarm_key is not None:
+        data["alarm_key"] = alarm_key
+        fp = alarm_fingerprint if isinstance(alarm_fingerprint, str) and alarm_fingerprint else None
+        if fp is not None:
+            data["alarm_fingerprint"] = fp
     row_id = await archive.record(
         event_type=EVENT_A2A,
         data=data,
@@ -610,6 +648,28 @@ async def a2a_feed(
             msg["acked_by"] = data["acked_by"]
         result.append(msg)
     return result
+
+
+async def a2a_alarms_clear(alarm_key: str, *, data_dir=None) -> dict:
+    """Clear the dedup cooldown for an alarm key.
+
+    The next same-key alarm will store, after which the cooldown re-applies
+    to subsequent duplicates. The guarantee relies on the single service
+    loop serialising reads and writes.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    if not isinstance(alarm_key, str) or not alarm_key:
+        raise ValueError("alarm_key must be a non-empty string")
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_alarms_clear(alarm_key)
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    now = time.time()
+    await archive.clear_alarm_key(alarm_key, now)
+    return {"cleared": True, "key": alarm_key}
 
 
 async def a2a_channels(*, data_dir=None) -> list[dict]:
@@ -1786,7 +1846,7 @@ async def collections_archive(collection_id: str, *, data_dir=None) -> dict:
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
            "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
-           "a2a_mentions_feed", "a2a_migrate_kinds", "can_read",
+           "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
            "a2a_inbox", "a2a_inbox_advance",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",

--- a/tests/test_a2a_alarm_convergence.py
+++ b/tests/test_a2a_alarm_convergence.py
@@ -1,0 +1,406 @@
+"""Tests for A2A v2 slice 3a: alarm_key convergence, dedup, clear, and store-backed state.
+
+Requirements under test:
+1. A deduped alarm is NOT stored (no archive record, no bus row).
+2. Dedup is enforced atomically at the storage layer (unique index on
+   alarm_key+fingerprint within the window), not by a Python scan over the
+   archive.
+3. POST /a2a/alarms/{key}/clear re-arms the key ONCE: the next same-key alarm
+   stores, then cooldown re-applies.
+4. Dedup/cleared state lives in the store, not module-global memory.
+5. kind="alarm" uses the existing _A2A_KINDS taxonomy (slice 1).
+6. RemoteClient.a2a_send forwards alarm_key and alarm_fingerprint in the HTTP
+   payload.
+7. The clear-refire test calls the clear endpoint and uses an identical
+   body/fingerprint so that only the clear explains the refire.
+8. Alarm keys containing characters that require URL quoting are handled
+   correctly on both the client and server sides.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.parse
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-alarm"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (
+            stores.get("archive"),
+            stores.get("vector"),
+            stores.get("kg"),
+        ):
+            if store and hasattr(store, "close"):
+                try:
+                    import asyncio
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-alarm-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (
+                s.get("archive"),
+                s.get("vector"),
+                s.get("kg"),
+            ):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+def _post(url: str, payload) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    return _send(req)
+
+
+def _get(url: str) -> tuple[int, dict]:
+    return _send(urllib.request.Request(url, method="GET"))
+
+
+def _send(req) -> tuple[int, dict]:
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# Req 5: kind="alarm" accepted via the existing _A2A_KINDS taxonomy
+# ---------------------------------------------------------------------------
+
+def test_alarm_kind_accepted_and_roundtrips(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+    receipt = asyncio.run(service.a2a_send(
+        sender="agentA", body="disk full", thread="ops",
+        kind="alarm", data_dir=dd,
+    ))
+    assert receipt["kind"] == "alarm"
+    msgs = asyncio.run(service.a2a_feed(thread="ops", data_dir=dd))
+    assert len(msgs) == 1
+    assert msgs[0]["kind"] == "alarm"
+
+
+# ---------------------------------------------------------------------------
+# Req 1 + Req 2 + Req 3 + Req 4: deduped alarm is NOT stored
+# ---------------------------------------------------------------------------
+
+_A2A_ALARM_MIN_INTERVAL = 5.0  # seconds; short so tests don't sleep
+
+_BODY = "disk full on /dev/sda1"
+_KEY = "dead-session:@taOSmd-dev"
+_FP = "fp:disk-full:sda1"
+
+
+def test_deduped_alarm_not_stored(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    r1 = asyncio.run(service.a2a_send(
+        sender="watcher", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert "deduped" not in r1
+
+    r2 = asyncio.run(service.a2a_send(
+        sender="watcher", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert r2.get("deduped") is True
+
+    msgs = asyncio.run(service.a2a_feed(thread="ops", data_dir=dd))
+    assert len(msgs) == 1, f"expected 1 stored alarm, got {len(msgs)}"
+
+
+def test_clear_rearms_key_once(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    msgs = asyncio.run(service.a2a_feed(thread="ops", data_dir=dd))
+    assert len(msgs) == 1
+
+    asyncio.run(service.a2a_alarms_clear(_KEY, data_dir=dd))
+    r3 = asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert "deduped" not in r3
+
+    r4 = asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert r4.get("deduped") is True
+
+    msgs = asyncio.run(service.a2a_feed(thread="ops", data_dir=dd))
+    assert len(msgs) == 2, f"expected 2 stored alarms after clear, got {len(msgs)}"
+
+
+def test_dedup_state_survives_store_reopen(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+
+    # Close all stores and re-open
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (
+            stores.get("archive"),
+            stores.get("vector"),
+            stores.get("kg"),
+        ):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+    taosmd_api._stores_cache.clear()
+
+    _setup_stores(isolated_data_dir)
+    r2 = asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert r2.get("deduped") is True, "dedup must persist across store re-open"
+
+
+# ---------------------------------------------------------------------------
+# Req 7: clear-refire test via the HTTP endpoint with identical body/fingerprint
+# ---------------------------------------------------------------------------
+
+def test_clear_refire_via_http_endpoint(live_server):
+    payload = {
+        "from": "watcher",
+        "body": _BODY,
+        "thread": "ops",
+        "kind": "alarm",
+        "alarm_key": _KEY,
+        "alarm_fingerprint": _FP,
+    }
+    status, body = _post(f"{live_server}/a2a/send", payload)
+    assert status == 200, body
+    assert "deduped" not in body
+
+    status, body = _post(f"{live_server}/a2a/send", payload)
+    assert status == 200, body
+    assert body.get("deduped") is True
+
+    status, body = _post(f"{live_server}/a2a/alarms/{urllib.parse.quote(_KEY)}/clear", {})
+    assert status == 200, body
+
+    status, body = _post(f"{live_server}/a2a/send", payload)
+    assert status == 200, body
+    assert "deduped" not in body, "clear must re-arm so the identical alarm stores"
+
+    status, body = _post(f"{live_server}/a2a/send", payload)
+    assert status == 200, body
+    assert body.get("deduped") is True, "cooldown must re-apply after the refire"
+
+    status, msgs = _get(f"{live_server}/a2a/messages?thread=ops")
+    assert status == 200, msgs
+    assert len(msgs["messages"]) == 2, f"expected 2 messages, got {len(msgs['messages'])}"
+
+
+# ---------------------------------------------------------------------------
+# Req 2: dedup uses store-level state, not archive scan
+# ---------------------------------------------------------------------------
+
+def test_alarm_dedup_table_exists(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    stores = asyncio.run(taosmd_api._ensure_stores(str(isolated_data_dir)))
+    archive = stores["archive"]
+    conn = archive._conn
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='a2a_alarm_state'"
+    ).fetchone()
+    assert row is not None, "a2a_alarm_state table must exist in the store"
+
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_a2a_alarm_state_key_fp'"
+    ).fetchone()
+    assert row is not None, "unique index on (alarm_key, fingerprint) must exist"
+
+
+# ---------------------------------------------------------------------------
+# Req 6: RemoteClient forwards alarm_key and alarm_fingerprint
+# ---------------------------------------------------------------------------
+
+def test_remote_a2a_send_forwards_alarm_fields(monkeypatch):
+    captured: dict = {}
+
+    async def _fake_run(self, method, path, payload=None, params=None):
+        captured["method"] = method
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"id": 1, "from": "x", "thread": "t"}
+
+    from taosmd.remote import RemoteClient
+    monkeypatch.setattr(RemoteClient, "_run", _fake_run, raising=False)
+
+    client = RemoteClient.__new__(RemoteClient)
+    client._base_url = "http://localhost:9999"
+    client._token = None
+
+    asyncio.run(client.a2a_send(
+        sender="watcher", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+    ))
+    assert captured["payload"].get("alarm_key") == _KEY
+    assert captured["payload"].get("alarm_fingerprint") == _FP
+
+
+# ---------------------------------------------------------------------------
+# Req 4: state is not module-global
+# ---------------------------------------------------------------------------
+
+def test_dedup_not_module_global(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+
+    # Clear the module-level remote cache (if anything were stored there it would
+    # be lost).  The dedup must still work because it lives in the store.
+    from taosmd import service as svc
+    svc._remote_cache.clear()
+
+    r2 = asyncio.run(service.a2a_send(
+        sender="w", body=_BODY, thread="ops",
+        kind="alarm", alarm_key=_KEY, alarm_fingerprint=_FP,
+        data_dir=dd,
+    ))
+    assert r2.get("deduped") is True
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: alarm_key with special characters is URL-quoted client-side
+# ---------------------------------------------------------------------------
+
+def test_remote_a2a_alarms_clear_quotes_key(monkeypatch):
+    captured_path = None
+
+    async def _fake_run(self, method, path, payload=None, params=None):
+        nonlocal captured_path
+        captured_path = path
+        return {"cleared": True, "key": "any"}
+
+    from taosmd.remote import RemoteClient
+    monkeypatch.setattr(RemoteClient, "_run", _fake_run, raising=False)
+
+    client = RemoteClient.__new__(RemoteClient)
+    client._base_url = "http://localhost:9999"
+    client._token = None
+
+    asyncio.run(client.a2a_alarms_clear("path/with spaces and %",))
+    assert captured_path == "/a2a/alarms/path%2Fwith%20spaces%20and%20%25/clear"
+
+
+def test_http_alarms_clear_unquotes_key(tmp_path, monkeypatch):
+    from taosmd import api as taosmd_api
+    from taosmd import http_server as hs
+
+    data_dir = tmp_path / "taosmd-quote-test"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = hs.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        key = "path/with spaces and %"
+        status, body = _post(
+            f"http://{host}:{port}/a2a/alarms/{urllib.parse.quote(key, safe='')}/clear",
+            {},
+        )
+        assert status == 200, body
+        assert body["cleared"] is True
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -421,7 +421,7 @@ def test_status_reports_pending_for_an_unstamped_legacy_store(tmp_path):
     # The baseline is already present, so it is reported as detected rather
     # than as a step that would run.
     assert st["detected_baseline"] == 1
-    assert st["pending"] == ["archive_index_project"]
+    assert st["pending"] == ["archive_index_project", "archive_index_alarm_state"]
 
     migrations.migrate(conn, "archive_index")
     st = migrations.status(conn, "archive_index")
@@ -714,3 +714,66 @@ def test_shipped_registry_passes_its_own_validation():
     """The invariant holds for what we actually ship, not just for fixtures."""
     for db, migs in migrations.REGISTRY.items():
         migrations._validate_registry(db, migs)
+
+
+def test_archive_index_alarm_state_migration_runs_when_table_is_missing(tmp_path):
+    """A live database that predates the alarm state table gains it via migration 3.
+
+    This is the upgrade path for existing deployments: the baseline schema
+    creates the table for fresh databases, but an older store that already
+    has archive_index and project but lacks a2a_alarm_state must pick it up
+    from migration 3.
+    """
+    path = tmp_path / "archive-index.db"
+    conn = _db.connect(path)
+    # Build the baseline schema minus the alarm state table by running the
+    # original (pre-alarm) baseline and then dropping the table.
+    baseline_without_alarm = """
+CREATE TABLE IF NOT EXISTS archive_index (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL NOT NULL,
+    event_type TEXT NOT NULL,
+    agent_name TEXT,
+    app_id TEXT,
+    project TEXT,
+    summary TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    data_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_archive_ts ON archive_index(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_archive_type ON archive_index(event_type);
+CREATE INDEX IF NOT EXISTS idx_archive_agent ON archive_index(agent_name);
+CREATE INDEX IF NOT EXISTS idx_archive_app ON archive_index(app_id);
+
+CREATE TABLE IF NOT EXISTS archive_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS archive_fts USING fts5(
+    summary,
+    content,
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+"""
+    conn.executescript(baseline_without_alarm)
+    conn.execute("PRAGMA user_version = 2")
+    conn.execute(
+        "INSERT INTO archive_index "
+        "(timestamp, event_type, agent_name, app_id, project, summary,"
+        " file_path, line_number, data_json) "
+        "VALUES (1.0, 'turn', 'a', 'app', 'proj', 's', 'f.jsonl', 1, '{}')"
+    )
+    conn.commit()
+
+    assert not migrations.table_exists(conn, "a2a_alarm_state")
+
+    migrations.migrate(conn, "archive_index")
+
+    assert migrations.table_exists(conn, "a2a_alarm_state")
+    assert _user_version(conn) == migrations.latest_version("archive_index")
+    row = conn.execute("SELECT project, summary FROM archive_index").fetchone()
+    assert tuple(row) == ("proj", "s"), "existing data must survive the migration"
+    conn.close()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Alarm-convergence migration imports a constant that does not exist; breaks upgrades, invisible to the suite (revises PR #394)

Autonomous build of board card tsk-ucmfta.

Reapply alarm_key convergence from PR #394 onto master 9de5bec1:
- define A2A_ALARM_STATE_SCHEMA in archive.py and include it in INDEX_SCHEMA
  so the constant and baseline table cannot drift
- add archive_index_alarm_state migration 3 using the constant
- add a2a_alarm_state store methods (record_alarm_dedup, get_alarm_dedup, clear_alarm_key)
- wire alarm dedup through a2a_send in service.py with _A2A_ALARM_MIN_INTERVAL
- add a2a_alarms_clear endpoint in service.py, remote.py, and http_server.py
- forward alarm_key and alarm_fingerprint in RemoteClient.a2a_send

Defect 3: URL-quote alarm_key client-side in remote.a2a_alarms_clear and
unquote server-side in _handle_a2a_alarms_clear. Add tests for keys with
slashes, spaces, and percent signs.

Defect 4: changelog says module-level min interval instead of per-key.

NIT 5: docstrings attribute dedup guarantee to the single service loop
serialising reads and writes, not to atomic storage-layer enforcement.

Tests: add tests/test_a2a_alarm_convergence.py and a migration test that
drops a2a_alarm_state then runs the runner and asserts the table reappears.

Docs: add alarm clear endpoint and dedup note to taosmd/docs/a2a-comms.md.

Suite: 1761 passed, 12 skipped.

Files:
 taosmd/docs/a2a-comms.md                        |   7 +
 taosmd/http_server.py                           |  18 ++
 taosmd/migrations.py                            |  11 +-
 taosmd/remote.py                                |  19 +-
 taosmd/service.py                               |  64 +++-
 tests/test_a2a_alarm_convergence.py             | 406 ++++++++++++++++++++++++
 tests/test_migrations.py                        |  65 +++-
 9 files changed, 631 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-enforced deduplication for alarm messages, suppressing repeated alarms within the configured interval.
  * Added an endpoint and client support to clear and re-arm alarm keys.
  * Alarm deduplication state now persists across service restarts.

* **Documentation**
  * Updated the A2A HTTP reference with alarm deduplication and clearing behavior.

* **Bug Fixes**
  * Prevented duplicate alarm events from being stored or delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->