### PR TITLE
Add POST /a2a/import: idempotent batch import of external chat envelopes onto the A2A bus

### DIFF
--- a/changelog.d/tsk-gbycx2-a2a-import.md
+++ b/changelog.d/tsk-gbycx2-a2a-import.md
@@ -1,0 +1,3 @@
+### Added
+
+- `POST /a2a/import`: idempotent batch import of external chat envelopes onto the A2A bus. Accepts a JSON array of envelope dicts, each requiring `source`, `source_id`, `from`, `body`, and `ts`. Deduped on the pair `(source, source_id)` so re-importing the same channel produces no duplicates. Original timestamps are preserved verbatim. The whole batch is rejected if any envelope is invalid, composes with exporter clients that pre-validate. Uses the same registry auth gate as `POST /a2a/send`.

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -91,7 +91,16 @@ CREATE TABLE IF NOT EXISTS a2a_alarm_state (
 CREATE INDEX IF NOT EXISTS idx_a2a_alarm_state_key_fp ON a2a_alarm_state(alarm_key, fingerprint);
 """
 
-INDEX_SCHEMA = INDEX_SCHEMA + A2A_ALARM_STATE_SCHEMA
+A2A_IMPORT_DEDUP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS a2a_import_dedup (
+    source TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    PRIMARY KEY (source, source_id)
+);
+CREATE INDEX IF NOT EXISTS idx_a2a_import_dedup_source_id ON a2a_import_dedup(source, source_id);
+"""
+
+INDEX_SCHEMA = INDEX_SCHEMA + A2A_ALARM_STATE_SCHEMA + A2A_IMPORT_DEDUP_SCHEMA
 
 
 class ArchiveStore:
@@ -201,6 +210,22 @@ class ArchiveStore:
         )
         self._conn.commit()
 
+    async def record_import_dedup(self, source: str, source_id: str) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO a2a_import_dedup (source, source_id) VALUES (?, ?)",
+            (source, source_id),
+        )
+        self._conn.commit()
+
+    async def get_import_dedup(self, source: str, source_id: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT source, source_id FROM a2a_import_dedup WHERE source = ? AND source_id = ?",
+            (source, source_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"source": row[0], "source_id": row[1]}
+
     # ------------------------------------------------------------------
     # Recording
     # ------------------------------------------------------------------
@@ -237,6 +262,7 @@ class ArchiveStore:
         app_id: str | None = None,
         summary: str = "",
         project: str | None = None,
+        timestamp: float | None = None,
     ) -> int:
         """Record an event to the archive. Returns the index row ID."""
         # Skip user activity events if tracking is disabled
@@ -250,7 +276,7 @@ class ArchiveStore:
             if key in data and isinstance(data[key], str):
                 data[key], _ = redact_secrets(data[key])
 
