### PR TITLE
A2A v2 slice 2c REVISION: a2a_inbox_unhandled returns a false empty (limit applied before the ack filter)

### DIFF
--- a/changelog.d/tsk-2hnss2-a2a-inbox-endpoints.md
+++ b/changelog.d/tsk-2hnss2-a2a-inbox-endpoints.md
@@ -1,0 +1,4 @@
+### Added
+* A2A inbox HTTP endpoints (`GET /a2a/inbox`, `POST /a2a/inbox/advance`, `POST /a2a/ack`, `GET /a2a/inbox/unhandled`) with registry auth derived from the verified token `sub`; remote forwarding for `a2a_inbox`, `a2a_inbox_advance`, `a2a_ack`, and `a2a_inbox_unhandled`.
+### Fixed
+* `a2a_inbox_unhandled` now applies the `limit` after filtering out acknowledged messages, so acked messages no longer consume the caller's budget and cause false-empty results.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -466,6 +466,10 @@ a2a_members(channel="CHANNEL")
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
+| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=` | `{"messages": [...]}`; `consumer` is derived from the verified token `sub` when registry auth is configured, otherwise required as a query parameter |
+| `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}`; consumer derived from verified token `sub` |
+| `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}`; `by` derived from verified token `sub` |
+| `GET`  | `/a2a/inbox/unhandled` | `?consumer=&limit=` | `{"messages": [...]}`; composed query: messages past cursor minus acks |
 | `POST` | `/a2a/alarms/{key}/clear` | path-encoded alarm key | `{"cleared": true, "key": str}` |
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -107,6 +107,10 @@ Endpoints
                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/mentions``    ``?since=&limit=&reader=``                  -> ``{"messages": [...]}`` (requires registry auth; ``reader`` is derived from the verified token ``sub``, or supplied as a query parameter when no verifier is configured)
+``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter)
+``POST /a2a/inbox/advance`` ``{"to_id": int}``                           -> ``{"ok": true}`` (principal derived from the verified token ``sub``)
+``POST /a2a/ack``          ``{"message_id": int}``                      -> ``{"id", "acked_by", "ok"}`` (``by`` derived from the verified token ``sub``)
+``GET  /a2a/inbox/unhandled`` ``?consumer=&limit=``                     -> ``{"messages": [...]}`` (composed query: mentions past cursor minus acks)
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream); ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400
 ``GET  /a2a/threads``      ``?principal=``                  -> ``{"threads": [...]}`` thread list for the principal, ordered by latest activity desc; each entry has ``thread``, ``kind``, ``participants``, ``last_message: {id, ts, from, body_preview}`` (see notes below)
 ``GET  /a2a/threads/{thread}/messages`` ``?before=&after=&limit=`` -> ``{"thread", "messages": [...]}`` cursor-paginated message envelope, oldest-first
@@ -1081,6 +1085,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_a2a_messages(query)
                 elif method == "GET" and path == "/a2a/mentions":
                     self._handle_a2a_mentions(query)
+                elif method == "GET" and path == "/a2a/inbox":
+                    self._handle_a2a_inbox(query)
+                elif method == "POST" and path == "/a2a/inbox/advance":
+                    self._handle_a2a_inbox_advance()
+                elif method == "POST" and path == "/a2a/ack":
+                    self._handle_a2a_ack()
+                elif method == "GET" and path == "/a2a/inbox/unhandled":
+                    self._handle_a2a_inbox_unhandled(query)
                 elif method == "GET" and path == "/a2a/stream":
                     self._handle_a2a_stream(query)
                     return  # SSE response already sent; skip _send_json error path
@@ -2021,6 +2033,129 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 service.a2a_alarms_clear(key, data_dir=data_dir)
             )
             self._send_json(200, result)
+
+        # ----- A2A inbox handlers -------------------------------------------
+
+        def _handle_a2a_inbox(self, qs: dict) -> None:
+            """GET /a2a/inbox -- messages past the consumer's cursor.
+
+            ``consumer`` is derived from the verified registry token ``sub``
+            when a verifier is configured; otherwise it is required as a
+            query parameter.
+            """
+            _validate_a2a_params(qs, frozenset({"consumer", "limit", "include_kinds"}))
+            consumer_qp = (qs.get("consumer") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            include_kinds_raw = (qs.get("include_kinds") or [None])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if _registry_verifier is not None:
+                token_consumer = self._get_authenticated_agent_id()
+                if token_consumer is None:
+                    self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                    return
+                if consumer_qp is not None:
+                    from .mentions import _normalise_handle  # noqa: PLC0415
+                    if _normalise_handle(consumer_qp) != _normalise_handle(token_consumer):
+                        self._send_json(403, {"error": "registry auth: consumer mismatch"})
+                        return
+                consumer = token_consumer
+            else:
+                consumer = consumer_qp
+                if not consumer:
+                    raise _BadRequest(
+                        "'consumer' query parameter is required when no registry verifier is configured"
+                    )
+            include_kinds = None
+            if include_kinds_raw:
+                include_kinds = [s.strip() for s in include_kinds_raw.split(",") if s.strip()]
+            messages = runner.run(
+                service.a2a_inbox(consumer, limit=limit_i, include_kinds=include_kinds, data_dir=data_dir)
+            )
+            self._send_json(200, {"messages": messages})
+
+        def _handle_a2a_inbox_advance(self) -> None:
+            """POST /a2a/inbox/advance -- advance the caller's inbox cursor.
+
+            The consumer identity is derived from the verified registry token
+            ``sub``; ``to_id`` comes from the JSON body.
+            """
+            body = self._read_json_body()
+            to_id_raw = body.get("to_id")
+            if to_id_raw is None:
+                raise _BadRequest("'to_id' is required")
+            try:
+                to_id = int(to_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'to_id' must be an integer") from exc
+            consumer = self._get_authenticated_agent_id()
+            if consumer is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            runner.run(
+                service.a2a_inbox_advance(consumer, to_id, data_dir=data_dir)
+            )
+            self._send_json(200, {"ok": True})
+
+        def _handle_a2a_ack(self) -> None:
+            """POST /a2a/ack -- record an acknowledgement for a message.
+
+            The ``by`` principal is derived from the verified registry token
+            ``sub``; ``message_id`` comes from the JSON body.
+            """
+            body = self._read_json_body()
+            message_id_raw = body.get("message_id")
+            if message_id_raw is None:
+                raise _BadRequest("'message_id' is required")
+            try:
+                message_id = int(message_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'message_id' must be an integer") from exc
+            by = self._get_authenticated_agent_id()
+            if by is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            result = runner.run(
+                service.a2a_ack(message_id, by, data_dir=data_dir)
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_inbox_unhandled(self, qs: dict) -> None:
+            """GET /a2a/inbox/unhandled -- composed unhandled query.
+
+            Returns messages past the consumer's cursor that are addressed
+            to the consumer and have NOT been acknowledged by the consumer.
+            """
+            _validate_a2a_params(qs, frozenset({"consumer", "limit"}))
+            consumer_qp = (qs.get("consumer") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if _registry_verifier is not None:
+                token_consumer = self._get_authenticated_agent_id()
+                if token_consumer is None:
+                    self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                    return
+                if consumer_qp is not None:
+                    from .mentions import _normalise_handle  # noqa: PLC0415
+                    if _normalise_handle(consumer_qp) != _normalise_handle(token_consumer):
+                        self._send_json(403, {"error": "registry auth: consumer mismatch"})
+                        return
+                consumer = token_consumer
+            else:
+                consumer = consumer_qp
+                if not consumer:
+                    raise _BadRequest(
+                        "'consumer' query parameter is required when no registry verifier is configured"
+                    )
+            messages = runner.run(
+                service.a2a_inbox_unhandled(consumer, limit=limit_i, data_dir=data_dir)
+            )
+            self._send_json(200, {"messages": messages})
 
         # ----- task graph handlers ----------------------------------------
 

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -245,6 +245,71 @@ class RemoteClient:
             "POST", f"/a2a/alarms/{urllib.parse.quote(alarm_key, safe='')}/clear", {},
         )
 
+    async def a2a_inbox(
+        self,
+        consumer: str,
+        *,
+        limit: int = 50,
+        include_kinds: list | None = None,
+        **_opts,
+    ) -> list[dict]:
+        """GET /a2a/inbox: return messages past ``consumer``'s cursor.
+
+        Returns the ``messages`` list from the server response.
+        """
+        params: dict = {"consumer": consumer, "limit": limit}
+        if include_kinds is not None:
+            params["include_kinds"] = ",".join(include_kinds)
+        resp = await self._run("GET", "/a2a/inbox", params=params)
+        return resp.get("messages", [])
+
+    async def a2a_inbox_advance(
+        self,
+        consumer: str,
+        to_id: int,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/inbox/advance: advance ``consumer``'s cursor to ``to_id``.
+
+        The ``consumer`` argument is accepted for API symmetry but is ignored
+        on the remote path; the server derives the principal from the
+        verified registry token ``sub``.
+
+        Returns ``{"ok": True}``.
+        """
+        return await self._run("POST", "/a2a/inbox/advance", {"to_id": to_id})
+
+    async def a2a_ack(
+        self,
+        message_id: int,
+        by: str,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/ack: record that ``by`` has acknowledged ``message_id``.
+
+        The ``by`` argument is accepted for API symmetry but is ignored on
+        the remote path; the server derives the principal from the verified
+        registry token ``sub``.
+
+        Returns ``{"id", "acked_by", "ok"}``.
+        """
+        return await self._run("POST", "/a2a/ack", {"message_id": message_id})
+
+    async def a2a_inbox_unhandled(
+        self,
+        consumer: str,
+        *,
+        limit: int = 50,
+        **_opts,
+    ) -> list[dict]:
+        """GET /a2a/inbox/unhandled: return unhandled messages for ``consumer``.
+
+        Returns the ``messages`` list from the server response.
+        """
+        params: dict = {"consumer": consumer, "limit": limit}
+        resp = await self._run("GET", "/a2a/inbox/unhandled", params=params)
+        return resp.get("messages", [])
+
     async def a2a_feed(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1204,6 +1204,7 @@ async def a2a_inbox(
     limit: int = 50,
     include_kinds: list | None = None,
     data_dir=None,
+    exclude_acked_by: str | None = None,
 ) -> list[dict]:
     """Return messages past ``consumer``'s cursor that are addressed to it.
 
@@ -1216,7 +1217,19 @@ async def a2a_inbox(
     ``alarm``, ``ack``, ``receipt``, and ``digest`` are excluded; pass
     ``include_kinds`` to widen the set.  Results are oldest-first.  Reading
     does NOT advance the cursor.
+
+    When ``exclude_acked_by`` is supplied, any message whose ``acked_by``
+    list contains that principal is omitted, so the caller's ``limit``
+    budget is spent only on messages that still need attention.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox(
+            consumer, limit=limit, include_kinds=include_kinds,
+        )
     if not isinstance(consumer, str) or not consumer:
         raise ValueError("consumer must be a non-empty string")
     stores = await _api._ensure_stores(data_dir)
@@ -1262,6 +1275,10 @@ async def a2a_inbox(
                     break
         if not addressed:
             continue
+        if exclude_acked_by is not None:
+            acked_by = data.get("acked_by")
+            if isinstance(acked_by, list) and exclude_acked_by in acked_by:
+                continue
         msg = {
             "id": row["id"],
             "ts": row["timestamp"],
@@ -1275,6 +1292,8 @@ async def a2a_inbox(
             msg["refs"] = data["refs"]
         if "blocks" in data:
             msg["blocks"] = data["blocks"]
+        if "acked_by" in data:
+            msg["acked_by"] = data["acked_by"]
         result.append(msg)
 
     result.sort(key=lambda m: (m["ts"], m["id"]))
@@ -1292,7 +1311,13 @@ async def a2a_inbox_advance(
 
     The cursor is persisted in the archive store so it survives restarts
     and is visible to every process sharing the same data dir.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox_advance(consumer, to_id)
     if not isinstance(consumer, str) or not consumer:
         raise ValueError("consumer must be a non-empty string")
     if not isinstance(to_id, int) or to_id < 0:
@@ -1301,6 +1326,35 @@ async def a2a_inbox_advance(
     archive = stores["archive"]
     await archive.set_a2a_inbox_cursor(consumer, to_id)
     return {"ok": True}
+
+
+async def a2a_inbox_unhandled(
+    consumer: str,
+    *,
+    limit: int = 50,
+    data_dir=None,
+) -> list[dict]:
+    """Return unhandled messages for ``consumer``: addressed messages past the
+    consumer's cursor that the consumer has NOT yet acknowledged.
+
+    This is the composed "unhandled for X" query: it combines the server-side
+    cursor from :func:`a2a_inbox` with the ack state from :func:`a2a_ack`
+    so callers see only the messages that still need attention.  Because the
+    ack filter is applied before the ``limit``, acked messages do not consume
+    the caller's budget.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox_unhandled(consumer, limit=limit)
+    if not isinstance(consumer, str) or not consumer:
+        raise ValueError("consumer must be a non-empty string")
+    msgs = await a2a_inbox(
+        consumer, limit=limit, data_dir=data_dir, exclude_acked_by=consumer,
+    )
+    return msgs
 
 
 async def a2a_record_delivered(
@@ -1419,7 +1473,13 @@ async def a2a_ack(message_id: int, by: str, *, data_dir=None) -> dict:
     acks) is deferred to slice 2c, which needs 2a's server-side cursor.
 
     Returns ``{"id", "acked_by", "ok"}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_ack(message_id, by)
     if not isinstance(by, str) or not by:
         raise ValueError("by must be a non-empty string")
     stores = await _api._ensure_stores(data_dir)
@@ -1847,7 +1907,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
-           "a2a_inbox", "a2a_inbox_advance",
+           "a2a_inbox", "a2a_inbox_advance", "a2a_inbox_unhandled",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_a2a_inbox_auth.py
+++ b/tests/test_a2a_inbox_auth.py
@@ -1,0 +1,250 @@
+"""Registry auth guards for the A2A inbox, advance, and ack HTTP endpoints.
+
+RED-first: these tests are expected to FAIL on unpatched master because the
+endpoints do not exist (404). After the slice-2c implementation they pass.
+
+Covers:
+  (a) missing Bearer token -> 401 on all three endpoints
+  (b) token ``sub`` mismatch against the requested consumer -> 403 on inbox
+  (c) bad-signature token -> 401 on advance and ack
+  (d) valid matching token -> 200 on all three endpoints
+"""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg, http_server, registry_auth
+
+
+# ---------------------------------------------------------------------------
+# Keypair / token helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+REG_PRIV_PEM, REG_PUB_PEM = _keypair()
+OTHER_PRIV_PEM, _OTHER_PUB_PEM = _keypair()
+
+
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=None):
+    claims = {"sub": sub}
+    if iss is not None:
+        claims["iss"] = iss
+    return pyjwt.encode(claims, priv_pem, algorithm="EdDSA")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _request(url, method, payload=None, token=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode()
+        try:
+            return exc.code, json.loads(body)
+        except json.JSONDecodeError:
+            return exc.code, {"error": body}
+
+
+def _get(url, token=None):
+    return _request(url, "GET", None, token)
+
+
+def _post(url, payload, token=None):
+    return _request(url, "POST", payload, token)
+
+
+# ---------------------------------------------------------------------------
+# Server fixture with registry verifier (enforce mode)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-inbox-auth"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None,
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): missing token -> 401
+# ---------------------------------------------------------------------------
+
+def test_inbox_without_token_is_rejected(authed_server):
+    status, _ = _get(f"{authed_server}/a2a/inbox")
+    assert status == 401
+
+
+def test_inbox_advance_without_token_is_rejected(authed_server):
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5})
+    assert status == 401
+
+
+def test_ack_without_token_is_rejected(authed_server):
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1})
+    assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# Gate (b): token sub mismatch against requested consumer -> 403 on inbox
+# ---------------------------------------------------------------------------
+
+def test_inbox_consumer_mismatch_is_rejected(authed_server):
+    token = _make_token("agent-A")
+    status, _ = _get(f"{authed_server}/a2a/inbox?consumer=agent-B", token=token)
+    assert status == 403
+
+
+# ---------------------------------------------------------------------------
+# Gate (c): bad-signature token -> 401 on advance and ack
+# ---------------------------------------------------------------------------
+
+def test_inbox_advance_with_bad_token_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", priv_pem=OTHER_PRIV_PEM)
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5}, token=bad_token)
+    assert status == 401
+
+
+def test_ack_with_bad_token_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", priv_pem=OTHER_PRIV_PEM)
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1}, token=bad_token)
+    assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# Gate (d): valid matching token -> 200 on all three endpoints
+# ---------------------------------------------------------------------------
+
+def test_inbox_with_valid_matching_token_succeeds(authed_server):
+    token = _make_token("agent-1")
+    status, body = _get(f"{authed_server}/a2a/inbox", token=token)
+    assert status == 200
+    assert "messages" in body
+
+
+def test_inbox_advance_with_valid_matching_token_succeeds(authed_server, tmp_path, monkeypatch):
+    dd = tmp_path / "inbox-advance-ok"
+    dd.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(dd)))
+    vmem = stores["vector"]
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+    # Seed via the HTTP server so the message lives in the server's archive.
+    token = _make_token("agent-1")
+    send_status, send_body = _post(
+        f"{authed_server}/a2a/send",
+        {"from": "agent-1", "body": "hello @agent-1", "thread": "general"},
+        token=token,
+    )
+    assert send_status == 200
+    msg_id = send_body["id"]
+
+    # Self-posts are excluded from inbox, so inbox is empty before advance.
+    inbox_status, inbox_body = _get(f"{authed_server}/a2a/inbox", token=token)
+    assert inbox_status == 200
+    assert inbox_body.get("messages") == []
+
+    status, body = _post(
+        f"{authed_server}/a2a/inbox/advance",
+        {"to_id": msg_id},
+        token=token,
+    )
+    assert status == 200
+    assert body.get("ok") is True
+
+
+def test_ack_with_valid_matching_token_succeeds(authed_server, tmp_path, monkeypatch):
+    dd = tmp_path / "ack-ok"
+    dd.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(dd)))
+    vmem = stores["vector"]
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+    # Seed via the HTTP server so the message lives in the server's archive.
+    token = _make_token("agent-1")
+    send_status, send_body = _post(
+        f"{authed_server}/a2a/send",
+        {"from": "agent-1", "body": "ack me", "thread": "acks"},
+        token=token,
+    )
+    assert send_status == 200
+    msg_id = send_body["id"]
+
+    status, body = _post(
+        f"{authed_server}/a2a/ack",
+        {"message_id": msg_id},
+        token=token,
+    )
+    assert status == 200
+    assert body.get("ok") is True
+    assert body.get("id") == msg_id

--- a/tests/test_a2a_inbox_unhandled.py
+++ b/tests/test_a2a_inbox_unhandled.py
@@ -1,0 +1,156 @@
+"""Tests for the A2A inbox 'unhandled' composed query.
+
+The unhandled query returns messages past the consumer's cursor that are
+addressed to the consumer AND have not been acknowledged by the consumer.
+
+Covers:
+  (a) mention before the cursor -> excluded
+  (b) mention after the cursor, not acked -> included
+  (c) mention after the cursor that has been acked -> excluded
+  (d) positive control: the underlying inbox query returns the expected
+      addressed messages before ack filtering
+  (e) limit applies AFTER the ack filter: acked messages do not consume
+      the caller's budget
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def unhandled_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-unhandled"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _send(data_dir, sender, body, thread="general", recipient=None, kind="chat"):
+    return asyncio.run(service.a2a_send(
+        sender, body, thread=thread, recipient=recipient, kind=kind, data_dir=str(data_dir),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): mention before cursor -> excluded
+# Gate (b): mention after cursor, not acked -> included
+# Gate (c): mention after cursor, acked -> excluded
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_unhandled_excludes_before_cursor_and_acked(unhandled_data_dir):
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "alice"
+
+    # msg1: before cursor (will be excluded once cursor advances)
+    msg1 = _send(dd, "bob", "early @alice", thread="general", recipient=None, kind="chat")
+    # msg2: after cursor, not acked -> should appear in unhandled
+    msg2 = _send(dd, "bob", "later @alice", thread="general", recipient=None, kind="chat")
+    # msg3: after cursor, acked by alice -> excluded from unhandled
+    msg3 = _send(dd, "bob", "acked @alice", thread="general", recipient=None, kind="chat")
+
+    # Advance cursor past msg1 (to msg1's id) so msg2 and msg3 are past cursor
+    asyncio.run(service.a2a_inbox_advance(consumer, msg1["id"], data_dir=dd))
+
+    # Ack msg3 by consumer
+    asyncio.run(service.a2a_ack(msg3["id"], consumer, data_dir=dd))
+
+    # Unhandled query should return only msg2
+    unhandled = asyncio.run(service.a2a_inbox_unhandled(consumer, data_dir=dd))
+    assert len(unhandled) == 1
+    assert unhandled[0]["id"] == msg2["id"]
+    assert unhandled[0]["body"] == "later @alice"
+
+
+# ---------------------------------------------------------------------------
+# Gate (d): positive control: inbox returns addressed messages before ack filter
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_positive_control_before_ack_filter(unhandled_data_dir):
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "alice"
+
+    msg1 = _send(dd, "bob", "early @alice", thread="general", kind="chat")
+    msg2 = _send(dd, "bob", "later @alice", thread="general", kind="chat")
+    msg3 = _send(dd, "bob", "acked @alice", thread="general", kind="chat")
+
+    # No cursor advance yet: inbox should return all 3
+    inbox = asyncio.run(service.a2a_inbox(consumer, data_dir=dd))
+    ids = {m["id"] for m in inbox}
+    assert msg1["id"] in ids
+    assert msg2["id"] in ids
+    assert msg3["id"] in ids
+
+
+# ---------------------------------------------------------------------------
+# Gate (e): limit applies AFTER the ack filter
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_unhandled_limit_after_ack_filter(unhandled_data_dir):
+    """RED-first: acks past the window must not consume the limit budget.
+
+    Ten messages mentioning @agent-1, first 8 acked.
+    a2a_inbox_unhandled with limit=8 must return the 2 unacked messages,
+    not 0.
+    """
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "agent-1"
+
+    ids = []
+    for i in range(1, 11):
+        msg = _send(dd, "bob", f"msg {i} @agent-1", thread="general", kind="chat")
+        ids.append(msg["id"])
+
+    # Advance cursor past the first message so all 10 are in the window
+    asyncio.run(service.a2a_inbox_advance(consumer, ids[0], data_dir=dd))
+
+    # Ack the first 8 messages
+    for mid in ids[:8]:
+        asyncio.run(service.a2a_ack(mid, consumer, data_dir=dd))
+
+    # With limit=1000, only the 2 unacked messages should be returned
+    unhandled_all = asyncio.run(service.a2a_inbox_unhandled(consumer, limit=1000, data_dir=dd))
+    assert len(unhandled_all) == 2
+    assert {m["id"] for m in unhandled_all} == {ids[8], ids[9]}
+
+    # With limit=8, the 2 unacked messages must still be returned.
+    # On the buggy code this returns 0 because limit is applied before
+    # the ack filter: a2a_inbox returns the first 8 (all acked), then
+    # the filter discards them all.
+    unhandled_limited = asyncio.run(service.a2a_inbox_unhandled(consumer, limit=8, data_dir=dd))
+    assert len(unhandled_limited) == 2
+    assert {m["id"] for m in unhandled_limited} == {ids[8], ids[9]}

--- a/tests/test_a2a_remote_forwarding.py
+++ b/tests/test_a2a_remote_forwarding.py
@@ -1,0 +1,212 @@
+"""Tests that the A2A inbox service layer forwards to the remote server.
+
+When ``server_url`` is configured in the data_dir's ``config.json``, the
+service functions ``a2a_inbox``, ``a2a_inbox_advance``, and ``a2a_ack`` must
+reach the remote HTTP server, not the local archive.
+
+The live server runs in verify-and-warn mode so unauthenticated ``a2a_send``
+pre-seeding is accepted; the caller sends the registry bearer token for the
+mutating endpoints.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as taosmd_config
+from taosmd import http_server, registry_auth, service as taosmd_service
+
+
+# ---------------------------------------------------------------------------
+# Keypair / token helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+REG_PRIV_PEM, REG_PUB_PEM = _keypair()
+
+
+def _make_token(sub, priv_pem=REG_PRIV_PEM):
+    return pyjwt.encode({"sub": sub}, priv_pem, algorithm="EdDSA")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Fixture: live server with registry verifier (warn mode)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-remote-fwd"
+    data_dir.mkdir()
+
+    # Warn mode so unauthenticated a2a_send pre-seeding is accepted.
+    taosmd_config.set_a2a_auth_enforce(False, str(data_dir))
+
+    # Write server_token as a valid registry JWT so both _check_token and
+    # _get_authenticated_agent_id() accept the same bearer credential.
+    valid_token = _make_token("agent-1")
+    cfg_file = data_dir / "config.json"
+    cfg_file.write_text(json.dumps({"server_token": valid_token}))
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None,
+    )
+
+    # Pre-seed via local service layer before the server starts, then clear
+    # the stores cache so the server creates fresh connections in its thread.
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "remote inbox hello @agent-1", thread="general", data_dir=str(data_dir),
+    ))
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "advance me @agent-1", thread="general", data_dir=str(data_dir),
+    ))
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "ack me remote @agent-1", thread="acks", data_dir=str(data_dir),
+    ))
+    taosmd_api._stores_cache.clear()
+
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}", str(data_dir)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixture: caller data_dir pointing at the live server
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def caller_data_dir(tmp_path, monkeypatch, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    valid_token = _make_token("agent-1")
+    cfg_file = caller_dir / "config.json"
+    cfg_file.write_text(json.dumps({"server_url": base_url, "server_token": valid_token}))
+    taosmd_service._remote_cache.clear()
+    yield str(caller_dir)
+    taosmd_service._remote_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_inbox forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    # Verify via the caller path: the remote server's seeded message is visible.
+    msgs = asyncio.run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    bodies = {m["body"] for m in msgs}
+    assert "remote inbox hello @agent-1" in bodies
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_inbox_advance forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_advance_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    # Read the seeded message via caller path to get its id.
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    advance_msg = [m for m in msgs if m["body"] == "advance me @agent-1"]
+    assert advance_msg, "seeded advance-me message not visible remotely"
+    msg_id = advance_msg[0]["id"]
+
+    result = asyncio_run(taosmd_service.a2a_inbox_advance(
+        "agent-1", msg_id, data_dir=caller_data_dir,
+    ))
+    assert result.get("ok") is True
+
+    # Verify via the caller path: the remote server's cursor moved.
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    assert not any(m["id"] == msg_id for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_ack forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_ack_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    # Read the seeded message via caller path to get its id.
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    ack_msg = [m for m in msgs if m["body"] == "ack me remote @agent-1"]
+    assert ack_msg, "seeded ack-me message not visible remotely"
+    msg_id = ack_msg[0]["id"]
+
+    result = asyncio_run(taosmd_service.a2a_ack(
+        msg_id, "agent-1", data_dir=caller_data_dir,
+    ))
+    assert result.get("ok") is True
+    assert result.get("id") == msg_id
+    assert "agent-1" in result.get("acked_by", [])


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): A2A v2 slice 2c REVISION: a2a_inbox_unhandled returns a false empty (limit applied before the ack filter)

Autonomous build of board card tsk-2hnss2.

Re-apply the slice-2c work (a2a_inbox_unhandled bug, registry auth,
remote forwarding) onto a clean branch off origin/master.

Fixes:
- a2a_inbox_unhandled now pushes the ack filter into the a2a_inbox
  query via exclude_acked_by so limit applies to unhandled messages
  only; acked messages no longer consume the caller's budget
- a2a_inbox now includes acked_by on envelopes when present

Adds:
- GET /a2a/inbox, POST /a2a/inbox/advance, POST /a2a/ack,
  GET /a2a/inbox/unhandled HTTP handlers with registry auth
- RemoteClient methods for a2a_inbox, a2a_inbox_advance, a2a_ack,
  a2a_inbox_unhandled
- Changelog fragment

Tests:
- 15 new tests across test_a2a_inbox_unhandled, test_a2a_inbox_auth,
  test_a2a_remote_forwarding
- Red-first test asserts a2a_inbox_unhandled returns non-empty when
  acks exceed the limit budget; fails on unfixed code, passes after

Also fixes while in there:
- RemoteClient docstrings note that a2a_ack by and a2a_inbox_advance
  consumer are ignored on the remote path
- Bad-token tests pin 401 instead of in (401, 403)
- File header corrected: bad-signature tokens return 401, not 403

Suite: 1807 passed, 12 skipped

Files:
 taosmd/docs/a2a-comms.md                      |   4 +
 taosmd/http_server.py                         | 135 ++++++++++++++
 taosmd/remote.py                              |  65 +++++++
 taosmd/service.py                             |  62 ++++++-
 tests/test_a2a_inbox_auth.py                  | 250 ++++++++++++++++++++++++++
 tests/test_a2a_inbox_unhandled.py             | 156 ++++++++++++++++
 tests/test_a2a_remote_forwarding.py           | 212 ++++++++++++++++++++++
 8 files changed, 887 insertions(+), 1 deletion(-)