### PR TITLE
REVISE PR #405: GET /tasks/edges drops the project scope on the remote path, so the leak survives in the shared-server deployment

### DIFF
--- a/changelog.d/tsk-7wau2y-task-edges-scoped.md
+++ b/changelog.d/tsk-7wau2y-task-edges-scoped.md
@@ -1,0 +1,14 @@
+### Added
+
+- `GET /tasks/edges` endpoint for reading active task edges with optional
+  `from_id`, `to_id`, `type`, and `limit` filters.
+
+### Fixed
+
+- Cross-project read leak on the remote path: `GET /tasks/edges` now forwards
+  the token-bound `project` through `service.task_list_edges` to
+  `remote.task_list_edges` (which previously dropped it), so a project-bound
+  token reading via a shared-server deployment can no longer see sibling
+  project edges.
+- Unbounded `limit` on `GET /tasks/edges`: negative values are rejected with
+  400 and the upper bound is capped at 500.

--- a/taosmd/capabilities.py
+++ b/taosmd/capabilities.py
@@ -148,13 +148,14 @@ CAPABILITY_PROBES: tuple[CapabilityProbe, ...] = (
         symbols=(
             "task_create",
             "task_list",
+            "task_list_edges",
             "task_ready",
             "task_prime",
             "task_update",
             "task_add_edge",
             "task_remove_edge",
         ),
-        route_markers=('"/tasks"', '"/tasks/ready"', '"/tasks/prime"'),
+        route_markers=('"/tasks"', '"/tasks/edges"', '"/tasks/ready"', '"/tasks/prime"'),
     ),
     CapabilityProbe(
         # Time-travel over the temporal KG: ?as_of= on GET /graph, plus the

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -470,6 +470,14 @@ a2a_members(channel="CHANNEL")
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |
 | `POST` | `/a2a/admin/supersede-message` | body JSON `{"id": int}` | `{"superseded": true, "id": int}`; admin, same token rule |
+| `GET`  | `/tasks/edges` | `?from_id=&to_id=&type=&limit=` | `{"edges": [...]}`; scoped to the token-bound project when registry auth is configured, tokenless requests return all edges |
+| `POST` | `/tasks` | body JSON `{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}` | task object |
+| `GET`  | `/tasks` | `?status=&project=&assignee=&limit=` | `{"tasks": [...]}` |
+| `GET`  | `/tasks/ready` | `?project=&assignee=&limit=` | `{"tasks": [...]}` |
+| `GET`  | `/tasks/prime` | `?project=&assignee=` | `{"text": ..., "tasks": [...]}` |
+| `POST` | `/tasks/{id}` | body JSON `{"status"?, "assignee"?, "priority"?, "body"?}` | updated task object |
+| `POST` | `/tasks/{id}/edges` | body JSON `{"to_id", "type", "created_by"}` | edge record |
+| `POST` | `/tasks/{id}/edges/remove` | body JSON `{"to_id", "type"}` | edge record with `removed_ts` |
 
 ### Admin token (separate from the data plane)
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -114,6 +114,7 @@ Endpoints
 ``GET  /a2a/members``      ``?channel=<name>``             -> ``{"members": [...]}``
 ``POST /tasks``            ``{"title", "body"?, "project"?, "assignee"?, "priority"?, "depends_on"?: [...], "created_by"}`` -> task object
 ``GET  /tasks``            ``?status=&project=&assignee=&limit=``  -> ``{"tasks": [...]}``
+``GET  /tasks/edges``      ``?from_id=&to_id=&type=&limit=``       -> ``{"edges": [...]}``
 ``GET  /tasks/ready``      ``?project=&assignee=&limit=``  -> ``{"tasks": [...]}``
 ``GET  /tasks/prime``      ``?project=&assignee=``         -> ``{"text": ..., "tasks": [...]}``
 ``POST /tasks/{id}``       ``{"status"?, "assignee"?, "priority"?, "body"?}`` -> updated task object
@@ -1116,6 +1117,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_task_create()
                 elif method == "GET" and path == "/tasks":
                     self._handle_task_list(query)
+                elif method == "GET" and path == "/tasks/edges":
+                    self._handle_task_list_edges(query)
                 elif method == "GET" and path == "/tasks/ready":
                     self._handle_task_ready(query)
                 elif method == "GET" and path == "/tasks/prime":
@@ -2098,6 +2101,36 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, {"tasks": tasks})
 
