### PR TITLE
a2a-receipts.db runs with no WAL and no busy timeout: ReceiptStore bypasses _db.connect

### DIFF
--- a/changelog.d/tsk-tnig47-receipts-wal-busy-timeout.md
+++ b/changelog.d/tsk-tnig47-receipts-wal-busy-timeout.md
@@ -1,0 +1,9 @@
+### Fixed
+- `ReceiptStore` (a2a-receipts.db) now opens through `taosmd._db.connect`, engaging
+  WAL journal mode and a 5000 ms busy timeout like the other stores. Previously it
+  bypassed the shared helper via a raw `sqlite3.connect`, running in rollback-journal
+  mode with a zero busy timeout and raising `database is locked` under contention
+  instead of waiting and retrying. `_db.connect` gained an optional keyword-only
+  `check_same_thread` parameter (default `True` to preserve every existing call
+  site) so `ReceiptStore` can pass `check_same_thread=False` without a thread-affinity
+  crash.

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -26,14 +26,23 @@ from typing import Union
 BUSY_TIMEOUT_MS = 5000
 
 
-def connect(db_path: Union[str, Path]) -> sqlite3.Connection:
+def connect(
+    db_path: Union[str, Path],
+    *,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
     """Open a SQLite connection in WAL mode with a busy timeout.
 
     Drop-in replacement for ``sqlite3.connect(db_path)``. Callers that need a
     ``row_factory`` or other connection attributes should set them on the
     returned connection as before.
+
+    ``check_same_thread`` defaults to ``True`` to preserve sqlite3's default
+    thread-affinity contract for the 15 existing call sites. Stores driven by
+    async methods that may be awaited from any thread pass
+    ``check_same_thread=False`` explicitly (e.g. ``ReceiptStore``).
     """
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, check_same_thread=check_same_thread)
     # ``PRAGMA journal_mode`` echoes the journal mode actually in effect. WAL
     # can silently refuse to engage on filesystems without shared-memory/mmap
     # support (notably some network mounts), where it falls back to the prior

--- a/taosmd/receipts.py
+++ b/taosmd/receipts.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 
+from taosmd import _db
+
 __all__ = ["SCHEMA", "ReceiptStore"]
 
 logger = logging.getLogger(__name__)
@@ -41,11 +43,15 @@ CREATE INDEX IF NOT EXISTS idx_receipts_delivered ON a2a_receipts(delivered_at);
 
 
 class ReceiptStore:
-    """Thread-affine store for A2A read receipts.
+    """Store for A2A read receipts.
 
     All methods are async so callers can ``await`` them uniformly; the body
