### PR TITLE
GET /a2a/messages?limit=-1 returns the entire feed: the limit has no floor

### DIFF
--- a/changelog.d/tsk-2opv44-limit-negative rejection.md
+++ b/changelog.d/tsk-2opv44-limit-negative rejection.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- `GET /a2a/messages?limit=-1` now returns 400 instead of returning the entire message feed. SQLite treats `LIMIT -1` as unbounded, so negative limits are rejected with `_BadRequest`.

--- a/changelog.d/tsk-2opv44-limit-negative rejection.md
+++ b/changelog.d/tsk-2opv44-limit-negative rejection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /a2a/messages?limit=-1` now returns 400 instead of returning the entire message feed. SQLite treats `LIMIT -1` as unbounded, so negative limits are rejected with `_BadRequest`.

--- a/changelog.d/tsk-2opv44-limit-negative-rejection.md
+++ b/changelog.d/tsk-2opv44-limit-negative-rejection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /a2a/messages?limit=-1` now returns 400 instead of returning the entire message feed. SQLite treats `LIMIT -1` as unbounded, so negative limits are rejected with `_BadRequest`.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -463,6 +463,14 @@ a2a_members(channel="CHANNEL")
 |--------|------|------------|----------|
 | `POST` | `/a2a/send` | body JSON `{"from", "body", "thread"?, "reply_to"?}` | `{"id", "from", "thread", "reply_to"}` |
 | `GET`  | `/a2a/messages` | `?thread=&since=&limit=&fields=&format=` | `{"messages": [...]}`; `fields=id,sender,body` projects each message down to those keys; `format=ndjson` emits one message per line (`application/x-ndjson`) |
+
+`limit` on `GET /a2a/messages` is bounded below as well as parsed. A negative
+value is rejected with `400 'limit' must not be negative`, and a non-integer
+with `400 'limit' must be an integer`. `limit=0` is valid and returns zero
+messages. Omitting the parameter, including passing it empty, falls through to
+the default page size rather than to an unbounded read. The floor matters
+because SQLite treats `LIMIT -1` as unbounded, so a cap written as
+`min(limit, N)` clamps only above and `?limit=-1` would return the whole feed.
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1736,6 +1736,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            if limit_i < 0:
+                raise _BadRequest("'limit' must not be negative")
             if fmt not in ("json", "ndjson"):
                 raise _BadRequest("'format' must be 'json' or 'ndjson'")
             messages = runner.run(

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -124,6 +124,45 @@ def test_http_a2a_messages_unknown_param_returns_400(live_server):
 
 
 # ---------------------------------------------------------------------------
+# New: limit parameter validation
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_limit_negative_returns_400(live_server):
+    """?limit=-1 on /a2a/messages must 400; SQLite treats -1 as unbounded."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "limit-neg-test"})
+    for i in range(20):
+        _post(f"{live_server}/a2a/send",
+              {"from": "agentA", "body": f"msg{i}", "thread": "limit-neg-test"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=limit-neg-test&limit=-1")
+    assert status == 400, body
+
+
+def test_http_a2a_messages_limit_zero_returns_zero(live_server):
+    """?limit=0 on /a2a/messages must return 0 rows."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "limit-zero-test"})
+    for i in range(20):
+        _post(f"{live_server}/a2a/send",
+              {"from": "agentA", "body": f"msg{i}", "thread": "limit-zero-test"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=limit-zero-test&limit=0")
+    assert status == 200
+    assert len(body["messages"]) == 0
+
+
+def test_http_a2a_messages_limit_one_returns_one(live_server):
+    """?limit=1 on /a2a/messages must return exactly 1 row."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "limit-one-test"})
+    for i in range(20):
+        _post(f"{live_server}/a2a/send",
+              {"from": "agentA", "body": f"msg{i}", "thread": "limit-one-test"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=limit-one-test&limit=1")
+    assert status == 200
+    assert len(body["messages"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Gate (b): kind round-trips send -> messages -> stream
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): GET /a2a/messages?limit=-1 returns the entire feed: the limit has no floor

Autonomous build of board card tsk-2opv44.



Files:
 changelog.d/tsk-2opv44-limit-negative rejection.md |  3 ++
 taosmd/http_server.py                              |  2 ++
 tests/test_a2a_kinds_strict_params.py              | 39 ++++++++++++++++++++++
 3 files changed, 44 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Negative `limit` values for `GET /a2a/messages` now return a clear 400 error instead of potentially returning an unbounded number of messages.
  - `limit=0` is accepted and returns no messages.
  - Positive limits return the requested number of messages.

- **Documentation**
  - Updated endpoint documentation with validation rules and default behavior for the `limit` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->