+        def _handle_task_list_edges(self, qs: dict) -> None:
+            from_id = (qs.get("from_id") or [None])[0]
+            to_id = (qs.get("to_id") or [None])[0]
+            edge_type = (qs.get("type") or [None])[0]
+            limit_raw = (qs.get("limit") or [500])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if limit_i < 0:
+                raise _BadRequest("'limit' must be non-negative")
+            limit_i = min(limit_i, 500)
+            project, ok = self._apply_token_binding(None, None)
+            if not ok:
+                return
+            try:
+                edges = runner.run(
+                    service.task_list_edges(
+                        from_id=from_id,
+                        to_id=to_id,
+                        edge_type=edge_type,
+                        limit=limit_i,
+                        project=project,
+                        data_dir=data_dir,
+                    )
+                )
+            except ValueError as exc:
+                raise _BadRequest(str(exc)) from exc
+            self._send_json(200, {"edges": edges})
+
         def _handle_task_ready(self, qs: dict) -> None:
             project = (qs.get("project") or [None])[0]
             assignee = (qs.get("assignee") or [None])[0]
@@ -2557,7 +2590,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "GET /pending, POST /pending/resolve, "
           "POST /a2a/send, GET /a2a/messages, GET /a2a/mentions, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
-          "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
+          "POST /tasks, GET /tasks, GET /tasks/edges, GET /tasks/ready, GET /tasks/prime, "
           "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove, "
           "GET /collections, GET /collections/{id}, POST /collections/{id}/link, "
           "POST /collections/{id}/unlink, POST /collections/{id}/grants, "

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -436,6 +436,33 @@ class RemoteClient:
         resp = await self._run("GET", "/tasks", params=params)
         return resp.get("tasks", [])
 
