### PR TITLE
fix(merge-gate): check_bot_anchoring must FETCH the inline comment count, not just read a field that is never present

### DIFF
--- a/changelog.d/tsk-q7dnww-bot-anchoring-inline-comments.md
+++ b/changelog.d/tsk-q7dnww-bot-anchoring-inline-comments.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `check_bot_anchoring.sh` now fetches PR reviews via `gh api graphql` so the
+  `comments.totalCount` field is available, replacing the `includesCreatedEdit`
+  heuristic that `gh pr view --json reviews` never populated with inline
+  comment counts. A bot review with an empty body and only inline comments is
+  now correctly detected as substantive.

--- a/scripts/merge-gate/check_bot_anchoring.sh
+++ b/scripts/merge-gate/check_bot_anchoring.sh
@@ -8,7 +8,31 @@ fi
 
 PR_NUMBER="$1"
 
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,headRefOid,reviews 2>/dev/null) || {
+REPO_JSON=$(gh repo view --json owner,name 2>/dev/null) || {
+    echo "FAILED: gh/network error"
+    exit 3
+}
+OWNER=$(echo "$REPO_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['owner']['login'])")
+REPO=$(echo "$REPO_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+
+PR_JSON=$(gh api graphql -f query='
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      number
+      headRefOid
+      reviews(first:50) {
+        nodes {
+          author { login }
+          state
+          body
+          commit { oid }
+          comments { totalCount }
+        }
+      }
+    }
+  }
+}' -F owner="$OWNER" -F repo="$REPO" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest' 2>/dev/null) || {
     echo "FAILED: gh/network error"
     exit 3
 }
@@ -23,7 +47,7 @@ except json.JSONDecodeError:
     sys.exit(3)
 
 head_oid = data.get('headRefOid', '')
-reviews = data.get('reviews', [])
+reviews = data.get('reviews', {}).get('nodes', [])
 bot_authors = {'coderabbitai', 'qodo-code-review', 'kilo-code-bot'}
 
 for r in reviews:
@@ -37,7 +61,7 @@ for r in reviews:
     if commit_oid != head_oid:
         continue
     body = r.get('body') or ''
-    has_inline = r.get('includesCreatedEdit', False)
+    has_inline = (r.get('comments') or {}).get('totalCount', 0) > 0
     if body.strip() or has_inline:
         print('SUCCESS: anchored substantive bot review found')
         sys.exit(0)

--- a/tests/fixtures/merge_gate/pr_anchored_head.json
+++ b/tests/fixtures/merge_gate/pr_anchored_head.json
@@ -1,22 +1,26 @@
 {
   "number": 218,
   "headRefOid": "abc123def456",
-  "reviews": [
-    {
-      "author": {"login": "coderabbitai"},
-      "state": "COMMENTED",
-      "body": "<details><summary>Nitpick comments (1)</summary><blockquote>\n\n**Add coverage for the new import-tracking table.**\n</blockquote></details>",
-      "commit": {"oid": "abc123def456"},
-      "includesCreatedEdit": false,
-      "submittedAt": "2026-07-28T12:21:45Z"
-    },
-    {
-      "author": {"login": "qodo-code-review"},
-      "state": "COMMENTED",
-      "body": "",
-      "commit": {"oid": "abc123def456"},
-      "includesCreatedEdit": false,
-      "submittedAt": "2026-07-28T12:22:07Z"
-    }
-  ]
+  "reviews": {
+    "nodes": [
+      {
+        "author": {"login": "coderabbitai"},
+        "state": "COMMENTED",
+        "body": "<details><summary>Nitpick comments (1)</summary><blockquote>\n\n**Add coverage for the new import-tracking table.**\n</blockquote></details>",
+        "commit": {"oid": "abc123def456"},
+        "comments": {"totalCount": 0},
+        "includesCreatedEdit": false,
+        "submittedAt": "2026-07-28T12:21:45Z"
+      },
+      {
+        "author": {"login": "qodo-code-review"},
+        "state": "COMMENTED",
+        "body": "",
+        "commit": {"oid": "abc123def456"},
+        "comments": {"totalCount": 0},
+        "includesCreatedEdit": false,
+        "submittedAt": "2026-07-28T12:22:07Z"
+      }
+    ]
+  }
 }

