### PR TITLE
install-skill silently keeps a stale skill forever: no version check, exit 0, 'already installed'

### DIFF
--- a/changelog.d/tsk-tkayq4-install-skill-versioning.md
+++ b/changelog.d/tsk-tkayq4-install-skill-versioning.md
@@ -1,0 +1,2 @@
+### Fixed
+- `taosmd install-skill` now compares the packaged skill `version` (from the SKILL.md frontmatter) against the installed copy and records a content hash in a `.taosmd-skill-manifest.json` at install time. A stale install with a newer package upgrades in place by default (no longer silently exits 0 with "already installed"); a copy carrying local edits is refused without `--force` so user edits are never silently clobbered.

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -8,9 +8,12 @@ shell (e.g. compaction, re-indexing, exporting an agent's shelf).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 from .agents import (
     AgentExistsError,
@@ -610,10 +613,78 @@ def _a2a_poll_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
-def _install_skill_cmd(args: argparse.Namespace) -> int:
-    """Handle ``taosmd install-skill``: copy the packaged skill into ~/.claude/skills/."""
+# ----- taosmd-a2a skill install helpers --------------------------------
+
+
+def _parse_skill_version(skill_md: Path) -> str | None:
+    """Read the ``version`` field from a SKILL.md YAML frontmatter block."""
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("---", 3)
+    if end == -1:
+        return None
+    m = re.search(r"^version:\s*(\S.*)$", text[3:end], re.MULTILINE)
+    return m.group(1).strip().strip("\"'") if m else None
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _skill_manifest_path(dest_dir: Path) -> Path:
+    return dest_dir / ".taosmd-skill-manifest.json"
+
+
+def _write_skill_manifest(dest_dir: Path, version: str | None) -> None:
+    manifest = {
+        "skill": "taosmd-a2a",
+        "version": version,
+        "skill_md_sha256": _sha256(dest_dir / "SKILL.md"),
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _skill_manifest_path(dest_dir).write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _has_local_edits(installed_md: Path, packaged_md: Path, manifest: Path) -> bool:
+    """True when the installed SKILL.md diverges from the copy we last placed.
+
+    A manifest hash recorded at install time is the primary signal: if the
+    installed content no longer matches it, user edits are assumed. With no
+    manifest (pre-versioning installs) we fall back to a content diff that
+    ignores the ``version`` line, since that line is the whole point of a bump.
+    """
+    if manifest.exists():
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        expected = data.get("skill_md_sha256")
+        if expected is None:
+            return False
+        return _sha256(installed_md) != expected
+
+    def _body(text: str) -> list[str]:
+        return [
+            ln for ln in text.splitlines() if not ln.strip().startswith("version:")
+        ]
+
+    return (
+        _body(installed_md.read_text(encoding="utf-8"))
+        != _body(packaged_md.read_text(encoding="utf-8"))
+    )
+
+
+def _copy_skill_tree(src_dir: Path, dest_dir: Path) -> None:
     import shutil  # noqa: PLC0415
-    from pathlib import Path  # noqa: PLC0415
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(str(src_dir), str(dest_dir), dirs_exist_ok=True)
+
+
+def _install_skill_cmd(args: argparse.Namespace) -> int:
+    """Handle ``taosmd install-skill``: copy the taosmd-a2a skill into ~/.claude/skills/."""
     from importlib.resources import files as _pkg_files  # noqa: PLC0415
 
     dest_dir = Path("~/.claude/skills/taosmd-a2a").expanduser()
@@ -622,8 +693,7 @@ def _install_skill_cmd(args: argparse.Namespace) -> int:
     if not skill_src_dir.is_dir():
         # Fallback: try importlib.resources (wheel installs)
         try:
-            _ref = _pkg_files("taosmd").joinpath("skills/taosmd-a2a")
-            # Convert Traversable to a concrete path via __file__ approach.
+            _pkg_files("taosmd").joinpath("skills/taosmd-a2a")
             skill_src_dir = Path(__file__).parent / "skills" / "taosmd-a2a"
         except Exception:
             pass
@@ -633,16 +703,68 @@ def _install_skill_cmd(args: argparse.Namespace) -> int:
         print("  Re-install the package to include skill assets.", file=sys.stderr)
         return 2
 
-    force = getattr(args, "force", False)
-    skill_md = dest_dir / "SKILL.md"
-    if skill_md.exists() and not force:
-        print(f"Skill already installed at {dest_dir}")
-        print("  Re-run with --force to overwrite.")
+    return _run_install_skill(
+        skill_src_dir, dest_dir, getattr(args, "force", False)
+    )
+
+
+def _run_install_skill(src_dir: Path, dest_dir: Path, force: bool) -> int:
+    """Core install/upgrade logic for the taosmd-a2a skill.
+
+    Compares the packaged version (from the SKILL.md frontmatter) against the
+    installed copy, using a content hash recorded at install time to detect
+    local edits. A newer package without local edits upgrades by default; a
+    copy carrying local edits is never clobbered without ``--force``.
+    """
+    packaged_md = src_dir / "SKILL.md"
+    installed_md = dest_dir / "SKILL.md"
+    manifest = _skill_manifest_path(dest_dir)
+    packaged_version = _parse_skill_version(packaged_md) or "0.0.0"
+
+    if not installed_md.exists():
+        _copy_skill_tree(src_dir, dest_dir)
+        _write_skill_manifest(dest_dir, packaged_version)
+        print(f"taosmd-a2a skill installed at {dest_dir} (v{packaged_version})")
         return 0
 
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(str(skill_src_dir), str(dest_dir), dirs_exist_ok=True)
-    print(f"taosmd-a2a skill installed at {dest_dir}")
+    installed_version = _parse_skill_version(installed_md)
+    has_local_edits = _has_local_edits(installed_md, packaged_md, manifest)
+    inst_repr = installed_version or "unknown (pre-versioning)"
+
+    if force:
+        _copy_skill_tree(src_dir, dest_dir)
+        _write_skill_manifest(dest_dir, packaged_version)
+        label = "overwriting local edits" if has_local_edits else "upgrading"
+        print(
+            f"taosmd-a2a skill {label}: "
+            f"v{inst_repr} -> v{packaged_version}"
+        )
+        return 0
+
+    if installed_version == packaged_version and not has_local_edits:
+        print(
+            f"taosmd-a2a skill already installed, up to date "
+            f"(v{packaged_version})."
+        )
+        return 0
+
+    if has_local_edits:
+        print(
+            f"error: taosmd-a2a skill has local edits "
+            f"(installed v{inst_repr}, packaged v{packaged_version}).",
+            file=sys.stderr,
+        )
+        print(
+            "  Refusing to overwrite local edits; re-run with --force to clobber.",
+            file=sys.stderr,
+        )
+        print("  taosmd install-skill --force", file=sys.stderr)
+        return 1
+
+    # Packaged version is newer and the installed copy is clean: upgrade.
+    _copy_skill_tree(src_dir, dest_dir)
+    _write_skill_manifest(dest_dir, packaged_version)
+    print(f"taosmd-a2a skill upgraded: v{inst_repr} -> v{packaged_version}")
     return 0
 
 

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -10,6 +10,27 @@ taOSmd's A2A bus lets any number of agents (Claude Code, Cursor, OpenClaw, or an
 
 ---
 
+## Check whether your installed skill is current
+
+`taosmd install-skill` copies the `taosmd-a2a` skill into
+`~/.claude/skills/taosmd-a2a/` only when the packaged copy is newer (it now
+records a `version` in each skill's `SKILL.md` frontmatter and a content hash at
+install time). Compare the installed version against the packaged one to confirm
+you are current:
+
+```
+# Installed version (a blank line means the skill is not installed):
+grep -m1 '^version:' ~/.claude/skills/taosmd-a2a/SKILL.md || echo "not installed"
+# Packaged version shipped with your taosmd:
+python -c "import taosmd,pathlib,re; p=pathlib.Path(taosmd.__file__).parent/'skills'/'taosmd-a2a'/'SKILL.md'; print(re.search(r'version: *(\S+)', p.read_text()).group(1))"
+```
+
+Re-running `taosmd install-skill` also reports both versions, and if the installed
+copy was edited locally it tells you to re-run with `--force` rather than silently
+clobbering your edits.
+
+---
+
 ## Step 1: Ensure taOSmd is installed
 
 Run:

--- a/taosmd/skills/taosmd-a2a/SKILL.md
+++ b/taosmd/skills/taosmd-a2a/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: taosmd-a2a
+version: 1.0.0
 description: Set up agent-to-agent comms and named channels via the taOSmd A2A bus.
 user-invocable: true
 ---

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,143 @@
+"""Tests for the versioned ``taosmd install-skill`` path.
+
+``taosmd install-skill`` compares the packaged skill ``version`` (read from
+the SKILL.md frontmatter) against the installed copy and records a content
+hash in a ``.taosmd-skill-manifest.json`` at install time. The behaviours
+under test:
+
+* a stale install with a newer package upgrades by default (non-silent, the
+  file actually changes);
+* identical copies stay quiet and exit 0;
+* a locally-edited copy is never clobbered without ``--force``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from taosmd.cli import _run_install_skill
+
+
+MANIFEST_NAME = ".taosmd-skill-manifest.json"
+
+
+def _write_skill(dest_dir, version, body="skill body"):
+    """Write a SKILL.md with the given frontmatter version into dest_dir."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    text = f"---\nname: taosmd-a2a\nversion: {version}\n---\n{body}\n"
+    (dest_dir / "SKILL.md").write_text(text)
+    return text
+
+
+def _sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_fresh_install_writes_skill_and_manifest(tmp_path):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+
+    rc = _run_install_skill(src, dest, force=False)
+    assert rc == 0
+    assert (dest / "SKILL.md").exists()
+    assert (dest / MANIFEST_NAME).exists()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.0.0"
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_identical_copy_is_quiet_and_exits_zero(tmp_path, capsys):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src, dest, force=False)  # fresh install
+    capsys.readouterr()  # clear
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "up to date" in out.out
+    assert out.err == ""
+
+
+def test_stale_clean_copy_upgrades_by_default(tmp_path, capsys):
+    """A stale install whose content still matches the recorded hash upgrades."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)  # install v1.0.0
+    before = (dest / "SKILL.md").read_text()
+
+    # Packaged skill evolves: newer version + new content.
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body\nnew a2a-watch / a2a-bridge lines")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "upgrad" in out.out.lower()  # non-silent
+    after = (dest / "SKILL.md").read_text()
+    assert after != before  # non-zero-change: the file actually advanced
+    assert "1.1.0" in after
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_locally_edited_copy_not_clobbered_without_force(tmp_path, capsys):
+    """Newer package + a user edit is refused without --force (zero-loss)."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)  # install v1.0.0 baseline
+
+    # Packaged skill evolves to 1.1, AND the user edits their copy in parallel.
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body\nnew lines")
+
+    edited = (dest / "SKILL.md").read_text() + "\n# local edit by user\n"
+    (dest / "SKILL.md").write_text(edited)
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    out = capsys.readouterr()
+    assert rc != 0
+    assert "local edits" in out.err
+    assert "--force" in out.err
+    assert (dest / "SKILL.md").read_text() == edited  # not clobbered
+
+    rc2 = _run_install_skill(src_v2, dest, force=True)
+    new_text = (dest / "SKILL.md").read_text()
+    assert rc2 == 0
+    assert new_text != edited
+    assert "1.1.0" in new_text
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_pre_versioning_stale_copy_refuses_without_force(tmp_path, capsys):
+    """A copy with no version field and no manifest is unknown provenance."""
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "SKILL.md").write_text(
+        "---\nname: taosmd-a2a\n---\nold body, no version\n"
+    )
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc != 0
+    assert "local edits" in out.err
+    assert "unknown (pre-versioning)" in out.err
+    # Not overwritten, no manifest written on a refused run.
+    assert (dest / "SKILL.md").read_text() == "---\nname: taosmd-a2a\n---\nold body, no version\n"
+    assert not (dest / MANIFEST_NAME).exists()
+
+    # --force upgrades it and records a manifest.
+    rc2 = _run_install_skill(src, dest, force=True)
+    capsys.readouterr()  # consume
+    assert rc2 == 0
+    assert "1.0.0" in (dest / "SKILL.md").read_text()
+    assert (dest / MANIFEST_NAME).exists()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -437,8 +437,8 @@ def test_install_skill_copies_skill(tmp_path, monkeypatch):
     assert "taosmd-a2a" in content
 
 
