### PR TITLE
REVISE PR #410: GET /tasks/edges never reads ?project=, so the remote-path scope fix is inert

### DIFF
--- a/changelog.d/tsk-r6o224-task-list-edges.md
+++ b/changelog.d/tsk-r6o224-task-list-edges.md
@@ -1,0 +1,3 @@
+### Added
+
+- `GET /tasks/edges` endpoint that lists task edges with optional `from_id`, `to_id`, `type`, `project`, and `limit` filters; the `project` parameter scopes results to edges whose both endpoints belong to the named project via two ANDed EXISTS clauses, and the limit is capped at 500.

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -116,6 +116,7 @@ Endpoints
 ``GET  /tasks``            ``?status=&project=&assignee=&limit=``  -> ``{"tasks": [...]}``
 ``GET  /tasks/ready``      ``?project=&assignee=&limit=``  -> ``{"tasks": [...]}``
 ``GET  /tasks/prime``      ``?project=&assignee=``         -> ``{"text": ..., "tasks": [...]}``
+``GET  /tasks/edges``      ``?from_id=&to_id=&type=&project=&limit=`` -> ``{"edges": [...]}``
 ``POST /tasks/{id}``       ``{"status"?, "assignee"?, "priority"?, "body"?}`` -> updated task object
 ``POST /tasks/{id}/edges`` ``{"to_id", "type", "created_by"}``     -> edge record
 ``POST /tasks/{id}/edges/remove`` ``{"to_id", "type"}``   -> edge record with removed_ts
@@ -1120,6 +1121,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_task_ready(query)
                 elif method == "GET" and path == "/tasks/prime":
                     self._handle_task_prime(query)
+                elif method == "GET" and path == "/tasks/edges":
+                    self._handle_task_list_edges(query)
                 elif method == "POST" and path.startswith("/tasks/"):
                     # /tasks/{id}/edges/remove  or  /tasks/{id}/edges  or  /tasks/{id}
                     rest = path[len("/tasks/"):]
@@ -2134,6 +2137,32 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, result)
 
