### PR TITLE
Registry startup guard checks pyjwt only, not cryptography, while its changelog claims both (revises PR #398)

### DIFF
--- a/changelog.d/tsk-lyr74o-registry-import-guard-cryptography.md
+++ b/changelog.d/tsk-lyr74o-registry-import-guard-cryptography.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Registry auth startup guard now checks that both `pyjwt` and `cryptography` are importable when `registry_url` is configured, not just `pyjwt`. A partial install (e.g. `pip install pyjwt` without its crypto extra) previously started the server silently and failed on the first EdDSA verification; the server now fails loudly at startup with an actionable `pip install taosmd[registry]` error.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -32,7 +32,7 @@ echo "  Host: $HOST   Port: $PORT"
 # --- Step 1: install taosmd --------------------------------------------------
 echo ""
 echo "Step 1: Installing taosmd..."
-pip install --quiet --upgrade taosmd
+pip install --quiet --upgrade "taosmd[registry]"
 echo "  taosmd $(taosmd --version 2>/dev/null || python -c "import taosmd; print(taosmd.__version__)") installed."
 
 # --- Step 2: install and start the background service -----------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,9 +44,9 @@ else
     cd "$INSTALL_DIR"
 fi
 
-# Install Python dependencies
+# Install Python dependencies (core + registry auth extra for fleet installs)
 echo "→ Installing dependencies..."
-pip install -e . --quiet 2>/dev/null || pip3 install -e . --quiet
+pip install -e ".[registry]" --quiet 2>/dev/null || pip3 install -e ".[registry]" --quiet
 
 # Install ONNX Runtime (for fast embeddings)
 pip install onnxruntime numpy --quiet 2>/dev/null || pip3 install onnxruntime numpy --quiet

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -30,6 +30,13 @@ If neither succeeds, install it from PyPI:
 pip install taosmd
 ```
 
+If you plan to use registry auth (set `registry_url`), install the extra
+instead so the `pyjwt` and `cryptography` dependencies are included:
+
+```
+pip install "taosmd[registry]"
+```
+
 or, for the latest unreleased changes, from GitHub:
 
 ```
@@ -497,9 +504,14 @@ can also be set with the `TAOSMD_A2A_AUTH_ENFORCE` environment variable (`1`,
 is verify-and-warn: an auth failure is logged as a warning and the message is
 still accepted, so a deployment can observe violations before flipping
 enforcement. In enforce mode a missing token returns `401` and a bad token or
-missing grant returns `403`, and the message is dropped. Independent of registry
-auth, when the server has `server_token` configured every `/a2a/*` endpoint
-requires a matching `Authorization: Bearer <token>` header.
+missing grant returns `403`, and the message is dropped.
+
+Registry auth requires the `pyjwt` and `cryptography` packages, which are not
+installed by default. If you set `registry_url`, install the `[registry]` extra:
+`pip install "taosmd[registry]"`. The server will fail loudly at startup if the
+extra is missing. Independent of registry auth, when the server has
+`server_token` configured every `/a2a/*` endpoint requires a matching
+`Authorization: Bearer <token>` header.
 
 Each message in `/a2a/messages` and the SSE stream has shape:
 `{"id", "ts", "from", "body", "thread", "reply_to"}`

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -694,6 +694,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         _registry_url = _config.get_registry_url(data_dir)
         if _registry_url:
             from . import registry_auth  # noqa: PLC0415 - optional path
+            registry_auth._require_jwt()
             # The revoked and grants feeds are admin-gated (#710/#719): send the
             # configured taOS local token on them; pin the issuer.
             _registry_admin_token = _config.get_registry_token(data_dir)

--- a/taosmd/registry_auth.py
+++ b/taosmd/registry_auth.py
@@ -42,6 +42,9 @@ class HumanAuthError(AuthError):
 def _require_jwt():
     try:
         import jwt  # noqa: PLC0415
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: PLC0415
+            Ed25519PublicKey,  # noqa: F401
+        )
     except ImportError as exc:  # pragma: no cover - exercised via degrade test
         raise AuthError(
             "registry auth requires the crypto extra: pip install taosmd[registry]"

--- a/tests/test_http_server_registry_import_guard.py
+++ b/tests/test_http_server_registry_import_guard.py
@@ -1,0 +1,48 @@
+"""Startup import guard for registry auth deps.
+
+When ``registry_url`` is configured but the optional crypto stack
+(``pyjwt`` + ``cryptography``) is missing, the server must fail at startup
+with an actionable error naming ``taosmd[registry]`` -- not start silently
+and blow up on the first auth-gated request.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from taosmd import config, http_server
+
+
+@pytest.fixture
+def data_dir_with_registry(tmp_path, monkeypatch):
+    monkeypatch.delenv("TAOSMD_REGISTRY_URL", raising=False)
+    data_dir = tmp_path / "taosmd-data"
+    data_dir.mkdir()
+    config.set_registry_url("http://reg.test", data_dir=str(data_dir))
+    return str(data_dir)
+
+
+def test_missing_jwt_fails_at_startup(data_dir_with_registry, monkeypatch):
+    monkeypatch.setitem(sys.modules, "jwt", None)
+    with pytest.raises(Exception, match=r"taosmd\[registry\]"):
+        http_server.make_server("127.0.0.1", 0, data_dir=data_dir_with_registry)
+
+
+def test_missing_cryptography_fails_at_startup(data_dir_with_registry, monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "cryptography.hazmat.primitives.asymmetric.ed25519",
+        None,
+    )
+    with pytest.raises(Exception, match=r"taosmd\[registry\]"):
+        http_server.make_server("127.0.0.1", 0, data_dir=data_dir_with_registry)
+
+
+def test_server_starts_when_deps_present(data_dir_with_registry):
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=data_dir_with_registry)
+    try:
+        assert httpd.server_address[:2]
+    finally:
+        httpd.service_loop.close()
+        httpd.server_close()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Registry startup guard checks pyjwt only, not cryptography, while its changelog claims both (revises PR #398)

Autonomous build of board card tsk-lyr74o.

The registry auth startup guard (_require_jwt) only imported pyjwt,
missing the cryptography dependency that pyjwt EdDSA verification needs.
A partial install (pip install pyjwt without its crypto extra) passed
the guard, booted the server, and failed on the first EdDSA verification
at request time instead of failing loudly at startup.

Widen _require_jwt to also import Ed25519PublicKey from
cryptography.hazmat.primitives.asymmetric, raising the same AuthError
naming taosmd[registry]. Error string stays in one place.

Also install taosmd[registry] in scripts/setup.sh and install-server.sh
and document the [registry] extra in a2a-comms.md, merged with the
existing #397 wording without overwriting it.

Files:
 ...sk-lyr74o-registry-import-guard-cryptography.md |  3 ++
 scripts/install-server.sh                          |  2 +-
 scripts/setup.sh                                   |  4 +-
 taosmd/docs/a2a-comms.md                           | 18 ++++++--
 taosmd/http_server.py                              |  1 +
 taosmd/registry_auth.py                            |  3 ++
 tests/test_http_server_registry_import_guard.py    | 48 ++++++++++++++++++++++
 7 files changed, 73 insertions(+), 6 deletions(-)