### PR TITLE
Raw bus: 400 on unrecognised query params (after= and since_id= are silently dropped today)

### DIFF
--- a/changelog.d/tsk-g35u5n-raw-bus-strict-params.md
+++ b/changelog.d/tsk-g35u5n-raw-bus-strict-params.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The A2A read endpoints (`GET /a2a/messages`, `GET /a2a/stream`, `GET /a2a/mentions`, and all other `GET /a2a/*`) now reject unknown query parameters with HTTP 400, naming both the offending parameter and the accepted set. This closes the silent-dropping defect where `after=` and `since_id=` (message-id cursors that these endpoints never accepted) were silently ignored, making a misspelt cursor indistinguishable from a working one. The 400 surfaces match the controller proxy (taOS #2390). No shipped client in this repo sends `after` or `since_id` to these endpoints.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -525,6 +525,25 @@ stored in `a2a_alarm_state` and survives restarts. Use
 Each channel in `/a2a/channels` has shape:
 `{"channel", "members", "message_count", "created_ts", "last_ts"}`
 
+### Strict query parameters
+
+Every `GET /a2a/*` endpoint rejects unknown query parameters with HTTP 400. The
+error response names both the offending parameter(s) and the accepted set, so a
+misspelt cursor (e.g. `after=` or `since_id=` on `/a2a/messages`, which only
+accepts `since` as a timestamp) is reported immediately rather than silently
+ignored. This mirrors the controller proxy (taOS #2390): an unknown query
+parameter is a 400, never a silent no-op. The accepted set is:
+
+| Endpoint | Accepted query parameters |
+|----------|--------------------------|
+| `GET /a2a/messages` | `thread`, `since`, `limit`, `fields`, `format` |
+| `GET /a2a/mentions` | `since`, `limit`, `reader` |
+| `GET /a2a/stream` | `thread`, `since` |
+| `GET /a2a/threads` | `principal` |
+| `GET /a2a/threads/{thread}/messages` | `before`, `after`, `limit` |
+| `GET /a2a/channels` | (none) |
+| `GET /a2a/members` | `channel` |
+
 ### MCP tools
 
 | Tool | Arguments | Returns |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -248,6 +248,16 @@ _A2A_MSG_MAX_LIMIT = 200
 
 
 def _validate_a2a_params(qs: dict, allowed: frozenset[str]) -> None:
+    """Reject query parameters not in *allowed* with HTTP 400.
+
+    General rule established here and on the authenticated controller proxy
+    (taOS #2390): an unknown query parameter is a 400, never a silent no-op.
+    A caller who misspells a parameter (e.g. ``after=`` or ``since_id=`` on
+    the feed endpoints, which only accept ``since``) must learn it immediately,
+    not infer it from results that look plausible.  The error message names
+    both the offending parameters and the accepted set so the caller can
+    self-correct in one round-trip.
+    """
     unknown = set(qs.keys()) - allowed
     if unknown:
         raise _BadRequest(

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -315,6 +315,146 @@ def test_http_a2a_members_unknown_param_returns_400(live_server):
 
 
 # ---------------------------------------------------------------------------
+# Cursor-shaped params that were silently dropped before strict validation:
+# after= and since_id= are NOT accepted on the feed/stream/messages endpoints
+# (they live on /a2a/threads/{thread}/messages, which is a different surface).
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_after_rejected_returns_400(live_server):
+    """after= is not a recognised param on /a2a/messages; must 400, not page."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "hi", "thread": "after-t"})
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=after-t&after=1"
+    )
+    assert status == 400, body
+    assert "after" in body["error"]
+
+
+def test_http_a2a_messages_since_id_rejected_returns_400(live_server):
+    """since_id= is not a recognised param on /a2a/messages; must 400, not page."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "hi", "thread": "since-id-t"})
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=since-id-t&since_id=1"
+    )
+    assert status == 400, body
+    assert "since_id" in body["error"]
+
+
+def test_http_a2a_stream_after_rejected_returns_400(live_server):
+    """after= is not accepted on /a2a/stream; must 400."""
+    status = _stream_status_code(
+        live_server, "/a2a/stream?thread=any&after=1"
+    )
+    assert status == 400
+
+
+def test_http_a2a_stream_since_id_rejected_returns_400(live_server):
+    """since_id= is not accepted on /a2a/stream; must 400."""
+    status = _stream_status_code(
+        live_server, "/a2a/stream?thread=any&since_id=1"
+    )
+    assert status == 400
+
+
+def test_http_a2a_mentions_after_rejected_returns_400(live_server):
+    """after= is not accepted on /a2a/mentions (the feed path); must 400."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "hi", "thread": "mention-after"})
+    status, body = _get(
+        f"{live_server}/a2a/mentions?reader=agentA&after=1"
+    )
+    assert status == 400, body
+    assert "after" in body["error"]
+
+
+def test_http_a2a_mentions_since_id_rejected_returns_400(live_server):
+    """since_id= is not accepted on /a2a/mentions; must 400."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "hi", "thread": "mention-since-id"})
+    status, body = _get(
+        f"{live_server}/a2a/mentions?reader=agentA&since_id=1"
+    )
+    assert status == 400, body
+    assert "since_id" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# Error shape: names both the offending param and the accepted set
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_error_names_accepted_set(live_server):
+    """The 400 error must name the offending parameter AND the accepted set."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "nameset"})
+    status, body = _get(
+        f"{live_server}/a2a/messages?thread=nameset&after=1"
+    )
+    assert status == 400, body
+    err = body["error"]
+    assert "after" in err
+    assert "thread" in err and "since" in err and "limit" in err
+    assert "fields" in err and "format" in err
+
+
+def test_http_a2a_mentions_error_names_accepted_set(live_server):
+    """The 400 error on /a2a/mentions names both the offending param and accepted set."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "nameset-m"})
+    status, body = _get(
+        f"{live_server}/a2a/mentions?reader=agentA&bogus=1"
+    )
+    assert status == 400, body
+    err = body["error"]
+    assert "bogus" in err
+    assert "reader" in err and "since" in err and "limit" in err
+
+
+# ---------------------------------------------------------------------------
+# Positive cases: every accepted param still works; no params still works
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_no_params_returns_200(live_server):
+    """A plain GET /a2a/messages with no query params must still work (200)."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "no-param msg", "thread": "noparams"})
+    status, body = _get(f"{live_server}/a2a/messages")
+    assert status == 200, body
+    assert "messages" in body
+
+
+def test_http_a2a_messages_all_accepted_params_return_200(live_server):
+    """All accepted params together on /a2a/messages must return 200, not 400."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "allparams", "thread": "allparams"})
+    ts = time.time() - 1
+    status, body = _get(
+        f"{live_server}/a2a/messages"
+        f"?thread=allparams&since={ts}&limit=10&fields=id,from,body&format=json"
+    )
+    assert status == 200, body
+    msgs = body["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "allparams"
+    assert set(msgs[0].keys()) == {"id", "from", "body"}
+
+
+def test_http_a2a_threads_no_params_returns_200(live_server):
+    """A plain GET /a2a/threads with no query params must still work (200)."""
+    status, body = _get(f"{live_server}/a2a/threads")
+    assert status == 200, body
+    assert "threads" in body
+
+
+def test_http_a2a_channels_no_params_returns_200(live_server):
+    """A plain GET /a2a/channels with no query params must still work (200)."""
+    status, body = _get(f"{live_server}/a2a/channels")
+    assert status == 200, body
+    assert "channels" in body
+
+
+# ---------------------------------------------------------------------------
 # SSE helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Raw bus: 400 on unrecognised query params (after= and since_id= are silently dropped today)

Autonomous build of board card tsk-g35u5n.

The A2A read endpoints (GET /a2a/messages, GET /a2a/stream, GET /a2a/mentions,
and all other GET /a2a/* paths) already reject unknown query parameters with
HTTP 400 via _validate_a2a_params (added in PR #393/taOS #2390). This commit
completes the tsk-g35u5n re-cut by adding the pieces that were still missing:

- Docstring on _validate_a2a_params stating the general rule: an unknown query
  parameter is a 400, never a silent no-op
- 12 tests covering the exact defect class: after= and since_id= are rejected
  on /a2a/messages, /a2a/stream, and /a2a/mentions; the error names both the
  offending parameter and the accepted set; all accepted params together still
  return 200; a request with no params still returns 200
- Docs in a2a-comms.md listing the accepted param set per endpoint
- Changelog fragment

Verified: 26 tests in test_a2a_kinds_strict_params.py pass, 132 A2A tests pass,
1805 total tests pass. doc-gate clean, ruff check clean, compileall clean.
No shipped client in this repo sends after or since_id to these read endpoints.

Files:
 changelog.d/tsk-g35u5n-raw-bus-strict-params.md |   3 +
 taosmd/docs/a2a-comms.md                        |  19 ++++
 taosmd/http_server.py                           |  10 ++
 tests/test_a2a_kinds_strict_params.py           | 140 ++++++++++++++++++++++++
 4 files changed, 172 insertions(+)