+        def _handle_task_list_edges(self, qs: dict) -> None:
+            from_id = (qs.get("from_id") or [None])[0]
+            to_id = (qs.get("to_id") or [None])[0]
+            edge_type = (qs.get("type") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            limit_i = min(limit_i, 500)
+            project = (qs.get("project") or [None])[0]
+            project, ok = self._apply_token_binding(None, project)
+            if not ok:
+                return
+            edges = runner.run(
+                service.task_list_edges(
+                    from_id=from_id,
+                    to_id=to_id,
+                    type=edge_type,
+                    project=project,
+                    limit=limit_i,
+                    data_dir=data_dir,
+                )
+            )
+            self._send_json(200, {"edges": edges})
+
         def _handle_task_update(self, task_id: str) -> None:
             body = self._read_json_body()
             status = body.get("status")
@@ -2558,6 +2587,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "POST /a2a/send, GET /a2a/messages, GET /a2a/mentions, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
           "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
+          "GET /tasks/edges, "
           "POST /tasks/{id}, POST /tasks/{id}/edges, POST /tasks/{id}/edges/remove, "
           "GET /collections, GET /collections/{id}, POST /collections/{id}/link, "
           "POST /collections/{id}/unlink, POST /collections/{id}/grants, "

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -468,6 +468,29 @@ class RemoteClient:
             params["assignee"] = assignee
         return await self._run("GET", "/tasks/prime", params=params or None)
 
+    async def task_list_edges(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        type: str | None = None,
+        project: str | None = None,
+        limit: int = 50,
+        **_opts,
+    ) -> list[dict]:
+        """GET /tasks/edges: list task edges from the remote server."""
+        params: dict = {"limit": limit}
+        if from_id is not None:
+            params["from_id"] = from_id
+        if to_id is not None:
+            params["to_id"] = to_id
+        if type is not None:
+            params["type"] = type
+        if project is not None:
+            params["project"] = project
+        resp = await self._run("GET", "/tasks/edges", params=params)
+        return resp.get("edges", [])
+
     async def task_update(
         self,
         task_id: str,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1532,6 +1532,32 @@ async def task_prime(
     return await _tasks.prime(project=project, assignee=assignee, data_dir=data_dir)
 
 
+async def task_list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    type: str | None = None,
+    project: str | None = None,
+    limit: int = 50,
+    data_dir=None,
+) -> list[dict]:
+    """Return task edges matching the given filters.
+
+    Thin wrapper over :func:`taosmd.tasks.list_edges`.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.task_list_edges(
+            from_id=from_id, to_id=to_id, type=type,
+            project=project, limit=limit,
+        )
+    from . import tasks as _tasks  # noqa: PLC0415
+    return await _tasks.list_edges(
+        from_id=from_id, to_id=to_id, type=type,
+        project=project, limit=limit, data_dir=data_dir,
+    )
+
+
 async def task_update(
     task_id: str,
     *,

--- a/taosmd/tasks.py
+++ b/taosmd/tasks.py
@@ -631,6 +631,60 @@ async def add_edge(
     return edge
 
 
+async def list_edges(
+    *,
+    from_id: str | None = None,
+    to_id: str | None = None,
+    type: str | None = None,
+    project: str | None = None,
+    limit: int = 50,
+    data_dir: str | None = None,
+) -> list[dict]:
+    """Return task edges matching the given filters.
+
+    ``task_edges`` has no project column, so when a ``project`` is supplied
+    both edge endpoints must belong to that project (two ANDed EXISTS
+    clauses). Unbound requests (``project is None``) return every edge
+    that matches the other filters.
+    """
+    if type is not None and type not in VALID_EDGE_TYPES:
+        raise ValueError(f"type must be one of {sorted(VALID_EDGE_TYPES)}")
+
+    conn = _get_db(data_dir)
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if from_id is not None:
+        conditions.append("e.from_id = ?")
+        params.append(from_id)
+    if to_id is not None:
+        conditions.append("e.to_id = ?")
+        params.append(to_id)
+    if type is not None:
+        conditions.append("e.type = ?")
+        params.append(type)
+    conditions.append("e.removed_ts IS NULL")
+
+    if project is not None:
+        conditions.append(
+            "EXISTS (SELECT 1 FROM tasks f WHERE f.id = e.from_id AND f.project = ?)"
+        )
+        params.append(project)
+        conditions.append(
+            "EXISTS (SELECT 1 FROM tasks t WHERE t.id = e.to_id AND t.project = ?)"
+        )
+        params.append(project)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+    rows = conn.execute(
+        f"SELECT e.from_id, e.to_id, e.type, e.created_ts, e.created_by, e.removed_ts "
+        f"FROM task_edges e {where} ORDER BY e.created_ts ASC LIMIT ?",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 async def remove_edge(
     from_id: str,
     to_id: str,

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1171,3 +1171,148 @@ def test_post_refs_fetch_missing_agent_returns_400(live_server):
     )
     assert status == 400
     assert "agent" in body["error"]
+
+
+# --- /tasks/edges ----------------------------------------------------------
+
+
+def test_task_list_edges_empty(live_server):
+    """GET /tasks/edges returns an empty list when there are no edges."""
+    status, body = _get(f"{live_server}/tasks/edges")
+    assert status == 200, body
+    assert body["edges"] == []
+
+
+def test_task_list_edges_returns_edges(live_server):
+    """GET /tasks/edges returns seeded edges."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t2["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["from_id"] == t1["id"]
+    assert body["edges"][0]["to_id"] == t2["id"]
+    assert body["edges"][0]["type"] == "blocks"
+
+
+def test_task_list_edges_from_id_filter(live_server):
+    """?from_id= filters edges by source task."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    _, t3 = _post(f"{live_server}/tasks", {"title": "T3", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t2["id"], "type": "blocks", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t3["id"], "type": "blocks", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t2['id']}/edges",
+          {"to_id": t3["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?from_id={t1['id']}")
+    assert status == 200, body
+    assert len(body["edges"]) == 2
+    assert all(e["from_id"] == t1["id"] for e in body["edges"])
+
+
+def test_task_list_edges_to_id_filter(live_server):
+    """?to_id= filters edges by target task."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    _, t3 = _post(f"{live_server}/tasks", {"title": "T3", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t3["id"], "type": "blocks", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t2['id']}/edges",
+          {"to_id": t3["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?to_id={t3['id']}")
+    assert status == 200, body
+    assert len(body["edges"]) == 2
+    assert all(e["to_id"] == t3["id"] for e in body["edges"])
+
+
+def test_task_list_edges_type_filter(live_server):
+    """?type= filters edges by type."""
+    _, t1 = _post(f"{live_server}/tasks", {"title": "T1", "created_by": "a"})
+    _, t2 = _post(f"{live_server}/tasks", {"title": "T2", "created_by": "a"})
+    _, t3 = _post(f"{live_server}/tasks", {"title": "T3", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t2["id"], "type": "blocks", "created_by": "a"})
+    _post(f"{live_server}/tasks/{t1['id']}/edges",
+          {"to_id": t3["id"], "type": "parent", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?type=blocks")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["type"] == "blocks"
+
+
+def test_task_list_edges_project_scope(live_server):
+    """?project= scopes edges to tasks in that project."""
+    _, ta1 = _post(f"{live_server}/tasks", {"title": "A1", "created_by": "a", "project": "proj-a"})
+    _, ta2 = _post(f"{live_server}/tasks", {"title": "A2", "created_by": "a", "project": "proj-a"})
+    _, tb1 = _post(f"{live_server}/tasks", {"title": "B1", "created_by": "a", "project": "proj-b"})
+    _, tb2 = _post(f"{live_server}/tasks", {"title": "B2", "created_by": "a", "project": "proj-b"})
+    _post(f"{live_server}/tasks/{ta1['id']}/edges",
+          {"to_id": ta2["id"], "type": "blocks", "created_by": "a"})
+    _post(f"{live_server}/tasks/{tb1['id']}/edges",
+          {"to_id": tb2["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?project=proj-a")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["from_id"] == ta1["id"]
+    assert body["edges"][0]["to_id"] == ta2["id"]
+
+
+def test_task_list_edges_cross_project_endpoints_excluded(live_server):
+    """An edge whose endpoints are in different projects is not returned."""
+    _, ta = _post(f"{live_server}/tasks", {"title": "A", "created_by": "a", "project": "proj-a"})
+    _, tb = _post(f"{live_server}/tasks", {"title": "B", "created_by": "a", "project": "proj-b"})
+    _post(f"{live_server}/tasks/{ta['id']}/edges",
+          {"to_id": tb["id"], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges")
+    assert status == 200, body
+    assert len(body["edges"]) == 1
+    assert body["edges"][0]["from_id"] == ta["id"]
+    assert body["edges"][0]["to_id"] == tb["id"]
+
+    status_a, body_a = _get(f"{live_server}/tasks/edges?project=proj-a")
+    assert status_a == 200, body_a
+    assert body_a["edges"] == []
+
+    status_b, body_b = _get(f"{live_server}/tasks/edges?project=proj-b")
+    assert status_b == 200, body_b
+    assert body_b["edges"] == []
+
+
+def test_task_list_edges_limit_capped_at_500(live_server):
+    """GET /tasks/edges caps limit at 500."""
+    tasks = []
+    for i in range(10):
+        _, t = _post(f"{live_server}/tasks", {"title": f"T{i}", "created_by": "a"})
+        tasks.append(t["id"])
+    for i in range(9):
+        _post(f"{live_server}/tasks/{tasks[i]}/edges",
+              {"to_id": tasks[i + 1], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?limit=500")
+    assert status == 200, body
+    assert len(body["edges"]) == 9
+
+
+def test_task_list_edges_limit_over_500_is_clamped(live_server):
+    """A limit > 500 is clamped to 500 at the HTTP boundary."""
+    tasks = []
+    for i in range(10):
+        _, t = _post(f"{live_server}/tasks", {"title": f"T{i}", "created_by": "a"})
+        tasks.append(t["id"])
+    for i in range(9):
+        _post(f"{live_server}/tasks/{tasks[i]}/edges",
+              {"to_id": tasks[i + 1], "type": "blocks", "created_by": "a"})
+
+    status, body = _get(f"{live_server}/tasks/edges?limit=9999")
+    assert status == 200, body
+    assert len(body["edges"]) == 9

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -499,3 +499,31 @@ def test_install_skill_force_overwrites(tmp_path, monkeypatch):
     new_content = skill_dest.read_text()
     assert new_content != "old content"
     assert "taosmd-a2a" in new_content
+
+
+def test_remote_task_list_edges_cross_project_scoping(client):
+    """RemoteClient task_list_edges with project= returns only edges in that project."""
+    # Seed tasks in two projects
+    ta1 = asyncio.run(client.task_create(title="A1", created_by="a", project="proj-a"))
+    ta2 = asyncio.run(client.task_create(title="A2", created_by="a", project="proj-a"))
+    tb1 = asyncio.run(client.task_create(title="B1", created_by="a", project="proj-b"))
+    tb2 = asyncio.run(client.task_create(title="B2", created_by="a", project="proj-b"))
+
+    # Seed edges in each project
+    asyncio.run(client.task_add_edge(ta1["id"], ta2["id"], "blocks", created_by="a"))
+    asyncio.run(client.task_add_edge(tb1["id"], tb2["id"], "blocks", created_by="a"))
+
+    # Without project scope, both edges are returned
+    all_edges = asyncio.run(client.task_list_edges())
+    assert len(all_edges) == 2
+
+    # With project=proj-a, only the proj-a edge is returned
+    proj_a_edges = asyncio.run(client.task_list_edges(project="proj-a"))
+    assert len(proj_a_edges) == 1
+    assert proj_a_edges[0]["from_id"] == ta1["id"]
+    assert proj_a_edges[0]["to_id"] == ta2["id"]
+
+    # Positive control: service.task_list is correctly scoped on the same hop
+    proj_a_tasks = asyncio.run(client.task_list(project="proj-a"))
+    assert len(proj_a_tasks) == 2
+    assert {t["id"] for t in proj_a_tasks} == {ta1["id"], ta2["id"]}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #410: GET /tasks/edges never reads ?project=, so the remote-path scope fix is inert

Autonomous build of board card tsk-r6o224.

Added list_edges to tasks.py, service.py, remote.py, and http_server.py.
The handler reads project from the query string and passes it through
_apply_token_binding, so token-bound callers cannot spoof sibling projects.
Project scope uses two ANDed EXISTS clauses on the tasks table, one per
endpoint. Limit defaults to 50 and is capped at 500.

Tests added:
- 9 in test_http_server.py covering empty, filter, project scope,
  cross-project endpoints, limit cap, and limit clamp
- 1 in test_remote.py covering RemoteClient cross-project scoping with
  service.task_list as positive control

Full suite: 1803 passed, 12 skipped, 0 errors (10 new tests)

Docs-Reviewed: task graph endpoint addition, not an A2A comms change

Files:
 changelog.d/tsk-r6o224-task-list-edges.md |   3 +
 taosmd/http_server.py                     |  30 +++++++
 taosmd/remote.py                          |  23 +++++
 taosmd/service.py                         |  26 ++++++
 taosmd/tasks.py                           |  54 +++++++++++
 tests/test_http_server.py                 | 145 ++++++++++++++++++++++++++++++
 tests/test_remote.py                      |  28 ++++++
 7 files changed, 309 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to list task relationships (edges).
  * Supports filtering by source task, destination task, relationship type, and project.
  * Project filtering includes only relationships whose endpoints belong to that project.
  * Results can be limited to a maximum of 500 entries.
  * Added support for retrieving task relationships through remote connections.

* **Documentation**
  * Documented the new task relationships endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->