--- a/tests/fixtures/merge_gate/pr_anchored_old_sha.json
+++ b/tests/fixtures/merge_gate/pr_anchored_old_sha.json
@@ -1,14 +1,17 @@
 {
   "number": 218,
   "headRefOid": "abc123def456",
-  "reviews": [
-    {
-      "author": {"login": "coderabbitai"},
-      "state": "COMMENTED",
-      "body": "Review content here",
-      "commit": {"oid": "oldsha123456"},
-      "includesCreatedEdit": false,
-      "submittedAt": "2026-07-28T12:21:45Z"
-    }
-  ]
+  "reviews": {
+    "nodes": [
+      {
+        "author": {"login": "coderabbitai"},
+        "state": "COMMENTED",
+        "body": "Review content here",
+        "commit": {"oid": "oldsha123456"},
+        "comments": {"totalCount": 0},
+        "includesCreatedEdit": false,
+        "submittedAt": "2026-07-28T12:21:45Z"
+      }
+    ]
+  }
 }

--- a/tests/fixtures/merge_gate/pr_human_only.json
+++ b/tests/fixtures/merge_gate/pr_human_only.json
@@ -1,14 +1,17 @@
 {
   "number": 218,
   "headRefOid": "abc123def456",
-  "reviews": [
-    {
-      "author": {"login": "jaylfc"},
-      "state": "APPROVED",
-      "body": "LGTM",
-      "commit": {"oid": "abc123def456"},
-      "includesCreatedEdit": false,
-      "submittedAt": "2026-07-28T12:30:00Z"
-    }
-  ]
+  "reviews": {
+    "nodes": [
+      {
+        "author": {"login": "jaylfc"},
+        "state": "APPROVED",
+        "body": "LGTM",
+        "commit": {"oid": "abc123def456"},
+        "comments": {"totalCount": 0},
+        "includesCreatedEdit": false,
+        "submittedAt": "2026-07-28T12:30:00Z"
+      }
+    ]
+  }
 }

--- a/tests/fixtures/merge_gate/pr_inline_only.json
+++ b/tests/fixtures/merge_gate/pr_inline_only.json
@@ -1,0 +1,21 @@
+{
+    "headRefOid": "4fc4bd016efe0a035b28a31586d76e919c9f19ca",
+    "number": 267,
+    "reviews": {
+        "nodes": [
+            {
+                "author": {
+                    "login": "kilo-code-bot"
+                },
+                "body": "",
+                "comments": {
+                    "totalCount": 7
+                },
+                "commit": {
+                    "oid": "4fc4bd016efe0a035b28a31586d76e919c9f19ca"
+                },
+                "state": "COMMENTED"
+            }
+        ]
+    }
+}

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -3,7 +3,6 @@ import subprocess
 import stat
 
 
-
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "merge_gate")
 
 
@@ -32,6 +31,9 @@ def main():
         print(REPO)
         return
     if a[0] == 'api' and len(a) > 1:
+        if a[1] == 'graphql':
+            print(PR)
+            return
         p = a[1]
         if 'status' in p:
             print(STATUS)
@@ -62,12 +64,23 @@ def _run(script, args, tmpdir, **fixtures):
     return result
 
 
+def _run_anchoring(tmp_path, pr_number="267", pr_fixture="pr_inline_only.json"):
+    return _run(
+        "check_bot_anchoring.sh",
+        [pr_number],
+        str(tmp_path),
+        pr=_read(pr_fixture),
+        repo=_read("repo_info.json"),
+    )
+
+
 def test_anchored_head_passes(tmp_path):
     result = _run(
         "check_bot_anchoring.sh",
         ["218"],
         str(tmp_path),
         pr=_read("pr_anchored_head.json"),
+        repo=_read("repo_info.json"),
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert result.stdout.startswith("SUCCESS:")
@@ -79,6 +92,7 @@ def test_anchored_old_sha_fails(tmp_path):
         ["218"],
         str(tmp_path),
         pr=_read("pr_anchored_old_sha.json"),
+        repo=_read("repo_info.json"),
     )
     assert result.returncode == 10, result.stdout + result.stderr
     assert result.stdout.startswith("FAILED:")
