### PR TITLE
REVISE PR #404 (#185 prep): GET /tasks/edges is unscoped, so a project-bound token reads every project's task graph, and limit is unbounded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 __pycache__/
 *.pyc
 *.egg-info/

--- a/changelog.d/tsk-jpitve-task-edges-scoped.md
+++ b/changelog.d/tsk-jpitve-task-edges-scoped.md
@@ -1,0 +1,11 @@
+### Added
+
+- `GET /tasks/edges` endpoint for reading active task edges with optional
+  `from_id`, `to_id`, `type`, and `limit` filters.
+
+### Fixed
+
+- Cross-project read leak: a project-bound token now sees only edges whose
+  both endpoints live in the token's project.
+- Unbounded `limit` on `GET /tasks/edges`: negative values are rejected with
+  400 and the upper bound is capped at 500.

--- a/taosmd/capabilities.py
+++ b/taosmd/capabilities.py
@@ -148,13 +148,14 @@ CAPABILITY_PROBES: tuple[CapabilityProbe, ...] = (
         symbols=(
             "task_create",
             "task_list",
+            "task_list_edges",
             "task_ready",
             "task_prime",
             "task_update",
             "task_add_edge",
             "task_remove_edge",
         ),
-        route_markers=('"/tasks"', '"/tasks/ready"', '"/tasks/prime"'),
+        route_markers=('"/tasks"', '"/tasks/edges"', '"/tasks/ready"', '"/tasks/prime"'),
     ),
     CapabilityProbe(
         # Time-travel over the temporal KG: ?as_of= on GET /graph, plus the

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -470,6 +470,14 @@ a2a_members(channel="CHANNEL")
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |
 | `POST` | `/a2a/admin/supersede-message` | body JSON `{"id": int}` | `{"superseded": true, "id": int}`; admin, same token rule |
+| `GET`  | `/tasks/edges` | `?from_id=&to_id=&type=&limit=` | `{"edges": [...]}`; scoped to the token-bound project when registry auth is configured, tokenless requests return all edges |
+| `POST` | `/tasks` | body JSON `{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}` | task object |
+| `GET`  | `/tasks` | `?status=&project=&assignee=&limit=` | `{"tasks": [...]}` |
+| `GET`  | `/tasks/ready` | `?project=&assignee=&limit=` | `{"tasks": [...]}` |
+| `GET`  | `/tasks/prime` | `?project=&assignee=` | `{"text": ..., "tasks": [...]}` |
+| `POST` | `/tasks/{id}` | body JSON `{"status"?, "assignee"?, "priority"?, "body"?}` | updated task object |
+| `POST` | `/tasks/{id}/edges` | body JSON `{"to_id", "type", "created_by"}` | edge record |
+| `POST` | `/tasks/{id}/edges/remove` | body JSON `{"to_id", "type"}` | edge record with `removed_ts` |
 
 ### Admin token (separate from the data plane)
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -114,6 +114,7 @@ Endpoints
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 ``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
 ``GET  /tasks``            ``?status=&project=&assignee=&limit=``  -> ``{"tasks": [...]}``
+``GET  /tasks/edges``      ``?from_id=&to_id=&type=&limit=``       -> ``{"edges": [...]}``
 ``GET  /tasks/ready``      ``?project=&assignee=&limit=``  -> ``{"tasks": [...]}``
 ``GET  /tasks/prime``      ``?project=&assignee=``         -> ``{"text": ..., "tasks": [...]}``
 ``POST /tasks/{id}``       ``{"status"?, "assignee"?, "priority"?, "body"?}`` -> updated task object
@@ -1116,6 +1117,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_task_create()
                 elif method == "GET" and path == "/tasks":
                     self._handle_task_list(query)
+                elif method == "GET" and path == "/tasks/edges":
+                    self._handle_task_list_edges(query)
                 elif method == "GET" and path == "/tasks/ready":
                     self._handle_task_ready(query)
                 elif method == "GET" and path == "/tasks/prime":
@@ -2098,6 +2101,36 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, {"tasks": tasks})
 