-def test_install_skill_idempotent_without_force(tmp_path, monkeypatch):
-    """Second install-skill call without --force returns 0 and does not overwrite."""
+def test_install_skill_idempotent_without_force(tmp_path, monkeypatch, capsys):
+    """A locally-modified install is not overwritten without --force; it warns and exits non-zero."""
     import argparse  # noqa: PLC0415
     from taosmd.cli import _install_skill_cmd  # noqa: PLC0415
     import pathlib  # noqa: PLC0415
@@ -459,15 +459,17 @@ def test_install_skill_idempotent_without_force(tmp_path, monkeypatch):
     args_first = argparse.Namespace(force=False)
     _install_skill_cmd(args_first)
 
-    # Write a sentinel into the destination to verify idempotency.
+    # Corrupting the installed file means it no longer matches the recorded hash.
     skill_dest = fake_home / ".claude" / "skills" / "taosmd-a2a" / "SKILL.md"
     skill_dest.write_text("sentinel content")
 
     args_second = argparse.Namespace(force=False)
     rc = _install_skill_cmd(args_second)
-    assert rc == 0
-    # Content should still be the sentinel (not overwritten).
+    assert rc != 0
     assert skill_dest.read_text() == "sentinel content"
+    err = capsys.readouterr().err
+    assert "local edits" in err
+    assert "--force" in err
 
 
 def test_install_skill_force_overwrites(tmp_path, monkeypatch):


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): install-skill silently keeps a stale skill forever: no version check, exit 0, 'already installed'