+    async def task_list_edges(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+        limit: int = 500,
+        project: str | None = None,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks/edges: return task edges from the remote server.
+
+        ``project`` is forwarded so project-scoped edges work over the remote
+        path, matching :meth:`task_list`.
+        """
+        params: dict = {"limit": limit}
+        if from_id is not None:
+            params["from_id"] = from_id
+        if to_id is not None:
+            params["to_id"] = to_id
+        if edge_type is not None:
+            params["type"] = edge_type
+        if project is not None:
+            params["project"] = project
+        resp = await self._run("GET", "/tasks/edges", params=params)
+        return resp.get("edges", [])
+
     async def task_ready(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1493,6 +1493,32 @@ async def task_list(
     )
 
 
+async def task_list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    project: str | None = None,
+    data_dir=None,
+) -> list[dict]:
+    """Return active task edges matching the given filters.
+
+    Thin wrapper over :func:`taosmd.tasks.list_edges`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_list_edges(
+            from_id=from_id, to_id=to_id, edge_type=edge_type,
+            limit=limit, project=project,
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.list_edges(
+        from_id=from_id, to_id=to_id, edge_type=edge_type,
+        limit=limit, project=project, data_dir=data_dir,
+    )
+
+
 async def task_ready(
     *,
     project: str | None = None,
@@ -1848,7 +1874,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
            "a2a_inbox", "a2a_inbox_advance",
-           "task_create", "task_list", "task_ready", "task_prime",
+           "task_create", "task_list", "task_list_edges", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",
            "admin_a2a_delete_channel", "admin_a2a_rename_channel",

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -16,6 +16,7 @@ Public API
 create_task(title, *, body, project, assignee, priority, depends_on,
             created_by, data_dir) -> dict
 list_tasks(*, status, project, assignee, limit, data_dir) -> list[dict]
+list_edges(*, from_id, to_id, edge_type, limit, project, data_dir) -> list[dict]
 ready_tasks(*, project, assignee, limit, data_dir) -> list[dict]
 prime(*, project, assignee, data_dir) -> {"text": str, "tasks": list[dict]}
 update_task(task_id, *, status, assignee, priority, body, data_dir) -> dict
@@ -313,6 +314,48 @@ async def get_task_projects(
         ids,
     ).fetchall()
     return {row["id"]: row["project"] for row in rows}
+
+
+async def list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    edge_type: str | None = None,
+    limit: int = 500,
+    project: str | None = None,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return active task edges matching the given filters, newest first."""
+    if edge_type is not None and edge_type not in VALID_EDGE_TYPES:
+        raise ValueError(f"edge_type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    conditions: list[str] = ["removed_ts IS NULL"]
+    params: list[Any] = []
+
+    if from_id is not None:
+        conditions.append("from_id = ?")
+        params.append(from_id)
+    if to_id is not None:
+        conditions.append("to_id = ?")
+        params.append(to_id)
+    if edge_type is not None:
+        conditions.append("type = ?")
+        params.append(edge_type)
+    if project is not None:
+        conditions.append("EXISTS (SELECT 1 FROM tasks WHERE id = task_edges.from_id AND project = ?)")
+        params.append(project)
+        conditions.append("EXISTS (SELECT 1 FROM tasks WHERE id = task_edges.to_id AND project = ?)")
+        params.append(project)
+
+    params.append(limit)
+    rows = conn.execute(
+        "SELECT from_id, to_id, type, created_ts, created_by, removed_ts "
+        f"FROM task_edges WHERE {' AND '.join(conditions)} "
+        "ORDER BY created_ts DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
 
 
 async def ready_tasks(

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -672,3 +672,105 @@ def test_task_update_scoped_token_same_project_succeeds(project_server):
         {"status": "in_progress", "assignee": "agent-1"}, token=tok)
     assert status == 200, body
     assert body["status"] == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests for GET /tasks/edges
+# ---------------------------------------------------------------------------
+
+
+def test_list_edges_tokenless_returns_empty_when_no_edges(project_server):
+    """Tokenless GET /tasks/edges returns an empty list when no edges exist."""
+    status, body = _get_json(project_server, "/tasks/edges")
+    assert status == 200, body
+    assert body["edges"] == []
+
+
+def test_list_edges_tokenless_returns_edges(project_server):
+    """Tokenless GET /tasks/edges returns active edges."""
+    t1 = _create_task(project_server, "Source", project="proj-a")
+    t2 = _create_task(project_server, "Target", project="proj-a")
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t2, "type": "blocks", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["from_id"] == t1
+    assert body["edges"][0]["to_id"] == t2
+
+
+def test_list_edges_with_type_filter(project_server):
+    """GET /tasks/edges?type=blocks filters by edge type."""
+    t1 = _create_task(project_server, "A", project="proj-a")
+    t2 = _create_task(project_server, "B", project="proj-a")
+    t3 = _create_task(project_server, "C", project="proj-a")
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t2, "type": "blocks", "created_by": "setup"})
+    _post_json(project_server, f"/tasks/{t1}/edges",
+               {"to_id": t3, "type": "relates", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges?type=blocks")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["type"] == "blocks"
+
+
+# ---------------------------------------------------------------------------
+# RED-FIRST tests for GET /tasks/edges security and limit validation
+# ---------------------------------------------------------------------------
+
+
+def test_list_edges_positive_control_cross_project_post_is_403(project_server):
+    """A proj-a token cannot add an edge between two proj-b tasks.
+
+    This is the positive control: it must pass before and after the list-edges
+    scoping fix, proving the registry verifier and grants gate are active.
+    """
+    t1 = _create_task(project_server, "Foreign blocker", project="proj-b")
+    t2 = _create_task(project_server, "Foreign blocked", project="proj-b")
+    tok = _make_token("agent-1", project_id="proj-a",
+                      iss=registry_auth.REGISTRY_ISS)
+    status, _ = _post_json(
+        project_server, f"/tasks/{t1}/edges",
+        {"to_id": t2, "type": "blocks", "created_by": "agent-1"},
+        token=tok)
+    assert status == 403
+    assert t2 in _ready_ids(project_server)
+
+
+def test_list_edges_cross_project_leak(project_server):
+    """A proj-a token reading /tasks/edges must not see proj-b's edges."""
+    t_a1 = _create_task(project_server, "Proj-a source", project="proj-a")
+    t_a2 = _create_task(project_server, "Proj-a target", project="proj-a")
+    t_b1 = _create_task(project_server, "Proj-b source", project="proj-b")
+    t_b2 = _create_task(project_server, "Proj-b target", project="proj-b")
+    _post_json(project_server, f"/tasks/{t_a1}/edges",
+               {"to_id": t_a2, "type": "blocks", "created_by": "setup"})
+    _post_json(project_server, f"/tasks/{t_b1}/edges",
+               {"to_id": t_b2, "type": "blocks", "created_by": "setup"})
+    tok = _make_token("agent-1", project_id="proj-a",
+                      iss=registry_auth.REGISTRY_ISS)
+    status, body = _get_json(project_server, "/tasks/edges", token=tok)
+    assert status == 200, body
+    returned_ids = {e["from_id"] for e in body["edges"]} | {e["to_id"] for e in body["edges"]}
+    assert t_b1 not in returned_ids
+    assert t_b2 not in returned_ids
+    assert t_a1 in returned_ids
+    assert t_a2 in returned_ids
+
+
+def test_list_edges_negative_limit_is_rejected(project_server):
+    """GET /tasks/edges?limit=-1 must not return the full table."""
+    tasks = [_create_task(project_server, f"T{i}", project="proj-a") for i in range(3)]
+    for i in range(2):
+        _post_json(project_server, f"/tasks/{tasks[i]}/edges",
+                   {"to_id": tasks[i + 1], "type": "blocks", "created_by": "setup"})
+    status, body = _get_json(project_server, "/tasks/edges?limit=-1")
+    assert status == 400, body
+    assert body.get("edges", []) == []
+
+
+def test_list_edges_invalid_type_returns_400(project_server):
+    """GET /tasks/edges?type=bogus returns 400."""
+    status, body = _get_json(project_server, "/tasks/edges?type=bogus")
+    assert status == 400, body
+    assert "edge_type" in body.get("error", "").lower() or "type" in body.get("error", "").lower()

--- a/tests/test_service_task_edges_remote.py
+++ b/tests/test_service_task_edges_remote.py
@@ -1,0 +1,79 @@
+"""Service-layer test: project scope survives the remote-path hop for /tasks/edges.
+
+PR #405 (commit 08a33b3d) added GET /tasks/edges and correctly scoped the local
+SQL path in ``taosmd.tasks.list_edges``.  But ``service.task_list_edges`` dropped
+``project`` when delegating to ``remote.task_list_edges`` (which also lacked the
+parameter), so a project-bound token reading via a shared-server deployment could
+see sibling-project edges.
+
+This test injects a *recording* fake remote and asserts that ``project``
+reaches ``remote.task_list_edges``.  ``service.task_list`` is exercised in the
+same test as a positive control: it forwards ``project`` correctly on every
+branch, so its assertion passing proves the recording probe itself is sound and
+a drop in ``task_list_edges`` cannot report a false green.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd import service as taosmd_service
+
+
+class _RecordingRemote:
+    """Fake RemoteClient that records every call for later assertion."""
+
+    def __init__(self) -> None:
+        self.task_list_calls: list[dict] = []
+        self.task_list_edges_calls: list[dict] = []
+
+    async def task_list(self, *, status=None, project=None, assignee=None,
+                        limit=50, **_opts) -> list[dict]:
+        self.task_list_calls.append(
+            {"status": status, "project": project,
+             "assignee": assignee, "limit": limit}
+        )
+        return []
+
+    async def task_list_edges(self, *, from_id=None, to_id=None,
+                              edge_type=None, limit=500, project=None, **_opts) -> list[dict]:
+        self.task_list_edges_calls.append(
+            {"from_id": from_id, "to_id": to_id, "edge_type": edge_type,
+             "limit": limit, "project": project}
+        )
+        return []
+
+
+@pytest.fixture
+def fake_remote(monkeypatch):
+    """Inject a recording fake remote into the service layer."""
+    fake = _RecordingRemote()
+    monkeypatch.setattr(
+        taosmd_service, "_get_remote", lambda data_dir: fake
+    )
+    return fake
+
+
+def test_task_list_edges_forwards_project_to_remote(fake_remote):
+    """service.task_list_edges must forward ``project`` to the remote client.
+
+    Positive control: service.task_list (which already forwards project) is
+    exercised in the same test so a broken recording probe cannot report a pass.
+    """
+    # --- target: task_list_edges must forward project ---
+    asyncio.run(taosmd_service.task_list_edges(
+        from_id="t-src", to_id="t-dst", edge_type="blocks",
+        limit=10, project="proj-a", data_dir="/fake",
+    ))
+    assert len(fake_remote.task_list_edges_calls) == 1
+    assert fake_remote.task_list_edges_calls[0]["project"] == "proj-a"
+
+    # --- positive control: task_list already forwards project ---
+    asyncio.run(taosmd_service.task_list(
+        status="open", project="proj-a", assignee="agent-1",
+        limit=20, data_dir="/fake",
+    ))
+    assert len(fake_remote.task_list_calls) == 1
+    assert fake_remote.task_list_calls[0]["project"] == "proj-a"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -285,6 +285,75 @@ def test_remove_edge_already_removed(data_dir):
 
 
 # ---------------------------------------------------------------------------
+# list_edges
+# ---------------------------------------------------------------------------
+
+
+def test_list_edges_empty(data_dir):
+    """No edges -> empty list."""
+    result = run(tasks_mod.list_edges(data_dir=data_dir))
+    assert result == []
+
+
+def test_list_edges_returns_active_edges(data_dir):
+    """list_edges returns active (non-soft-deleted) edges."""
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    result = run(tasks_mod.list_edges(data_dir=data_dir))
+    assert len(result) == 1
+    assert result[0]["from_id"] == a["id"]
+    assert result[0]["to_id"] == b["id"]
+    assert result[0]["type"] == "blocks"
+
+
+def test_list_edges_type_filter(data_dir):
+    """list_edges with edge_type filter returns only matching edges."""
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    c = run(tasks_mod.create_task("C", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], c["id"], "relates", "x", data_dir=data_dir))
+    result = run(tasks_mod.list_edges(edge_type="blocks", data_dir=data_dir))
+    assert len(result) == 1
+    assert result[0]["type"] == "blocks"
+
+
+def test_list_edges_invalid_type_raises(data_dir):
+    """list_edges rejects an invalid edge_type with ValueError."""
+    with pytest.raises(ValueError, match="edge_type"):
+        run(tasks_mod.list_edges(edge_type="bogus", data_dir=data_dir))
+
+
+def test_list_edges_excludes_removed(data_dir):
+    """list_edges does not return soft-removed edges."""
+    a = run(tasks_mod.create_task("A", created_by="x", data_dir=data_dir))
+    b = run(tasks_mod.create_task("B", created_by="x", data_dir=data_dir))
+    run(tasks_mod.add_edge(a["id"], b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.remove_edge(a["id"], b["id"], "blocks", data_dir=data_dir))
+    result = run(tasks_mod.list_edges(data_dir=data_dir))
+    assert result == []
+
+
+def test_list_edges_project_scoping(data_dir):
+    """list_edges with project returns only edges whose both endpoints are
+    in that project."""
+    a_a = run(tasks_mod.create_task("A-a", created_by="x", project="proj-a", data_dir=data_dir))
+    a_b = run(tasks_mod.create_task("A-b", created_by="x", project="proj-a", data_dir=data_dir))
+    b_a = run(tasks_mod.create_task("B-a", created_by="x", project="proj-b", data_dir=data_dir))
+    b_b = run(tasks_mod.create_task("B-b", created_by="x", project="proj-b", data_dir=data_dir))
+    run(tasks_mod.add_edge(a_a["id"], a_b["id"], "blocks", "x", data_dir=data_dir))
+    run(tasks_mod.add_edge(b_a["id"], b_b["id"], "blocks", "x", data_dir=data_dir))
+
+    proj_a_edges = run(tasks_mod.list_edges(project="proj-a", data_dir=data_dir))
+    returned = {e["from_id"] for e in proj_a_edges} | {e["to_id"] for e in proj_a_edges}
+    assert a_a["id"] in returned
+    assert a_b["id"] in returned
+    assert b_a["id"] not in returned
+    assert b_b["id"] not in returned
+
+
+# ---------------------------------------------------------------------------
 # depends_on in create_task
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #405: GET /tasks/edges drops the project scope on the remote path, so the leak survives in the shared-server deployment

Autonomous build of board card tsk-7wau2y.

Revises PR #405 (08a33b3d) by re-applying its work plus the missing security
half. PR #405 added GET /tasks/edges with correct local SQL scoping in
taosmd.tasks.list_edges (two EXISTS subqueries on task_edges.from_id and
to_id join to tasks.project), but service.task_list_edges dropped the
project argument when delegating to remote.task_list_edges, which did not
accept it. In the shared-server deployment (_get_remote returns a client
when server_url is set in config.json) the caller's token-bound project
was resolved then thrown away before the request left the box, and the
upstream call traveled under server_token rather than the caller's token,
so nothing downstream restored the scope. A proj-a token could read
proj-b's edges.

Changes:
- taosmd/tasks.py: add list_edges with load-bearing EXISTS-based project
  scoping (kept exactly as in #405, local scoping is correct)
- taosmd/remote.py: add task_list_edges with project: str | None = None,
  included in params when not None, matching remote.task_list
- taosmd/service.py: forward project=project from task_list_edges into the
  remote call (the actual fix)
- taosmd/http_server.py: route dispatch, _handle_task_list_edges handler
  with negative-limit 400, 500 cap, type validation 400, token binding,
  endpoint docs, startup listing
- taosmd/capabilities.py: tasks.v1 probe adds task_list_edges symbol and
  /tasks/edges route marker
- taosmd/docs/a2a-comms.md: HTTP endpoints table documents /tasks/edges
- changelog.d/tsk-7wau2y-task-edges-scoped.md: Added/Fixed fragment
- tests: 7 HTTP-level tests in test_http_server_registry_auth.py
  (happy-path, positive control, cross-project leak, negative limit,
  invalid type), 6 list_edges unit tests in test_tasks.py, 1 service-layer
  test in test_service_task_edges_remote.py using a recording fake remote

Proof (all run with ./.venv/bin/python -m pytest):
- Service-layer probe: rc=1 on 08a33b3d (project dropped, assert None ==
  proj-a), rc=0 on this branch (project forwarded to remote.task_list_edges
  + positive control service.task_list also forwarded project in same test)
- Mutation: replacing 'if project is not None:' block in list_edges with
  'if False: pass' makes test_list_edges_cross_project_leak FAIL (rc=1,
  proj-b edges leak) while test_list_edges_positive_control_cross_project_
  post_is_403 still PASSES (rc=0)
- Full suite (detached worktree off origin/master, -p no:randomly):
  Master 4ece1c5c: 1793 passed, 10 skipped, 7 errors
  This branch:    1807 passed, 10 skipped, 7 errors
  The 7 errors are pre-existing mcp_server import failures on both sides

Files:
 taosmd/http_server.py                       |  35 +++++++++-
 taosmd/remote.py                            |  27 ++++++++
 taosmd/service.py                           |  28 +++++++-
 taosmd/tasks.py                             |  43 ++++++++++++
 tests/test_http_server_registry_auth.py     | 102 ++++++++++++++++++++++++++++
 tests/test_service_task_edges_remote.py     |  79 +++++++++++++++++++++
 tests/test_tasks.py                         |  69 +++++++++++++++++++
 10 files changed, 405 insertions(+), 3 deletions(-)