+        def _handle_task_list_edges(self, qs: dict) -> None:
+            from_id = (qs.get("from_id") or [None])[0]
+            to_id = (qs.get("to_id") or [None])[0]
+            edge_type = (qs.get("type") or [None])[0]
+            limit_raw = (qs.get("limit") or [500])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if limit_i < 0:
+                raise _BadRequest("'limit' must be non-negative")
+            limit_i = min(limit_i, 500)
+            project, ok = self._apply_token_binding(None, None)
+            if not ok:
+                return
+            try:
+                edges = runner.run(
+                    service.task_list_edges(
+                        from_id=from_id,
+                        to_id=to_id,
+                        edge_type=edge_type,
+                        limit=limit_i,
+                        project=project,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, {"edges": edges})
+
         def _handle_task_ready(self, qs: dict) -> None:
             project = (qs.get("project") or [None])[0]
             assignee = (qs.get("assignee") or [None])[0]
@@ -2557,7 +2590,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "GET /pending, POST /pending/resolve, "
           "POST /a2a/send, GET /a2a/messages, GET /a2a/mentions, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
-          "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
+          "POST /tasks, GET /tasks, GET /tasks/edges, GET /tasks/ready, GET /tasks/prime, "
           "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove, "
           "GET /collections, GET /collections/{id}, POST /collections/{id}/link, "
           "POST /collections/{id}/unlink, POST /collections/{id}/grants, "

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -436,6 +436,26 @@ class RemoteClient:
         resp = await self._run("GET", "/tasks", params=params)
         return resp.get("tasks", [])
 
+    async def task_list_edges(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+        limit: int = 500,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks/edges: return task edges from the remote server."""
+        params: dict = {"limit": limit}
+        if from_id is not None:
+            params["from_id"] = from_id
+        if to_id is not None:
+            params["to_id"] = to_id
+        if edge_type is not None:
+            params["type"] = edge_type
+        resp = await self._run("GET", "/tasks/edges", params=params)
+        return resp.get("edges", [])
+
     async def task_ready(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1493,6 +1493,31 @@ async def task_list(
     )
 
 
+async def task_list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    project: str | None = None,
+    data_dir=None,
+) -> list[dict]:
+    """Return active task edges matching the given filters.
+
+    Thin wrapper over :func:`taosmd.tasks.list_edges`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_list_edges(
+            from_id=from_id, to_id=to_id, edge_type=edge_type, limit=limit
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.list_edges(
+        from_id=from_id, to_id=to_id, edge_type=edge_type,
+        limit=limit, project=project, data_dir=data_dir,
+    )
+
+
 async def task_ready(
     *,
     project: str | None = None,
@@ -1848,7 +1873,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
            "a2a_inbox", "a2a_inbox_advance",
-           "task_create", "task_list", "task_ready", "task_prime",
+           "task_create", "task_list", "task_list_edges", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -16,6 +16,7 @@ Public API
 create_task(title, *, body, project, assignee, priority, depends_on,
             created_by, data_dir) -> dict
 list_tasks(*, status, project, assignee, limit, data_dir) -> list[dict]
+list_edges(*, from_id, to_id, edge_type, limit, data_dir) -> list[dict]
 ready_tasks(*, project, assignee, limit, data_dir) -> list[dict]
 prime(*, project, assignee, data_dir) -> {"text": str, "tasks": list[dict]}
 update_task(task_id, *, status, assignee, priority, body, data_dir) -> dict
@@ -313,6 +314,48 @@ async def get_task_projects(
         ids,
     ).fetchall()
     return {row["id"]: row["project"] for row in rows}
+
+
+async def list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    project: str | None = None,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return active task edges matching the given filters, newest first."""
+    if edge_type is not None and edge_type not in VALID_EDGE_TYPES:
+        raise ValueError(f"edge_type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    conditions: list[str] = ["removed_ts IS NULL"]
+    params: list[Any] = []
+
+    if from_id is not None:
+        conditions.append("from_id = ?")
+        params.append(from_id)
+    if to_id is not None:
+        conditions.append("to_id = ?")
+        params.append(to_id)
+    if edge_type is not None:
+        conditions.append("type = ?")
+        params.append(edge_type)
+    if project is not None:
+        conditions.append("EXISTS (SELECT 1 FROM tasks WHERE id = task_edges.from_id AND project = ?)")
+        params.append(project)
+        conditions.append("EXISTS (SELECT 1 FROM tasks WHERE id = task_edges.to_id AND project = ?)")
+        params.append(project)
+
+    params.append(limit)
+    rows = conn.execute(
+        "SELECT from_id, to_id, type, created_ts, created_by, removed_ts "
+        f"FROM task_edges WHERE {' AND '.join(conditions)} "
+        "ORDER BY created_ts DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
 
 
 async def ready_tasks(

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -672,3 +672,101 @@ def test_task_update_scoped_token_same_project_succeeds(project_server):
         {"status": "in_progress", "assignee": "agent-1"}, token=tok)
     assert status == 200, body
     assert body["status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests for GET /tasks/edges (PR #404 shape)
+# ---------------------------------------------------------------------------
+
+def test_list_edges_tokenless_returns_empty_when_no_edges(project_server):
+    """Tokenless GET /tasks/edges returns an empty list when no edges exist."""
+    status, body = _get_json(project_server, "/tasks/edges")
+    assert status == 200, body
+    assert body["edges"] == []
+
+
+def test_list_edges_tokenless_returns_edges(project_server):
+    """Tokenless GET /tasks/edges returns active edges."""
+    t1 = _create_task(project_server, "Source", project="proj-a")
+    t2 = _create_task(project_server, "Target", project="proj-a")
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t2, "type": "blocks", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["from_id"] == t1
+    assert body["edges"][0]["to_id"] == t2
+
+
+def test_list_edges_with_type_filter(project_server):
+    """GET /tasks/edges?type=blocks filters by edge type."""
+    t1 = _create_task(project_server, "A", project="proj-a")
+    t2 = _create_task(project_server, "B", project="proj-a")
+    t3 = _create_task(project_server, "C", project="proj-a")
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t2, "type": "blocks", "created_by": "setup"})
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t3, "type": "relates", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges?type=blocks")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["type"] == "blocks"
+
+
+# ---------------------------------------------------------------------------
+# RED-FIRST tests for GET /tasks/edges security and limit validation
+# ---------------------------------------------------------------------------
+
+def test_list_edges_positive_control_cross_project_post_is_403(project_server):
+    """A proj-a token cannot add an edge between two proj-b tasks.
+
+    This is the positive control: it must pass before and after the list-edges
+    scoping fix, proving the registry verifier and grants gate are active.
+    """
+    t1 = _create_task(project_server, "Foreign blocker", project="proj-b")
+    t2 = _create_task(project_server, "Foreign blocked", project="proj-b")
+    tok = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
+    status, _ = _post_json(
+        project_server, f"/tasks/{t1}/edges",
+        {"to_id": t2, "type": "blocks", "created_by": "agent-1"},
+        token=tok)
+    assert status == 403
+    assert t2 in _ready_ids(project_server)
+
+
+def test_list_edges_cross_project_leak(project_server):
+    """A proj-a token reading /tasks/edges must not see proj-b's edges."""
+    t_a1 = _create_task(project_server, "Proj-a source", project="proj-a")
+    t_a2 = _create_task(project_server, "Proj-a target", project="proj-a")
+    t_b1 = _create_task(project_server, "Proj-b source", project="proj-b")
+    t_b2 = _create_task(project_server, "Proj-b target", project="proj-b")
+    _post_json(project_server, f"/tasks/{t_a1}/edges",
+               {"to_id": t_a2, "type": "blocks", "created_by": "setup"})
+    _post_json(project_server, f"/tasks/{t_b1}/edges",
+               {"to_id": t_b2, "type": "blocks", "created_by": "setup"})
+    tok = _make_token("agent-1", project_id="proj-a", iss=registry_auth.REGISTRY_ISS)
+    status, body = _get_json(project_server, "/tasks/edges", token=tok)
+    assert status == 200, body
+    returned_ids = {e["from_id"] for e in body["edges"]} | {e["to_id"] for e in body["edges"]}
+    assert t_b1 not in returned_ids
+    assert t_b2 not in returned_ids
+    assert t_a1 in returned_ids
+    assert t_a2 in returned_ids
+
+
+def test_list_edges_negative_limit_is_rejected(project_server):
+    """GET /tasks/edges?limit=-1 must not return the full table."""
+    tasks = [_create_task(project_server, f"T{i}", project="proj-a") for i in range(3)]
+    for i in range(2):
+        _post_json(project_server, f"/tasks/{tasks[i]}/edges",
+                   {"to_id": tasks[i + 1], "type": "blocks", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges?limit=-1")
+    assert status == 400, body
+    assert body.get("edges", []) == []
+
+
+def test_list_edges_invalid_type_returns_400(project_server):
+    """GET /tasks/edges?type=bogus returns 400."""
+    status, body = _get_json(project_server, "/tasks/edges?type=bogus")
+    assert status == 400, body
+    assert "edge_type" in body.get("error", "").lower() or "type" in body.get("error", "").lower()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #404 (#185 prep): GET /tasks/edges is unscoped, so a project-bound token reads every project's task graph, and limit is unbounded

Autonomous build of board card tsk-jpitve.

Rebuild PR #404 shape with the missing security half.

Added:
- GET /tasks/edges endpoint with from_id, to_id, type, limit filters
- taosmd.tasks.list_edges query and service/remote wrappers
- tasks.v1 capability probe update
- 3 happy-path tests for the new endpoint
- 4 RED-FIRST tests: positive control cross-project POST is 403,
  cross-project GET leak is blocked, negative limit is rejected,
  invalid edge_type returns 400

Fixed:
- BLOCKER 1: _handle_task_list_edges now calls _apply_token_binding
  and scopes results through a task project join so only edges whose
  both endpoints live in the token's project are returned
- BLOCKER 2: negative limit is rejected with 400 and upper bound is
  capped at 500
- BLOCKER 3: changelog fragment and a2a-comms.md docs coverage added
- Non-blocking: two blank lines before ready_tasks in tasks.py,
  .venv/ added to .gitignore

Proof:
- RED run (unpatched base): 2 failed, 2 passed
  (leak and limit=-1 failed, positive control and invalid type passed)
- GREEN run (full suite): 1777 passed, 12 skipped
- ruff clean

Files:
 taosmd/capabilities.py                      |  3 +-
 taosmd/docs/a2a-comms.md                    |  8 +++
 taosmd/http_server.py                       | 35 ++++++++++-
 taosmd/remote.py                            | 20 ++++++
 taosmd/service.py                           | 27 +++++++-
 taosmd/tasks.py                             | 43 +++++++++++++
 tests/test_http_server_registry_auth.py     | 98 +++++++++++++++++++++++++++++
 9 files changed, 243 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-edge listing through the `GET /tasks/edges` endpoint.
  * Supports filtering by source task, destination task, edge type, and result limit.
  * Added client and service support for retrieving task edges.

* **Bug Fixes**
  * Restricted project-scoped access to edges whose endpoints belong to the permitted project.
  * Invalid or negative limits now return a validation error; limits are capped at 500.

* **Documentation**
  * Documented task-management endpoints, including edge queries and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->