Autonomous build of board card tsk-tkayq4.

install-skill now compares the packaged version (read from the SKILL.md
frontmatter) against the installed copy and records a content hash in a
.taosmd-skill-manifest.json at install time. A stale install with a newer
package upgrades in place by default; a copy carrying local edits is refused
without --force so user edits are never silently clobbered. Pre-versioning
copies without a manifest are treated as unknown provenance and also require
--force rather than reporting success while changing nothing.

Adds changelog fragment and a version-check one-liner to a2a-comms.md.

Tests: 5 in test_install_skill.py plus the 3 install-skill tests in
test_remote.py; all pass (88 total across install/remote/doc-gate suites).

Files:
 changelog.d/tsk-tkayq4-install-skill-versioning.md |   2 +
 taosmd/cli.py                                      | 148 +++++++++++++++++++--
 taosmd/docs/a2a-comms.md                           |  21 +++
 taosmd/skills/taosmd-a2a/SKILL.md                  |   1 +
 tests/test_install_skill.py                        | 143 ++++++++++++++++++++
 tests/test_remote.py                               |  12 +-
 6 files changed, 309 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version-aware skill installation and upgrades.
  * Installations now record version, content hash, and timestamp metadata.
  * Clean outdated installations upgrade automatically.
  * Locally edited installations are protected and require `--force` to overwrite.
  * Added version verification guidance for the `taosmd-a2a` skill.

* **Bug Fixes**
  * Improved detection and reporting of modified or unknown installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->