### PR TITLE
test(a2a): make the inbox kind-exclusion gate discriminate instead of assert vacuously (tsk-s5doj3)

### DIFF
--- a/changelog.d/tsk-s5doj3-inbox-kind-gate.md
+++ b/changelog.d/tsk-s5doj3-inbox-kind-gate.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `tests/test_a2a_inbox_cursors.py`: the gate for `a2a_inbox`'s default kind exclusion was vacuous. Its alarm, ack, receipt and digest fixture messages were not addressed to the consumer, so the addressed-filter removed them and deleting the kind filter entirely left the suite green. Those four messages now mention the consumer, so the kind filter is the only rule that can exclude them, and `include_kinds` gained the coverage it had none of.

--- a/tests/test_a2a_inbox_cursors.py
+++ b/tests/test_a2a_inbox_cursors.py
@@ -53,7 +53,8 @@ def _setup_stores(data_dir):
 
 
 def _seed_inbox_fixture(data_dir):
-    """Create 20 messages: 4 addressed to alice, rest not addressed or excluded.
+    """Create 20 messages: 8 addressed to alice, of which 4 survive the default
+    kind filter.
 
     Messages 5 to 8 mention ``@alice`` on purpose.  They are addressed by every
     other rule the query applies, so the ONLY thing that can keep them out of
@@ -102,8 +103,9 @@ def _seed_inbox_fixture(data_dir):
 # ---------------------------------------------------------------------------
 
 def test_a2a_inbox_excludes_self_and_alarm_kind(inbox_data_dir):
-    """Exactly 4 of 20 messages are addressed to alice; self-posts and alarm
-    kinds are excluded by default."""
+    """8 of 20 messages are addressed to alice and exactly 4 are returned;
+    self-posts are excluded, and so are the alarm, ack, receipt and digest
+    kinds, which is the only reason messages 5 to 8 are absent."""
     _setup_stores(inbox_data_dir)
     dd = str(inbox_data_dir)
     _seed_inbox_fixture(inbox_data_dir)

--- a/tests/test_a2a_inbox_cursors.py
+++ b/tests/test_a2a_inbox_cursors.py
@@ -53,7 +53,14 @@ def _setup_stores(data_dir):
 
 
 def _seed_inbox_fixture(data_dir):
-    """Create 20 messages: 4 addressed to alice, rest not addressed or excluded."""
+    """Create 20 messages: 4 addressed to alice, rest not addressed or excluded.
+
+    Messages 5 to 8 mention ``@alice`` on purpose.  They are addressed by every
+    other rule the query applies, so the ONLY thing that can keep them out of
+    the result is the default kind exclusion.  If that filter is removed the
+    fixture yields 8 instead of 4, which is what makes gate (a) discriminate
+    the kind half rather than assert it vacuously.
+    """
     dd = str(data_dir)
     consumer = "alice"
 
@@ -63,10 +70,10 @@ def _seed_inbox_fixture(data_dir):
         ("alice", "self post", "general", None, "chat"),          # 2: self-post -> EXCLUDED
         ("bob", "in your thread", "alice", None, "chat"),         # 3: owned thread -> ADDRESSED
         ("bob", "for alice", "general", "alice", "chat"),         # 4: direct recipient -> ADDRESSED
-        ("bob", "alarm!", "general", None, "alarm"),              # 5: alarm-kind -> EXCLUDED
-        ("bob", "ack this", "general", None, "ack"),              # 6: ack-kind -> EXCLUDED
-        ("bob", "receipt", "general", None, "receipt"),           # 7: receipt-kind -> EXCLUDED
-        ("bob", "digest", "general", None, "digest"),             # 8: digest-kind -> EXCLUDED
+        ("bob", "@alice alarm!", "general", None, "alarm"),       # 5: addressed, alarm-kind -> EXCLUDED
+        ("bob", "@alice ack this", "general", None, "ack"),       # 6: addressed, ack-kind -> EXCLUDED
+        ("bob", "@alice receipt", "general", None, "receipt"),    # 7: addressed, receipt-kind -> EXCLUDED
+        ("bob", "@alice digest", "general", None, "digest"),      # 8: addressed, digest-kind -> EXCLUDED
         ("bob", "random chat", "general", None, "chat"),          # 9: not addressed
         ("bob", "another chat", "general", None, "chat"),         # 10: not addressed
         ("charlie", "hey @bob", "general", None, "chat"),         # 11: mentions bob, not alice
@@ -118,6 +125,32 @@ def test_a2a_inbox_excludes_self_and_alarm_kind(inbox_data_dir):
     assert "ack" not in kinds
     assert "receipt" not in kinds
     assert "digest" not in kinds
+
+    # The four excluded-kind messages are addressed to alice by mention, so
+    # their absence is attributable to the kind filter and nothing else.
+    assert "@alice alarm!" not in bodies
+    assert "@alice ack this" not in bodies
+    assert "@alice receipt" not in bodies
+    assert "@alice digest" not in bodies
+
+
+def test_a2a_inbox_include_kinds_widens_the_default_exclusion(inbox_data_dir):
+    """``include_kinds`` re-admits a kind the default excludes, and only that
+    kind."""
+    _setup_stores(inbox_data_dir)
+    dd = str(inbox_data_dir)
+    _seed_inbox_fixture(inbox_data_dir)
+
+    widened = asyncio.run(
+        service.a2a_inbox("alice", limit=50, include_kinds=["alarm"], data_dir=dd)
+    )
+
+    assert len(widened) == 5
+    bodies = {m["body"] for m in widened}
+    assert "@alice alarm!" in bodies
+    assert "@alice ack this" not in bodies
+    assert "@alice receipt" not in bodies
+    assert "@alice digest" not in bodies
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Card `tsk-s5doj3` (A2A v2 slice 2a) asked for the service layer plus three gates. The service layer landed in #396 on 2026-08-27 and is correct. The card stayed open, and when I picked it up I checked the gates rather than the titles. One of them does not hold.