@@ -90,6 +104,7 @@ def test_human_only_fails(tmp_path):
         ["218"],
         str(tmp_path),
         pr=_read("pr_human_only.json"),
+        repo=_read("repo_info.json"),
     )
     assert result.returncode == 10, result.stdout + result.stderr
     assert result.stdout.startswith("FAILED:")
@@ -132,3 +147,45 @@ def test_red_first_usage_error():
     )
     assert result.returncode == 2
     assert result.stdout.startswith("FAILED:")
+
+
+def test_inline_only_review_rejected_by_buggy_logic(tmp_path):
+    """The pre-fix logic reads includesCreatedEdit (absent from GraphQL)
+    instead of comments.totalCount, so an inline-only bot review goes undetected."""
+    script_path = os.path.abspath(
+        os.path.join("scripts", "merge-gate", "check_bot_anchoring.sh")
+    )
+    fixed_script = open(script_path).read()
+    buggy_script = fixed_script.replace(
+        "has_inline = (r.get('comments') or {}).get('totalCount', 0) > 0",
+        "has_inline = r.get('includesCreatedEdit', False)",
+    )
+    assert buggy_script != fixed_script, "string replacement did not match"
+
+    buggy_path = os.path.join(str(tmp_path), "check_bot_anchoring_buggy.sh")
+    with open(buggy_path, "w") as f:
+        f.write(buggy_script)
+
+    _make_fake_gh(
+        str(tmp_path),
+        pr=_read("pr_inline_only.json"),
+        repo=_read("repo_info.json"),
+    )
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + ":" + env.get("PATH", "")
+    result = subprocess.run(
+        ["bash", buggy_path, "267"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 10, result.stdout + result.stderr
+    assert result.stdout.startswith("FAILED:")
+
+
+def test_inline_only_review_accepted_by_fix(tmp_path):
+    """The fixed logic reads comments.totalCount from the GraphQL payload,
+    so an inline-only bot review anchored to head is detected."""
+    result = _run_anchoring(tmp_path, "267")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.startswith("SUCCESS:")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix(merge-gate): check_bot_anchoring must FETCH the inline comment count, not just read a field that is never present

Autonomous build of board card tsk-q7dnww.

Replace `gh pr view --json reviews` (which never carries comments.totalCount)
with a `gh api graphql` query that includes reviews.nodes.comments.totalCount.
Derive OWNER and REPO from `gh repo view --json owner,name` instead of
hardcoding jaylfc/taosmd. Update the reviews iteration to read
data.reviews.nodes and the has_inline check to use comments.totalCount
instead of the absent includesCreatedEdit field.

Existing fixtures updated to the GraphQL nodes shape. pr_inline_only.json
captured from real PR #267 data (kilo-code-bot, empty body, 7 inline comments,
anchored to head). PR #279's two tests ported to the new payload shape, using
string replacement to derive the pre-fix script so they cannot drift.

Verification (6-PR loop, matching expected outcome exactly):
#267 SUCCESS, #272 SUCCESS, #276 SUCCESS
#274 FAILED, #275 FAILED, #277 FAILED

Fixture proof -- comm -23 fx.paths live.paths printed nothing, no fabricated
keys in pr_inline_only.json.

Positive control: #230 and #241 still print SUCCESS (non-empty-body branch
untouched). #244 now prints FAILED because its headRefOid 69a93ba does not
match the review commit fa0a516bcda... (head ref state change since the card
was written; same result with the old `gh pr view --json` format, so this is
not a regression from the code change).

Tests: 8 passed (uv run --extra dev pytest tests/test_merge_gate.py -q)

Files:
 .../tsk-q7dnww-bot-anchoring-inline-comments.md    |  7 +++
 scripts/merge-gate/check_bot_anchoring.sh          | 30 +++++++++--
 tests/fixtures/merge_gate/pr_anchored_head.json    | 40 ++++++++-------
 tests/fixtures/merge_gate/pr_anchored_old_sha.json | 23 +++++----
 tests/fixtures/merge_gate/pr_human_only.json       | 23 +++++----
 tests/fixtures/merge_gate/pr_inline_only.json      | 21 ++++++++
 tests/test_merge_gate.py                           | 59 +++++++++++++++++++++-
 7 files changed, 161 insertions(+), 42 deletions(-)