-        ts = time.time()
+        ts = timestamp if timestamp is not None else time.time()
         event = {
             "timestamp": ts,
             "event_type": event_type,

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -178,12 +178,21 @@ Your ID: AGENT_NAME          (replace with this agent's own name/identifier)
      -H "Content-Type: application/json" \
      -d '{"from": "AGENT_NAME", "body": "your message here", "thread": "CHANNEL"}'
 
-   To reply to a specific message (use its id field):
-   curl -X POST SERVER_URL/a2a/send \
-     -H "Content-Type: application/json" \
-     -d '{"from": "AGENT_NAME", "body": "reply text", "thread": "CHANNEL", "reply_to": "MESSAGE_ID"}'
+    To reply to a specific message (use its id field):
+    curl -X POST SERVER_URL/a2a/send \
+      -H "Content-Type: application/json" \
+      -d '{"from": "AGENT_NAME", "body": "reply text", "thread": "CHANNEL", "reply_to": "MESSAGE_ID"}'
 
---- Reading messages ---
+    To import a backlog of messages from an external chat system, preserving
+    original timestamps and deduplicating on (source, source_id):
+    curl -X POST SERVER_URL/a2a/import \
+      -H "Content-Type: application/json" \
+      -d '[{"source": "CHANNEL", "source_id": "EXTERNAL-ID", "from": "SENDER", "body": "message text", "ts": 1709452800.0}]'
+
+    The whole batch is rejected if any envelope is invalid. Re-importing the
+    same (source, source_id) pair is a no-op.
+
+ --- Reading messages ---
 
    All messages (oldest-first, up to 50):
    curl "SERVER_URL/a2a/messages?thread=CHANNEL&limit=50"

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -103,8 +103,11 @@ Endpoints
 ``GET  /pending?agent=``                                   -> ``{"pending": [...]}``
 ``POST /pending/resolve``  ``{"id", "decision", "note"?}`` -> resolve result
 ``POST /a2a/send``         ``{"from", "body", "thread"?, "reply_to"?, "refs"?, "blocks"?}`` -> send receipt
-                            ``refs``: optional list (<=8) of ``{"kind": doc|report|spec|log, "title", "uri", "sha256"?, "doc_id"?, "version"?, "for"?, "summary"?}``
-                            ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
+                             ``refs``: optional list (<=8) of ``{"kind": doc|report|spec|log, "title", "uri", "sha256"?, "doc_id"?, "version"?, "for"?, "summary"?}``
+                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
+``POST /a2a/import``       ``[{"source", "source_id", "from", "body", "ts", "thread"?, "kind"?, "reply_to"?, "refs"?, "blocks"?}]`` -> import receipt
+                             ``source`` + ``source_id`` form the idempotency key; the whole batch is rejected if any envelope is invalid
+                             ``ts`` is the original epoch timestamp, preserved verbatim
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/mentions``    ``?since=&limit=&reader=``                  -> ``{"messages": [...]}`` (requires registry auth; ``reader`` is derived from the verified token ``sub``, or supplied as a query parameter when no verifier is configured)
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream); ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400
@@ -790,6 +793,16 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("JSON body must be an object")
             return parsed
 
+        def _read_json_body_any(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            if length <= 0:
+                return None
+            raw = self.rfile.read(length)
+            try:
+                return json.loads(raw.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise _BadRequest(f"invalid JSON body: {exc}") from exc
+
         # ----- auth helpers ------------------------------------------------
         def _check_token(self, path: str) -> bool:
             """Return True when the request is authorised to proceed.
@@ -1071,6 +1084,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_pending_resolve()
                 elif method == "POST" and path == "/a2a/send":
                     self._handle_a2a_send()
+                elif method == "POST" and path == "/a2a/import":
+                    self._handle_a2a_import()
                 elif method == "GET" and path == "/a2a/channels":
                     self._handle_a2a_channels(query)
                 elif method == "GET" and path == "/a2a/census":
@@ -1640,76 +1655,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             # failure: identity is proven and nothing is being impersonated, so
             # it follows the same warn-or-enforce path as a missing token.
             if _registry_verifier is not None:
-                from . import registry_auth  # noqa: PLC0415 - optional path
-                auth = self.headers.get("Authorization", "")
-                token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
-
-                # Compute warn_reason (None = auth passed) and the status/message
-                # to use in enforce mode. Presented-credential failures return
-                # immediately; grant failures fall through to the single
-                # enforce-or-warn decision below.
-                warn_reason: str | None = None
-                _reject_status: int = 403
-                _reject_msg: str = ""
-
-                if not token:
-                    warn_reason = "missing Bearer token"
-                    _reject_status = 401
-                    _reject_msg = "registry auth: Bearer token required"
-                else:
-                    try:
-                        _registry_verifier.authorize(token, from_)
-                    except registry_auth.HumanAuthError as exc:
-                        logger.warning("human principal %r rejected: %s", from_, exc)
-                        self._send_json(403, {"error": f"registry auth: {exc}"})
-                        return
-                    except registry_auth.AuthError as exc:
-                        # Class 2: presented-credential failure. Always reject,
-                        # even in warn mode -- see the comment block above.
-                        _registry_url_cfg = _config.get_registry_url(data_dir)
-                        _registry_token_cfg = _config.get_registry_token(data_dir)
-                        if _registry_url_cfg is not None and _registry_token_cfg is None:
-                            msg = (
-                                "registry auth: registry_token is unset "
-                                "(registry_url is set without registry_token; "
-                                "set it with `taosmd config set-registry-token ...` "
-                                "or clear registry_url)"
-                            )
-                        else:
-                            msg = f"registry auth: {exc}"
-                        logger.warning(
-                            "a2a auth: rejecting presented-credential failure "
-                            "from %r (regardless of enforce mode): %s", from_, msg,
-                        )
-                        self._send_json(403, {"error": msg})
-                        return
-
-                # Grant check: token proves identity; grant proves permission.
-                # Human principals (controller sessions) have no registry grant,
-                # so the grants check is skipped for them.
-                if warn_reason is None and _grants_verifier is not None:
-                    if not _registry_verifier.is_human(from_):
-                        try:
-                            if not _grants_verifier.has_grant(from_):
-                                warn_reason = "no a2a_send grant"
-                                _reject_status = 403
-                                _reject_msg = f"registry auth: no active grant for {from_!r}"
-                        except registry_auth.AuthError as exc:
-                            warn_reason = str(exc)
-                            _reject_status = 403
-                            _reject_msg = f"registry auth: {exc}"
-                    else:
-                        logger.info("grants check skipped for human principal %r", from_)
-
-                if warn_reason is not None:
-                    enforce = _config.get_a2a_auth_enforce(data_dir)
-                    if enforce:
-                        self._send_json(_reject_status, {"error": _reject_msg})
-                        return
-                    logger.warning(
-                        "a2a verify-and-warn: accepting unverified post from %r: %s",
-                        from_, warn_reason,
-                    )
+                if not self._check_a2a_registry_auth(from_):
+                    return
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
@@ -1718,6 +1665,94 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     alarm_key=alarm_key, alarm_fingerprint=alarm_fingerprint,
                     data_dir=data_dir,
                 )
+            )
+            self._send_json(200, result)
+
+        def _check_a2a_registry_auth(self, claimed_from: str | None = None) -> bool:
+            if _registry_verifier is None:
+                return True
+            from . import registry_auth  # noqa: PLC0415 - optional path
+            auth = self.headers.get("Authorization", "")
+            token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+
+            warn_reason: str | None = None
+            _reject_status: int = 403
+            _reject_msg: str = ""
+
+            if not token:
+                warn_reason = "missing Bearer token"
+                _reject_status = 401
+                _reject_msg = "registry auth: Bearer token required"
+            else:
+                try:
+                    if claimed_from is not None:
+                        _registry_verifier.authorize(token, claimed_from)
+                    else:
+                        pubkey = _registry_verifier._get_pubkey()
+                        claims = registry_auth.decode_and_verify(token, pubkey)
+                        sub = claims.get("sub")
+                        if not sub:
+                            raise registry_auth.AuthError("token has no 'sub' claim")
+                        is_human = sub in _registry_verifier._human_principal_ids
+                        revoked = set() if is_human else _registry_verifier._get_revoked()
+                        if not is_human and sub in revoked:
+                            raise registry_auth.AuthError(f"canonical_id {sub!r} is revoked")
+                except registry_auth.HumanAuthError as exc:
+                    logger.warning("human principal rejected: %s", exc)
+                    self._send_json(403, {"error": f"registry auth: {exc}"})
+                    return False
+                except registry_auth.AuthError as exc:
+                    _registry_url_cfg = _config.get_registry_url(data_dir)
+                    _registry_token_cfg = _config.get_registry_token(data_dir)
+                    if _registry_url_cfg is not None and _registry_token_cfg is None:
+                        _reject_msg = (
+                            "registry auth: registry_token is unset "
+                            "(registry_url is set without registry_token; "
+                            "set it with `taosmd config set-registry-token ...` "
+                            "or clear registry_url)"
+                        )
+                    else:
+                        _reject_msg = f"registry auth: {exc}"
+                    logger.warning(
+                        "a2a auth: rejecting presented-credential failure: %s",
+                        _reject_msg,
+                    )
+                    self._send_json(403, {"error": _reject_msg})
+                    return False
+
+            if warn_reason is None and claimed_from is not None and _grants_verifier is not None:
+                if not _registry_verifier.is_human(claimed_from):
+                    try:
+                        if not _grants_verifier.has_grant(claimed_from):
+                            warn_reason = "no a2a_send grant"
+                            _reject_status = 403
+                            _reject_msg = f"registry auth: no active grant for {claimed_from!r}"
+                    except registry_auth.AuthError as exc:
+                        warn_reason = str(exc)
+                        _reject_status = 403
+                        _reject_msg = f"registry auth: {exc}"
+                else:
+                    logger.info("grants check skipped for human principal %r", claimed_from)
+
+            if warn_reason is not None:
+                enforce = _config.get_a2a_auth_enforce(data_dir)
+                if enforce:
+                    self._send_json(_reject_status, {"error": _reject_msg})
+                    return False
+                logger.warning(
+                    "a2a verify-and-warn: accepting unverified post from %r: %s",
+                    claimed_from, warn_reason,
+                )
+            return True
+
+        def _handle_a2a_import(self) -> None:
+            if not self._check_a2a_registry_auth():
+                return
+            body = self._read_json_body_any()
+            if not isinstance(body, list):
+                raise _BadRequest("'batch' must be a JSON array of envelope dicts")
+            result = runner.run(
+                service.a2a_import(body, data_dir=data_dir)
             )
             self._send_json(200, result)
 

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -235,6 +235,13 @@ class RemoteClient:
             payload["alarm_fingerprint"] = alarm_fingerprint
         return await self._run("POST", "/a2a/send", payload)
 
+    async def a2a_import(self, batch: list[dict], **_opts) -> dict:
+        """POST /a2a/import: bulk-import external chat envelopes onto the A2A bus.
+
+        Returns the import receipt ``{"imported", "skipped", "messages"}``.
+        """
+        return await self._run("POST", "/a2a/import", batch)
+
     async def a2a_alarms_clear(
         self,
         alarm_key: str,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -543,6 +543,192 @@ async def a2a_send(
     return receipt
 
 
+_A2A_REF_KINDS = frozenset({"doc", "report", "spec", "log"})
+_A2A_MAX_REFS = 8
+
+
+async def a2a_import(batch, *, data_dir=None) -> dict:
+    """Import a batch of external chat envelopes onto the A2A bus.
+
+    Each envelope must be a dict with:
+
+    * ``source`` (str, non-empty): the channel/source name; used as the
+      dedupe key first element and as the thread when ``thread`` is absent.
+    * ``source_id`` (str, non-empty): unique ID from the external system;
+      used as the dedupe key second element.
+    * ``from`` (str, non-empty): sender handle.
+    * ``ts`` (float): original epoch timestamp; preserved verbatim in the
+      archive so backlog imports do not collapse onto import time.
+    * ``body`` (str, non-empty): message text. Required when ``blocks`` is
+      absent; required alongside ``blocks`` when ``blocks`` is present
+      (body is the flattened plain-text rendering).
+
+    Optional envelope fields: ``thread`` (defaults to ``source``), ``kind``
+    (one of the A2A kinds, default ``"chat"``), ``reply_to``, ``refs``
+    (list of dicts, max 8, each with ``kind`` in the ref-kinds enum),
+    ``blocks`` (list of dicts), ``recipient``.
+
+    **Whole-batch semantics**: if *any* envelope in the batch is invalid the
+    entire batch is rejected with ``ValueError``. This composes with
+    exporter clients that pre-validate and refuse to send a batch if any
+    author is unmapped.
+
+    **Idempotence**: deduped on the pair ``(source, source_id)``. A
+    re-import of the same envelope is a no-op (skipped), so retrying a
+    failed export is safe.
+
+    Returns ``{"imported": int, "skipped": int, "messages": [...]}`` where
+    ``messages`` contains the row ids and source keys of newly imported
+    messages.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    if not isinstance(batch, list):
+        raise ValueError("'batch' must be a list of envelope dicts")
+    if not batch:
+        return {"imported": 0, "skipped": 0, "messages": []}
+
+    # Pre-validate every envelope before touching the store so the whole
+    # batch is rejected on the first error.
+    for i, env in enumerate(batch):
+        if not isinstance(env, dict):
+            raise ValueError(f"batch[{i}] must be an object")
+        source = env.get("source")
+        source_id = env.get("source_id")
+        from_ = env.get("from")
+        ts = env.get("ts")
+        body = env.get("body")
+        blocks = env.get("blocks")
+        kind = env.get("kind", "chat")
+        if kind is None:
+            kind = "chat"
+        refs = env.get("refs")
+        if not isinstance(source, str) or not source:
+            raise ValueError(f"batch[{i}].source must be a non-empty string")
+        if not isinstance(source_id, str) or not source_id:
+            raise ValueError(f"batch[{i}].source_id must be a non-empty string")
+        if not isinstance(from_, str) or not from_:
+            raise ValueError(f"batch[{i}].from must be a non-empty string")
+        if not isinstance(ts, (int, float)):
+            raise ValueError(f"batch[{i}].ts must be a number")
+        if not isinstance(body, str) or not body:
+            raise ValueError(
+                f"batch[{i}].body must be a non-empty string"
+                + (" when blocks is absent" if not blocks else "")
+            )
+        if kind not in _A2A_KINDS:
+            raise ValueError(
+                f"batch[{i}].kind must be one of {sorted(_A2A_KINDS)}; got {kind!r}"
+            )
+        if refs is not None:
+            if not isinstance(refs, list):
+                raise ValueError(f"batch[{i}].refs must be a list")
+            if len(refs) > _A2A_MAX_REFS:
+                raise ValueError(
+                    f"batch[{i}].refs must have at most {_A2A_MAX_REFS} items"
+                )
+            for j, ref in enumerate(refs):
+                if not isinstance(ref, dict):
+                    raise ValueError(f"batch[{i}].refs[{j}] must be an object")
+                ref_kind = ref.get("kind")
+                if ref_kind not in _A2A_REF_KINDS:
+                    raise ValueError(
+                        f"batch[{i}].refs[{j}].kind must be one of {sorted(_A2A_REF_KINDS)}"
+                    )
+        if blocks is not None:
+            if not isinstance(blocks, list):
+                raise ValueError(f"batch[{i}].blocks must be a list")
+            for j, block in enumerate(blocks):
+                if not isinstance(block, dict):
+                    raise ValueError(f"batch[{i}].blocks[{j}] must be an object")
+        # Total serialized message (body+refs+blocks) <= 64KB.
+        serialized = json.dumps({"body": body, "refs": refs, "blocks": blocks})
+        if len(serialized.encode("utf-8")) > 64 * 1024:
+            raise ValueError(
+                f"batch[{i}] message (body+refs+blocks) exceeds 64KB limit"
+            )
+
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_import(batch)
+
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    if data_dir is not None:
+        from .admin import A2AAdminState  # noqa: PLC0415
+        _admin = A2AAdminState(data_dir)
+
+    imported = 0
+    skipped = 0
+    messages = []
+    for env in batch:
+        source = env["source"]
+        source_id = env["source_id"]
+        from_ = env["from"]
+        ts = float(env["ts"])
+        body = env["body"]
+        thread = env.get("thread") or source
+        kind = env.get("kind", "chat") or "chat"
+        reply_to = env.get("reply_to")
+        refs = env.get("refs")
+        blocks = env.get("blocks")
+        recipient = env.get("recipient")
+
+        if data_dir is not None:
+            thread = _admin.resolve_channel(thread)
+
+        existing = await archive.get_import_dedup(source, source_id)
+        if existing is not None:
+            skipped += 1
+            continue
+
+        data = {
+            "from": from_,
+            "body": body,
+            "thread": thread,
+            "reply_to": reply_to,
+            "kind": kind,
+            "source": source,
+            "source_id": source_id,
+        }
+        if recipient is not None:
+            data["recipient"] = recipient
+        if refs is not None:
+            data["refs"] = refs
+        if blocks is not None:
+            data["blocks"] = blocks
+        row_id = await archive.record(
+            event_type=EVENT_A2A,
+            data=data,
+            agent_name=from_,
+            app_id=thread,
+            summary=body[:200],
+            timestamp=ts,
+        )
+        await archive.record_import_dedup(source, source_id)
+        receipt = {
+            "id": row_id,
+            "ts": ts,
+            "source": source,
+            "source_id": source_id,
+            "from": from_,
+            "thread": thread,
+            "reply_to": reply_to,
+            "kind": kind,
+        }
+        if recipient is not None:
+            receipt["recipient"] = recipient
+        if refs is not None:
+            receipt["refs"] = refs
+        if blocks is not None:
+            receipt["blocks"] = blocks
+        messages.append(receipt)
+        imported += 1
+
+    return {"imported": imported, "skipped": skipped, "messages": messages}
+
+
 async def a2a_feed(
     *,
     thread: str | None = None,
@@ -1844,7 +2030,7 @@ async def collections_archive(collection_id: str, *, data_dir=None) -> dict:
 
 
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
-           "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
+           "supersede", "fetch_by_ref", "a2a_send", "a2a_import", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
            "a2a_inbox", "a2a_inbox_advance",

--- a/tests/test_a2a_import.py
+++ b/tests/test_a2a_import.py
@@ -1,0 +1,327 @@
+"""Tests for POST /a2a/import: idempotent batch import of external chat envelopes.
+
+All tests drive a real HTTP server object over the real route; no mocked
+clients. POST /a2a/send is included as a positive control in the same run so
+a red result unambiguously means the new route is missing, not that the
+harness is broken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+
+pytest.importorskip("jwt")
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-import"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    import asyncio
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+@pytest.fixture
+def live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-a2a-import-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir))
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        for s in list(taosmd_api._stores_cache.values()):
+            for store in (s.get("archive"), s.get("vector"), s.get("kg")):
+                if store and hasattr(store, "close"):
+                    try:
+                        httpd.service_loop.run(store.close())
+                    except Exception:
+                        pass
+        httpd.service_loop.close()
+
+
+def _post(url: str, payload, headers: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    hdrs = {"Content-Type": "application/json"}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(
+        url, data=data, headers=hdrs, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+def _get(url: str) -> tuple[int, dict]:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# 1. Route existence: positive control with /a2a/send, new route /a2a/import
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_route_exists(live_server):
+    status, body = _post(
+        f"{live_server}/a2a/send",
+        {"from": "ctrl", "body": "positive-control", "thread": "ctrl-t"},
+    )
+    assert status == 200, body
+
+    status, body = _post(
+        f"{live_server}/a2a/import",
+        [
+            {
+                "source": "ctrl-t",
+                "source_id": "msg-1",
+                "from": "ctrl",
+                "body": "imported hello",
+                "ts": 1709452800.0,
+            }
+        ],
+    )
+    assert status == 200, body
+    assert body["imported"] == 1
+    assert body["skipped"] == 0
+    assert len(body["messages"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Whole-batch rejection on bad envelope
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_rejects_whole_batch_on_bad_envelope(live_server):
+    status, body = _post(
+        f"{live_server}/a2a/import",
+        [
+            {"source": "ch", "source_id": "1", "from": "a", "body": "ok", "ts": 1709452800.0},
+            {"source": "ch", "source_id": "2", "from": "a", "ts": "not-a-float"},
+        ],
+    )
+    assert status == 400, body
+    assert "ts" in body["error"]
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=ch")
+    assert status == 200
+    assert len(body["messages"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Timestamp preservation
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_preserves_timestamp(live_server):
+    past_ts = 1709452800.0
+    status, body = _post(
+        f"{live_server}/a2a/import",
+        [
+            {
+                "source": "ts-chan",
+                "source_id": "ts-msg-1",
+                "from": "agent",
+                "body": "old message",
+                "ts": past_ts,
+            }
+        ],
+    )
+    assert status == 200, body
+    assert body["messages"][0]["ts"] == past_ts
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=ts-chan")
+    assert status == 200
+    assert len(body["messages"]) == 1
+    assert body["messages"][0]["ts"] == past_ts
+    assert abs(body["messages"][0]["ts"] - time.time()) > 100
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotence: re-import is a no-op
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_is_idempotent(live_server):
+    batch = [
+        {"source": "idem-chan", "source_id": f"msg-{i}", "from": "agent", "body": f"msg {i}", "ts": 1709452800.0 + i}
+        for i in range(3)
+    ]
+    status, body = _post(f"{live_server}/a2a/import", batch)
+    assert status == 200, body
+    assert body["imported"] == 3
+    assert body["skipped"] == 0
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=idem-chan")
+    assert status == 200
+    assert len(body["messages"]) == 3
+
+    status, body = _post(f"{live_server}/a2a/import", batch)
+    assert status == 200, body
+    assert body["imported"] == 0
+    assert body["skipped"] == 3
+
+    status, body = _get(f"{live_server}/a2a/messages?thread=idem-chan")
+    assert status == 200
+    assert len(body["messages"]) == 3
+
+
+def test_http_a2a_import_idempotence_fails_when_dedup_is_broken(isolated_data_dir, monkeypatch):
+    """Break the dedup predicate by clearing the dedup table between imports."""
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    batch = [
+        {"source": "break-chan", "source_id": "b1", "from": "a", "body": "m1", "ts": 1709452800.0},
+    ]
+    result = asyncio.run(service.a2a_import(batch, data_dir=dd))
+    assert result["imported"] == 1
+
+    msgs = asyncio.run(service.a2a_feed(thread="break-chan", data_dir=dd))
+    assert len(msgs) == 1
+
+    stores = asyncio.run(taosmd_api._ensure_stores(dd))
+    archive = stores["archive"]
+    archive._conn.execute("DELETE FROM a2a_import_dedup")
+    archive._conn.commit()
+
+    result = asyncio.run(service.a2a_import(batch, data_dir=dd))
+    assert result["imported"] == 1
+    assert result["skipped"] == 0
+
+    msgs = asyncio.run(service.a2a_feed(thread="break-chan", data_dir=dd))
+    assert len(msgs) == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. Auth parity: caller who cannot send cannot import
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    from taosmd import config as cfg, registry_auth
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives import serialization
+
+    data_dir = tmp_path / "taosmd-auth"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": pub_pem})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None
+    )
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier)
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}", priv_pem
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        httpd.service_loop.close()
+
+
+def test_http_a2a_import_rejects_unauthenticated(authed_server):
+    base_url, _ = authed_server
+    status, body = _post(
+        f"{base_url}/a2a/import",
+        [{"source": "ch", "source_id": "1", "from": "a", "body": "hi", "ts": 1709452800.0}],
+    )
+    assert status in (401, 403), body
+
+
+def test_http_a2a_import_accepts_valid_token(authed_server):
+    base_url, priv_pem = authed_server
+    token = pyjwt.encode({"sub": "agent-1"}, priv_pem, algorithm="EdDSA")
+    status, body = _post(
+        f"{base_url}/a2a/import",
+        [{"source": "ch", "source_id": "1", "from": "agent-1", "body": "hi", "ts": 1709452800.0}],
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert status == 200, body
+
+
+def test_http_a2a_send_and_import_share_auth_gate(authed_server):
+    base_url, priv_pem = authed_server
+    bad_status_send, _ = _post(
+        f"{base_url}/a2a/send",
+        {"from": "agent-1", "body": "hi"},
+    )
+    bad_status_import, _ = _post(
+        f"{base_url}/a2a/import",
+        [{"source": "ch", "source_id": "1", "from": "agent-1", "body": "hi", "ts": 1709452800.0}],
+    )
+    assert bad_status_send in (401, 403)
+    assert bad_status_import in (401, 403)
+    assert bad_status_send == bad_status_import


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Add POST /a2a/import: idempotent batch import of external chat envelopes onto the A2A bus

Autonomous build of board card tsk-gbycx2.

- Accepts a JSON array of envelope dicts, each requiring source, source_id,
  from, body, and ts (epoch float)
- Deduped on (source, source_id) using a2a_import_dedup table so re-imports
  are no-ops
- Original timestamps preserved verbatim in archive.record via new timestamp
  parameter
- Whole batch rejected if any envelope is invalid (composes with exporters
  that pre-validate)
- Registry auth gate consistent with POST /a2a/send
- Added 8 tests covering route existence, whole-batch rejection, timestamp
  preservation, idempotence (including dedup-break failure test), and auth
  parity
- Documented endpoint in docs/a2a-comms.md and added changelog fragment

Proof: uv run --extra dev pytest -q -p no:randomly tests/test_a2a_import.py
rc=0, 8 passed. Full suite: 1800 passed, 12 skipped, 0 errors.

Files:
 changelog.d/tsk-gbycx2-a2a-import.md |   3 +
 taosmd/archive.py                    |  30 +++-
 taosmd/docs/a2a-comms.md             |  19 +-
 taosmd/http_server.py                | 179 +++++++++++--------
 taosmd/remote.py                     |   7 +
 taosmd/service.py                    | 188 +++++++++++++++++++-
 tests/test_a2a_import.py             | 327 +++++++++++++++++++++++++++++++++++
 7 files changed, 673 insertions(+), 80 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batch import for external chat history through `POST /a2a/import`.
  - Preserves original message timestamps and prevents duplicate imports.
  - Validates the complete batch before importing; invalid batches are rejected.
  - Added client support for submitting import batches and receiving import results.

- **Documentation**
  - Added usage guidance and examples for importing chat backlogs.

- **Bug Fixes**
  - Improved consistency of authentication checks for A2A messaging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->