## The defect

Gate (a) is specified as "inbox excludes self-posts and alarm-kind". It proves the self-post half and is blind to the kind half.

The fixture's alarm, ack, receipt and digest messages are sent by `bob`, into thread `general`, with no recipient and no mention of the consumer. They are therefore **not addressed to alice by any rule**, so `a2a_inbox`'s addressed-filter drops them before the kind filter is ever consulted. The assertions `"alarm" not in kinds` and friends are satisfied by messages that could never have appeared in the result for an unrelated reason.

Measured, on master, by neutralising the kind filter alone (`taosmd/service.py:1248`, `if kind not in allowed_kinds:` to `if False:`):

```
$ sed -i '1248s/.*/        if False:/' taosmd/service.py
$ .venv/bin/python -m pytest tests/test_a2a_inbox_cursors.py -q -p no:randomly; echo "exit $?"
...                                                                      [100%]
3 passed in 0.25s
exit 0
```

The whole default kind exclusion can be deleted and the gate that exists to catch that stays green. `include_kinds` had no coverage at all.

For contrast, three other mutations in the same run were killed, so the file is not inert in general: neutralising the self-post exclusion (`:1245`) reds 3 of 3, and making `a2a_inbox_advance` a no-op (`:1302`) reds 2 of 3.

## The fix

Fixture messages 5 to 8 now mention `@alice`. They are addressed by every other rule the query applies, so the only thing that can keep them out of the result is the kind filter. The result is still exactly 4 of 20, so the card's stated shape is unchanged. A fourth test covers `include_kinds` widening.

## Evidence

The card's usual red-then-green recipe assumes unpatched production code; here the implementation is already merged, so the honest equivalent is that the **same mutation the old gate could not see now kills it**.

Same mutation (`:1248`), against the strengthened tests:

```
$ sed -i '1248s/.*/        if False:/' taosmd/service.py
$ .venv/bin/python -m pytest tests/test_a2a_inbox_cursors.py -q -p no:randomly; echo "exit $?"
FAILED tests/test_a2a_inbox_cursors.py::test_a2a_inbox_excludes_self_and_alarm_kind
FAILED tests/test_a2a_inbox_cursors.py::test_a2a_inbox_include_kinds_widens_the_default_exclusion
FAILED tests/test_a2a_inbox_cursors.py::test_a2a_inbox_fetch_does_not_advance_cursor
FAILED tests/test_a2a_inbox_cursors.py::test_a2a_inbox_cursor_survives_stores_cache_reset
4 failed in 0.30s
exit 1
```

And a mutation aimed only at the widening branch (`:1230`, `excluded_kinds -= set(include_kinds)` to `pass`) reds the new test and nothing else, so it is anchored on its own behaviour rather than riding on the filter above it:

```
FAILED tests/test_a2a_inbox_cursors.py::test_a2a_inbox_include_kinds_widens_the_default_exclusion
1 failed, 3 passed in 0.28s
exit 1
```

Green, unmutated tree:

```
$ .venv/bin/python -m pytest tests/test_a2a_inbox_cursors.py -q -p no:randomly; echo "exit $?"
....                                                                     [100%]
4 passed in 0.26s
exit 0
```

## Gates

All run in a detached worktree off `origin/master` (`4ece1c5c`), rc captured directly, never off the end of a pipeline.

| check | result |
| --- | --- |
| `git rev-list --count HEAD..origin/master` | `0` |
| `check_deleted_symbols.py --base origin/master` | `deleted-symbols-guard: clean`, rc 0 |
| `ruff check taosmd/ tests/ benchmarks/` | `All checks passed!`, rc 0 |
| `check_doc_gate.py diff-gate --base origin/master` | `doc-gate: clean`, rc 0 (empty-diff control also 0) |
| em dashes in added lines | 0, over a positive control of 43 added lines |
| `git merge-tree --write-tree origin/master <head>` | rc 0, applies cleanly to current master |

Full suite: **1794 passed, 10 skipped, 7 errors**, against a baseline re-measured today on clean `4ece1c5c` of **1793 passed, 10 skipped, 7 errors**. The delta is exactly the one added test. The 7 errors are the pre-existing `taosmd.mcp_server.build_server` import failures and are not mine.

One caveat, reported rather than smoothed over: the first full run showed `1 failed, 1793 passed` and I did not capture the name before the summary scrolled. Two subsequent full runs were clean at 1794/10/7 with zero `FAILED` lines, and this file's four tests pass in isolation. The diff touches one test file and one changelog fragment, so the flake is not plausibly caused by this change, but it is a flake somebody should name.

## Scope

Tests and one changelog fragment only. No production code is touched, so the merged behaviour of `a2a_inbox` is unchanged. Slice 2c (the HTTP endpoints) is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox filtering so messages excluded by default are correctly omitted unless their kind is explicitly included.
  * Including the `alarm` kind now correctly restores only alarm messages, while acknowledgment, receipt, and digest messages remain excluded.
* **Tests**
  * Added coverage for messages addressed to the consumer and verified default exclusions and kind-filter behavior.
* **Documentation**
  * Documented the updated inbox filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->