-    runs synchronously against a single SQLite connection, exactly like the
-    other taOSmd stores.
+    runs synchronously against a single SQLite connection. The connection is
+    opened through ``taosmd._db.connect`` (WAL journal mode, 5000 ms busy
+    timeout) with ``check_same_thread=False`` so the connection stays usable
+    from whichever thread drives the event loop -- this differs from the
+    thread-affine stores and is required because the async methods are not
+    guaranteed to run on the creating thread.
     """
 
     def __init__(self, db_path: str) -> None:
@@ -53,7 +59,7 @@ class ReceiptStore:
         self._conn: sqlite3.Connection | None = None
 
     async def init(self) -> None:
-        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn = _db.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
         self._conn.commit()

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -217,6 +217,69 @@ def test_receipt_store_seen_idempotent():
 
 
 # ---------------------------------------------------------------------------
+# Connection configuration: WAL + busy_timeout via _db.connect
+# ---------------------------------------------------------------------------
+
+def test_receipt_store_uses_wal_and_busy_timeout():
+    """ReceiptStore must open via _db.connect so WAL + busy_timeout are set.
+
+    The direct sqlite3.connect bypass (pre-taosmd #TNIG47) left the database in
+    rollback-journal mode with a zero busy timeout, surfacing
+    ``sqlite3.OperationalError: database is locked`` under contention instead of
+    waiting up to 5000 ms. This pins that regression.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "a2a-receipts.db")
+        store = receipts.ReceiptStore(db_path=db_path)
+        asyncio.run(store.init())
+        try:
+            mode = store._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            timeout = store._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            assert mode == "wal", mode
+            assert int(timeout) == 5000, timeout
+        finally:
+            asyncio.run(store.close())
+
+
+# ---------------------------------------------------------------------------
+# Thread-affinity: connection must stay usable across threads
+# ---------------------------------------------------------------------------
+
+def test_receipt_store_usable_from_non_creating_thread():
+    """check_same_thread=False keeps the connection usable cross-thread.
+
+    ReceiptStore's async methods may be driven by any event loop or thread, so
+    the connection must not demand thread affinity (the default for
+    ``sqlite3.connect``). This pins that behaviour so a naive swap back to the
+    default does not turn the concurrency fix into a thread-affinity crash.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "a2a-receipts.db")
+        store = receipts.ReceiptStore(db_path=db_path)
+        asyncio.run(store.init())  # connection created on the main thread
+        outcome: dict = {}
+
+        def worker() -> None:
+            try:
+                asyncio.run(store.record_delivered(1, "alice", 100.0))
+                got = asyncio.run(store.get_receipt(1, "alice"))
+                outcome["ok"] = got
+            except Exception as exc:  # noqa: BLE001
+                outcome["err"] = repr(exc)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        try:
+            assert "err" not in outcome, outcome.get("err")
+            assert outcome["ok"]["delivered_at"] == 100.0
+        finally:
+            asyncio.run(store.close())
+
+
+# ---------------------------------------------------------------------------
 # HTTP endpoint tests with valid registry tokens
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): a2a-receipts.db runs with no WAL and no busy timeout: ReceiptStore bypasses _db.connect

Autonomous build of board card tsk-tnig47.

ReceiptStore opened a2a-receipts.db with a raw sqlite3.connect, bypassing
taosmd._db.connect, so the database ran in rollback-journal mode with a zero
busy timeout (default 0 ms). Concurrent receipt writes raised
"sqlite3.OperationalError: database is locked" immediately instead of waiting
up to 5000 ms. Direct sibling MentionStore was unaffected.

Extend _db.connect with an optional keyword-only check_same_thread parameter
(defaults True to preserve all 15 existing single-arg call sites), then route
ReceiptStore.init through _db.connect(db_path, check_same_thread=False). The
False is deliberate: ReceiptStore's async methods may be driven by any thread,
and _db.connect takes no check_same_thread parameter, so a naive swap to
_db.connect(db_path) would trade this concurrency defect for a thread-affinity
crash. Also fix the docstring that falsely claimed the store runs "exactly like
the other taOSmd stores".

Added two tests in tests/test_receipts.py, scoped to that file:
- test_receipt_store_uses_wal_and_busy_timeout: PRAGMA journal_mode == wal
  and PRAGMA busy_timeout == 5000.
- test_receipt_store_usable_from_non_creating_thread: connection remains
  usable from a non-creating thread (pins check_same_thread=False).

Proof (pytest -p no:randomly tests/test_receipts.py, rc captured directly not
off a pipeline, failed count reported):
- WAL test RED vs unfixed code: "1 failed, 19 passed, rc=1" (journal_mode=delete)
- WAL test GREEN after fix: "20 passed, rc=0"
- Thread test RED via throwaway check_same_thread=True-default trap:
  "1 failed, rc=1" (ProgrammingError: SQLite objects created in a thread can
  only be used in that same thread)
- Thread test GREEN after revert of throwaway edit: "20 passed, rc=0"
- ruff check on changed files: "All checks passed!, rc=0"

changelog fragment: changelog.d/tsk-tnig47-receipts-wal-busy-timeout.md

Files:
 .../tsk-tnig47-receipts-wal-busy-timeout.md        |  9 ++++
 taosmd/_db.py                                      | 13 ++++-
 taosmd/receipts.py                                 | 14 +++--
 tests/test_receipts.py                             | 63 ++++++++++++++++++++++
 4 files changed, 93 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt database reliability during concurrent access by enabling WAL mode and a 5-second busy timeout.
  * Receipt storage can now safely operate across threads, preventing database locking and thread-affinity errors.

* **Tests**
  * Added coverage for concurrent database access and cross-thread receipt store usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->