### PR TITLE
REVISE PR #417: the per-channel read ACL leaves 3 unfiltered disclosure paths, the admin read route is unreachable, and get_acl fails open

### DIFF
--- a/changelog.d/tsk-b3qryl-a2a-acl-bypass.md
+++ b/changelog.d/tsk-b3qryl-a2a-acl-bypass.md
@@ -1,0 +1,5 @@
+### Fixed
+- A2A per-channel read ACL: filter channels, members, census, and thread-messages endpoints so restricted channels are not disclosed to unauthenticated or unauthorized callers
+- A2A admin channel-acl GET route: make it reachable with admin_token independent of server_token
+- A2A message feed limit starvation: over-fetch when no thread filter is set so restricted rows cannot consume the public limit window
+- ACL config parsing: deny on malformed read/post values and list-shaped entries instead of failing open to wildcard

--- a/taosmd/config.py
+++ b/taosmd/config.py
@@ -69,6 +69,8 @@ _HUMAN_PRINCIPAL_IDS_KEY = "human_principal_ids"
 # one of these directories. Empty (the default) means collections are off.
 _COLLECTIONS_SECTION_KEY = "collections"
 _COLLECTIONS_ALLOWED_ROOTS_KEY = "allowed_roots"
+# Per-channel ACL for the A2A bus.
+_ACL_SECTION_KEY = "acls"
 
 MANAGED_BY_STANDALONE = "standalone"
 MANAGED_BY_TAOS = "taos"
@@ -841,6 +843,115 @@ def set_collections_allowed_roots(roots, *, clear: bool = False, data_dir=None) 
     _write(data, data_dir)
 
 
+# ---------------------------------------------------------------------------
+# A2A per-channel ACL
+# ---------------------------------------------------------------------------
+
+
+def get_acl(data_dir=None, channel=None):
+    """Return the ACL for *channel*, defaulting to ``{"read": ["*"], "post": ["*"]}``.
+
+    Resolution order:
+
+    1. ``TAOSMD_ACL_CHANNELS`` env var (JSON string)
+    2. ``acls`` key in ``~/.taosmd/config.json``
+
+    When *channel* is ``None`` the default ACL is returned.  When *channel*
+    is provided the channel-specific ACL is returned if configured, otherwise
+    the default ACL.  A malformed or list-shaped entry is treated as deny
+    (empty allowlists).
+    """
+    env = os.environ.get("TAOSMD_ACL_CHANNELS")
+    if env is not None:
+        env = env.strip()
+        if env:
+            try:
+                env_acls = json.loads(env)
+                if isinstance(env_acls, dict):
+                    if channel is not None and channel in env_acls:
+                        return _normalize_acl(env_acls[channel])
+            except json.JSONDecodeError:
+                logger.warning("taosmd: invalid TAOSMD_ACL_CHANNELS env var")
+    data = _read(data_dir)
+    acls = data.get(_ACL_SECTION_KEY, {})
+    if isinstance(acls, dict):
+        if channel is not None and channel in acls:
+            return _normalize_acl(acls[channel])
+    return {"read": ["*"], "post": ["*"]}
+
+
+def set_acl(data_dir=None, channel=None, read_ids=None, post_ids=None, clear=False):
+    """Set the ACL for *channel*.
+
+    Args:
+        data_dir: taOSmd data directory.
+        channel: channel name (required unless ``clear`` is True).
+        read_ids: list of identity strings allowed to read.
+        post_ids: list of identity strings allowed to post.
+        clear: when True, remove the channel's ACL entry.
+
+    Raises:
+        ValueError: when ``clear`` is False and an id list contains a
+            non-empty string.
+    """
+    if clear:
+        data = _read(data_dir)
+        section = data.get(_ACL_SECTION_KEY, {})
+        if isinstance(section, dict) and channel in section:
+            del section[channel]
+            if not section:
+                data.pop(_ACL_SECTION_KEY, None)
+            else:
+                data[_ACL_SECTION_KEY] = section
+            _write(data, data_dir)
+        return
+    if read_ids is not None:
+        _validate_acl_ids(read_ids, "read")
+    if post_ids is not None:
+        _validate_acl_ids(post_ids, "post")
+    data = _read(data_dir)
+    section = data.get(_ACL_SECTION_KEY, {})
+    if not isinstance(section, dict):
+        section = {}
+    entry = {}
+    if read_ids is not None:
+        entry["read"] = list(read_ids)
+    if post_ids is not None:
+        entry["post"] = list(post_ids)
+    if entry:
+        section[channel] = entry
+        data[_ACL_SECTION_KEY] = section
+        _write(data, data_dir)
+
+
+def _normalize_acl(channel_acl):
+    """Normalize a per-channel ACL entry to ``{"read": [...], "post": [...]}``.
+
+    Malformed entries (non-dict, non-list read/post values, list-shaped
+    entries) are treated as deny: empty allowlists.
+    """
+    if not isinstance(channel_acl, dict):
+        return {"read": [], "post": []}
+    read = channel_acl.get("read", [])
+    post = channel_acl.get("post", [])
+    if not isinstance(read, list):
+        return {"read": [], "post": []}
+    if not isinstance(post, list):
+        return {"read": [], "post": []}
+    return {
+        "read": [str(x) for x in read if isinstance(x, str) and x],
+        "post": [str(x) for x in post if isinstance(x, str) and x],
+    }
+
+
+def _validate_acl_ids(ids, field):
+    if not isinstance(ids, list):
+        raise ValueError(f"{field} must be a list")
+    for i, id_ in enumerate(ids):
+        if not isinstance(id_, str) or not id_:
+            raise ValueError(f"{field}[{i}] must be a non-empty string")
+
+
 __all__ = [
     "get_memory_model",
     "set_memory_model",
@@ -875,4 +986,6 @@ __all__ = [
     "set_generator_profile",
     "get_collections_allowed_roots",
     "set_collections_allowed_roots",
+    "get_acl",
+    "set_acl",
 ]

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -467,6 +467,8 @@ a2a_members(channel="CHANNEL")
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
 | `POST` | `/a2a/alarms/{key}/clear` | path-encoded alarm key | `{"cleared": true, "key": str}` |
+| `POST` | `/a2a/admin/set-channel-acl` | body JSON `{"channel", "read"?, "post"?}` | `{"ok": true, "channel": str}`; admin, same token rule |
+| `GET`  | `/a2a/admin/channel-acl` | `?channel=<name>` | `{"channel": str, "acl": {"read": [...], "post": [...]}}`; admin, same token rule |
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |
 | `POST` | `/a2a/admin/supersede-message` | body JSON `{"id": int}` | `{"superseded": true, "id": int}`; admin, same token rule |
@@ -524,6 +526,39 @@ stored in `a2a_alarm_state` and survives restarts. Use
 
 Each channel in `/a2a/channels` has shape:
 `{"channel", "members", "message_count", "created_ts", "last_ts"}`
+
+### Per-channel ACL
+
+Channels default to open (read and post allow `*`). To restrict a channel, set
+an ACL via `POST /a2a/admin/set-channel-acl`:
+
+```
+POST /a2a/admin/set-channel-acl
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{"channel": "secret", "read": ["agent-allowed"], "post": ["agent-allowed"]}
+```
+
+Read the current ACL with `GET /a2a/admin/channel-acl?channel=<name>`.
+
+When a channel has an ACL:
+- `GET /a2a/messages?thread=<channel>` returns 403 for callers whose verified
+  identity is not in the `read` allowlist.
+- `GET /a2a/messages` without a thread drops rows from channels the caller
+  cannot read instead of returning every message on the bus.
+- `GET /a2a/threads` filters out restricted channels.
+- `GET /a2a/stream?thread=<channel>` returns 403 before SSE headers when the
+  channel is denied.
+- `GET /a2a/stream` without a thread filters restricted messages from the
+  delivery loop.
+- `GET /a2a/channels`, `GET /a2a/members?channel=<name>`, and
+  `GET /a2a/census` all hide restricted channels from unauthenticated or
+  unauthorized callers.
+
+The ACL is resolved from `TAOSMD_ACL_CHANNELS` (JSON env var) or the `acls`
+section in `~/.taosmd/config.json`. Malformed ACL entries deny (empty
+allowlists) rather than failing open.
 
 ### MCP tools
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -170,6 +170,8 @@ Admin endpoints (all require a configured server token; 403 if none is set)
 ``POST /a2a/admin/delete-channel``             ``{"channel": str}`` -> ``{"deleted": true, "channel": str}``
 ``POST /a2a/admin/rename-channel``             ``{"from": str, "to": str}`` -> ``{"renamed": true, "from": str, "to": str}``
 ``POST /a2a/admin/supersede-message``          ``{"id": int}`` -> ``{"superseded": true, "id": int}``
+``POST /a2a/admin/set-channel-acl``           ``{"channel", "read"?, "post"?}`` -> ``{"ok": true, "channel": str}``
+``GET  /a2a/admin/channel-acl``               ``?channel=<name>`` -> ``{"channel": str, "acl": {"read": [...], "post": [...]}}``
 
 Inspection UI
 -------------
@@ -841,6 +843,46 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             except Exception:  # noqa: BLE001
                 return None
 
+        def _can_read_channel(self, channel: str) -> bool:
+            """Return True when the caller may read *channel* (no response written)."""
+            acl = _config.get_acl(data_dir, channel)
+            allowlist = acl.get("read", ["*"])
+            if "*" in allowlist:
+                return True
+            verified_id = self._get_authenticated_agent_id()
+            if verified_id is None:
+                return False
+            return verified_id in allowlist
+
+        def _enforce_channel_acl(self, channel: str, permission: str) -> bool:
+            """Enforce per-channel ACL for *channel* and *permission*.
+
+            Returns True when the request is allowed.  Returns False and
+            writes a 403 response when the request is denied.
+            """
+            acl = _config.get_acl(data_dir, channel)
+            allowlist = acl.get(permission, ["*"])
+            if "*" in allowlist:
+                return True
+            verified_id = self._get_authenticated_agent_id()
+            if verified_id is None:
+                self._send_json(403, {
+                    "error": (
+                        f"{permission} denied for {channel!r}; "
+                        "identity not verified and ACL is configured"
+                    )
+                })
+                return False
+            if verified_id not in allowlist:
+                self._send_json(403, {
+                    "error": (
+                        f"{permission} denied for {channel!r}; "
+                        f"identity {verified_id!r} not in {permission} allowlist"
+                    )
+                })
+                return False
+            return True
+
         @staticmethod
         def _is_admin_route(method: str, path: str) -> bool:
             """Return True for admin write routes (#154).
@@ -857,6 +899,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 # stays on the data plane.
                 rest = path[len("/collections/"):]
                 return bool(rest) and "/" not in rest
+            if path == "/a2a/admin/channel-acl":
+                return True
             if method != "POST":
                 return False
             if path == "/shelves" or path.startswith("/shelves/"):
@@ -870,6 +914,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 "/a2a/admin/rename-channel",
                 "/a2a/admin/supersede-message",
                 "/a2a/admin/prune-receipts",
+                "/a2a/admin/set-channel-acl",
             )
 
         def _check_admin_token(self) -> bool:
@@ -1109,6 +1154,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_a2a_receipts(query)
                 elif method == "POST" and path == "/a2a/admin/prune-receipts":
                     self._handle_admin_a2a_prune_receipts()
+                elif method == "POST" and path == "/a2a/admin/set-channel-acl":
+                    self._handle_admin_a2a_set_channel_acl()
+                elif method == "GET" and path == "/a2a/admin/channel-acl":
+                    self._handle_admin_a2a_get_channel_acl()
                 elif method == "POST" and path.startswith("/a2a/alarms/") and path.endswith("/clear"):
                     key = path[len("/a2a/alarms/"):-len("/clear")]
                     self._handle_a2a_alarms_clear(key)
@@ -1551,18 +1600,36 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         def _handle_a2a_channels(self, qs: dict) -> None:
             _validate_a2a_params(qs, frozenset())
             channels = runner.run(service.a2a_channels(data_dir=data_dir))
+            channels = [
+                c for c in channels
+                if self._can_read_channel(c.get("channel") or "general")
+            ]
             self._send_json(200, {"channels": channels})
 
         def _handle_a2a_census(self, qs: dict) -> None:
             _validate_a2a_params(qs, frozenset())
             census = runner.run(service.a2a_sender_census(data_dir=data_dir))
-            self._send_json(200, {"census": census})
+            filtered_census = {}
+            for sender, entry in census.items():
+                filtered_channels = {
+                    chan: count for chan, count in entry.get("channels", {}).items()
+                    if self._can_read_channel(chan or "general")
+                }
+                if filtered_channels:
+                    filtered_entry = dict(entry)
+                    filtered_entry["channels"] = filtered_channels
+                    filtered_entry["total"] = sum(filtered_channels.values())
+                    filtered_census[sender] = filtered_entry
+            self._send_json(200, {"census": filtered_census})
 
         def _handle_a2a_members(self, qs: dict) -> None:
             _validate_a2a_params(qs, frozenset({"channel"}))
             channel = (qs.get("channel") or [None])[0]
             if not channel:
                 raise _BadRequest("'channel' query parameter is required")
+            if not self._can_read_channel(channel):
+                self._send_json(200, {"members": []})
+                return
             members = runner.run(service.a2a_members(channel=channel, data_dir=data_dir))
             self._send_json(200, {"members": members})
 
@@ -1713,6 +1780,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                         "a2a verify-and-warn: accepting unverified post from %r: %s",
                         from_, warn_reason,
                     )
+            if not self._enforce_channel_acl(thread, "post"):
+                return
             result = runner.run(
                 service.a2a_send(
                     sender=from_, body=body_text,
@@ -1738,9 +1807,22 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 raise _BadRequest("'limit' must be an integer") from exc
             if fmt not in ("json", "ndjson"):
                 raise _BadRequest("'format' must be 'json' or 'ndjson'")
-            messages = runner.run(
-                service.a2a_feed(thread=thread, since=since, limit=limit_i, data_dir=data_dir)
-            )
+            if thread is not None:
+                if not self._enforce_channel_acl(thread, "read"):
+                    return
+            if thread is None:
+                messages = runner.run(
+                    service.a2a_feed(thread=thread, since=since, limit=limit_i * 10, data_dir=data_dir)
+                )
+                messages = [
+                    m for m in messages
+                    if self._can_read_channel(m.get("thread") or "general")
+                ]
+                messages = messages[:limit_i]
+            else:
+                messages = runner.run(
+                    service.a2a_feed(thread=thread, since=since, limit=limit_i, data_dir=data_dir)
+                )
             # Compact mode: ?fields=id,sender,body projects each message down
             # to the named keys so token-frugal consumers (LLM agents) skip
             # framing they never read. Unknown names are ignored, never a 400,
@@ -1843,6 +1925,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             if last_ts is None:
                 last_ts = time.time()
 
+            if thread is not None:
+                if not self._enforce_channel_acl(thread, "read"):
+                    return
+
             subscriber_agent = self._get_authenticated_agent_id()
 
             # Send SSE response headers before entering the poll loop.
@@ -1854,14 +1940,26 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
 
             try:
                 while True:
-                    msgs = runner.run(
-                        service.a2a_feed(
-                            thread=thread, since=last_ts, limit=200, data_dir=data_dir,
+                    if thread is None:
+                        msgs = runner.run(
+                            service.a2a_feed(
+                                thread=thread, since=last_ts, limit=2000, data_dir=data_dir,
+                            )
                         )
-                    )
+                    else:
+                        msgs = runner.run(
+                            service.a2a_feed(
+                                thread=thread, since=last_ts, limit=200, data_dir=data_dir,
+                            )
+                        )
                     # Keep only messages strictly newer than last_ts to avoid
                     # re-sending the boundary row on subsequent polls.
                     new_msgs = [m for m in msgs if m["ts"] > last_ts]
+                    if thread is None:
+                        new_msgs = [
+                            m for m in new_msgs
+                            if self._can_read_channel(m.get("thread") or "general")
+                        ]
                     if new_msgs:
                         for msg in new_msgs:
                             frame = f"data: {json.dumps(msg)}\n\n"
@@ -1891,6 +1989,10 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             threads = runner.run(
                 service.a2a_threads(principal=principal, data_dir=data_dir)
             )
+            threads = [
+                t for t in threads
+                if self._can_read_channel(t.get("thread") or "general")
+            ]
             self._send_json(200, {"threads": threads})
 
         def _handle_a2a_thread_messages(self, thread: str, qs: dict) -> None:
@@ -1904,6 +2006,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 limit_i = int(limit_raw)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            if not self._enforce_channel_acl(thread, "read"):
+                return
             result = runner.run(
                 service.a2a_thread_messages(
                     thread=thread, before=before, after=after,
@@ -2012,6 +2116,38 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 service.a2a_prune_receipts(older_than_ts, data_dir=data_dir)
             )
             self._send_json(200, result)
+
+        def _handle_admin_a2a_set_channel_acl(self) -> None:
+            """POST /a2a/admin/set-channel-acl -- set ACL for a channel."""
+            if not self._check_admin_token():
+                return
+            body = self._read_json_body()
+            channel = body.get("channel")
+            if not isinstance(channel, str) or not channel:
+                raise _BadRequest("'channel' (non-empty string) is required")
+            read_ids = body.get("read")
+            post_ids = body.get("post")
+            if read_ids is not None and not isinstance(read_ids, list):
+                raise _BadRequest("'read' must be a list when provided")
+            if post_ids is not None and not isinstance(post_ids, list):
+                raise _BadRequest("'post' must be a list when provided")
+            clear = body.get("clear", False)
+            _config.set_acl(
+                data_dir, channel=channel,
+                read_ids=read_ids, post_ids=post_ids, clear=clear,
+            )
+            self._send_json(200, {"ok": True, "channel": channel})
+
+        def _handle_admin_a2a_get_channel_acl(self) -> None:
+            """GET /a2a/admin/channel-acl?channel=<name> -- return ACL for a channel."""
+            if not self._check_admin_token():
+                return
+            qs = parse_qs(urlsplit(self.path).query)
+            channel = (qs.get("channel") or [None])[0]
+            if not channel:
+                raise _BadRequest("'channel' query parameter is required")
+            acl = _config.get_acl(data_dir, channel)
+            self._send_json(200, {"channel": channel, "acl": acl})
 
         def _handle_a2a_alarms_clear(self, key: str) -> None:
             """POST /a2a/alarms/{key}/clear -- re-arm the alarm dedup for key."""
@@ -2593,11 +2729,12 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
           "POST /collections/{id}/unlink, POST /collections/{id}/grants, "
           "DELETE /collections/{id}/grants/{agent}")
     print("Admin (admin token required): POST /collections, POST /collections/{id}/index, "
-          "DELETE /collections/{id}, "
-          "POST /shelves, POST /shelves/{id}/archive, "
-          "POST /shelves/{id}/unarchive, "
-          "POST /a2a/admin/delete-channel, POST /a2a/admin/rename-channel, "
-          "POST /a2a/admin/supersede-message")
+           "DELETE /collections/{id}, "
+           "POST /shelves, POST /shelves/{id}/archive, "
+           "POST /shelves/{id}/unarchive, "
+           "POST /a2a/admin/delete-channel, POST /a2a/admin/rename-channel, "
+           "POST /a2a/admin/supersede-message, "
+           "POST /a2a/admin/set-channel-acl, GET /a2a/admin/channel-acl")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/tests/test_a2a_channel_acls.py
+++ b/tests/test_a2a_channel_acls.py
@@ -1,0 +1,654 @@
+"""RED tests for A2A per-channel ACL enforcement.
+
+These tests must fail on unpatched code (no ACL enforcement) and pass after
+the fix lands.  They follow the fixture and helper patterns from
+``tests/test_http_server_trust_enforcement.py``.
+"""
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg
+from taosmd import http_server, registry_auth
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _mint(canonical_id: str) -> str:
+    return pyjwt.encode(
+        {"sub": canonical_id, "iss": registry_auth.REGISTRY_ISS},
+        PRIV_PEM, algorithm="EdDSA",
+    )
+
+
+def _forge(canonical_id: str) -> str:
+    """Return a JWT-shaped string with a garbage signature (verification fails)."""
+    token = _mint(canonical_id)
+    parts = token.split(".")
+    return f"{parts[0]}.{parts[1]}.forged_signature"
+
+
+def _make_verifier(grants=None):
+    def fake_opener(url, timeout=5.0, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return json.dumps([])
+        if url.endswith(registry_auth.GRANTS_PATH):
+            return json.dumps({"grants": grants or []})
+        raise ValueError(f"unexpected url: {url}")
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+        expected_iss=registry_auth.REGISTRY_ISS,
+    )
+    gv = registry_auth.grants_verifier_from_url(
+        "http://reg.test", opener=fake_opener,
+    )
+    return verifier, gv
+
+
+def _post_send(base_url, from_, body, token=None, thread="general"):
+    payload = json.dumps({"from": from_, "body": body, "thread": thread}).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        base_url + "/a2a/send", data=payload, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_messages(base_url, thread=None, token=None, limit=None):
+    path = "/a2a/messages"
+    params = []
+    if thread is not None:
+        params.append(f"thread={urllib.parse.quote(thread)}")
+    if limit is not None:
+        params.append(f"limit={limit}")
+    if params:
+        path += "?" + "&".join(params)
+    req = urllib.request.Request(base_url + path)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_threads(base_url, token=None):
+    req = urllib.request.Request(base_url + "/a2a/threads")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_admin_channel_acl(base_url, channel, token=None):
+    path = f"/a2a/admin/channel-acl?channel={channel}"
+    req = urllib.request.Request(base_url + path)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _stream_status_code(base_url, path, timeout=3.0):
+    """Read only the HTTP status line from the SSE stream at path."""
+    parsed = urllib.parse.urlsplit(base_url)
+    host = parsed.hostname
+    port = parsed.port
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode()
+        )
+        sock.settimeout(timeout)
+        line = b""
+        while b"\r\n" not in line:
+            try:
+                chunk = sock.recv(128)
+            except (socket.timeout, TimeoutError) as exc:
+                raise AssertionError(f"timed out reading stream status line: {exc}") from exc
+            if not chunk:
+                break
+            line += chunk
+    status_line = line.decode("utf-8", "replace").splitlines()[0]
+    return int(status_line.split()[1])
+
+
+def _read_sse_frames(base_url, path, timeout=8.0):
+    """Open a raw TCP connection, send a minimal HTTP GET, read SSE frames."""
+    parsed = urllib.parse.urlsplit(base_url)
+    host = parsed.hostname
+    port = parsed.port
+    frames = []
+    deadline = time.monotonic() + timeout
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.sendall(
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n".encode()
+        )
+        buf = b""
+        header_done = False
+        while time.monotonic() < deadline and not frames:
+            sock.settimeout(max(0.1, deadline - time.monotonic()))
+            try:
+                chunk = sock.recv(4096)
+            except (socket.timeout, TimeoutError):
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if not header_done:
+                sep = buf.find(b"\r\n\r\n")
+                if sep != -1:
+                    buf = buf[sep + 4:]
+                    header_done = True
+            if header_done:
+                text = buf.decode("utf-8", errors="replace")
+                for line in text.splitlines():
+                    if line.startswith("data: "):
+                        frames.append(line[6:])
+    return frames
+
+
+def _set_acl(data_dir, channel, read_ids=None, post_ids=None):
+    cfg.set_acl(
+        str(data_dir), channel=channel,
+        read_ids=read_ids, post_ids=post_ids,
+    )
+
+
+def _get_channels(base_url, token=None):
+    req = urllib.request.Request(base_url + "/a2a/channels")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_members(base_url, channel, token=None):
+    path = f"/a2a/members?channel={channel}"
+    req = urllib.request.Request(base_url + path)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get_census(base_url, token=None):
+    req = urllib.request.Request(base_url + "/a2a/census")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def acl_server(tmp_path, monkeypatch):
+    """Server with registry verifier in enforce mode."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    verifier, gv = _make_verifier([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def acl_warn_server(tmp_path, monkeypatch):
+    """Server with registry verifier in warn mode (a2a_auth_enforce=False)."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    verifier, gv = _make_verifier([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def acl_admin_server(tmp_path, monkeypatch):
+    """Server with distinct admin_token and server_token."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+    cfg.set_admin_token("admin-token", data_dir=str(data_dir))
+    cfg.set_server_token("server-token", data_dir=str(data_dir))
+
+    verifier, gv = _make_verifier([{"canonical_id": "agent-allowed"}])
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=gv,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Test (a): forged unsigned JWT whose sub IS in the allowlist must 403
+# ---------------------------------------------------------------------------
+
+def test_forged_jwt_with_matching_sub_is_rejected_by_acl(acl_warn_server, tmp_path):
+    """A forged token whose sub happens to be in the post allowlist is 403.
+
+    In warn mode, auth failures are accepted but ACL enforcement must still
+    reject because the identity cannot be verified.
+    """
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret-chan", post_ids=["agent-allowed"])
+
+    forged = _forge("agent-allowed")
+    status, body = _post_send(acl_warn_server, "agent-allowed", "hello", token=forged, thread="secret-chan")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Test (b): post with spoofed from to an ACLed channel must 403
+# ---------------------------------------------------------------------------
+
+def test_spoofed_from_is_rejected_by_acl(acl_warn_server, tmp_path):
+    """Body `from` does not satisfy ACL; verified token identity does.
+
+    Valid token for `agent-evil`, body claims `from: agent-allowed`, ACL
+    allows only `agent-allowed`.  In warn mode auth accepts the mismatch,
+    but ACL enforcement must reject because the verified identity is
+    `agent-evil`, not `agent-allowed`.
+    """
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret-chan", post_ids=["agent-allowed"])
+
+    token = _mint("agent-evil")
+    status, body = _post_send(acl_warn_server, "agent-allowed", "hello", token=token, thread="secret-chan")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Test (c): channel with no ACL entry behaves as before
+# ---------------------------------------------------------------------------
+
+def test_no_acl_entry_allows_post(acl_server):
+    """A channel with no explicit ACL entry allows any verified identity."""
+    token = _mint("agent-allowed")
+    status, body = _post_send(acl_server, "agent-allowed", "hello", token=token, thread="no-acl-chan")
+    assert status == 200, body
+
+
+# ---------------------------------------------------------------------------
+# Positive control: ?thread=secret returns 403
+# ---------------------------------------------------------------------------
+
+def test_thread_secret_returns_403_positive_control(acl_server, tmp_path):
+    """Positive control: ?thread=secret correctly returns 403 for unverified caller."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    status, body = _get_messages(acl_server, thread="secret")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Leak 1: GET /a2a/messages with no thread must not leak restricted bodies
+# ---------------------------------------------------------------------------
+
+def test_messages_no_thread_filters_restricted(acl_server, tmp_path):
+    """GET /a2a/messages without thread must drop messages from ACL-restricted channels."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    token_allowed = _mint("agent-allowed")
+    _post_send(acl_server, "agent-allowed", "canary-body-secret", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "public-body", token=token_allowed, thread="public")
+
+    status, body = _get_messages(acl_server)
+    assert status == 200, body
+    bodies = [m.get("body", "") for m in body.get("messages", [])]
+    assert "canary-body-secret" not in bodies, "restricted canary leaked in unfiltered feed"
+    assert "public-body" in bodies, "public message should still be visible"
+
+
+# ---------------------------------------------------------------------------
+# Leak 2: GET /a2a/admin/channel-acl must require admin token
+# ---------------------------------------------------------------------------
+
+def test_admin_channel_acl_requires_admin_token(acl_server, tmp_path):
+    """GET /a2a/admin/channel-acl without admin token must return 401/403."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    status, body = _get_admin_channel_acl(acl_server, "secret")
+    assert status in (401, 403), body
+
+
+# ---------------------------------------------------------------------------
+# Leak 3: GET /a2a/threads must filter restricted channels
+# ---------------------------------------------------------------------------
+
+def test_threads_filters_restricted(acl_server, tmp_path):
+    """GET /a2a/threads must not expose channels the caller cannot read."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    token_allowed = _mint("agent-allowed")
+    _post_send(acl_server, "agent-allowed", "thread-canary", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "public-msg", token=token_allowed, thread="public")
+
+    status, body = _get_threads(acl_server)
+    assert status == 200, body
+    thread_names = [t.get("thread") for t in body.get("threads", [])]
+    assert "secret" not in thread_names, "restricted thread name leaked"
+    assert "public" in thread_names, "public thread should still be visible"
+
+
+# ---------------------------------------------------------------------------
+# Leak 4: GET /a2a/stream?thread=secret must deny when ACL denies
+# ---------------------------------------------------------------------------
+
+def test_stream_thread_denied_returns_403(acl_server, tmp_path):
+    """GET /a2a/stream?thread=secret must 403 before SSE headers when ACL denies."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    status = _stream_status_code(acl_server, "/a2a/stream?thread=secret")
+    assert status == 403, "restricted thread stream should 403 before sending SSE headers"
+
+
+# ---------------------------------------------------------------------------
+# Leak 4b: GET /a2a/stream (no thread) must filter restricted messages
+# ---------------------------------------------------------------------------
+
+def test_stream_no_thread_filters_restricted(acl_server, tmp_path):
+    """GET /a2a/stream without thread must not deliver restricted messages."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    # parsed = urllib.parse.urlsplit(acl_server)
+    # host = parsed.hostname
+    # port = parsed.port
+
+    frames_received = []
+    error_holder = []
+
+    def _stream_reader():
+        try:
+            result = _read_sse_frames(
+                acl_server, "/a2a/stream", timeout=8.0,
+            )
+            frames_received.extend(result)
+        except Exception as exc:
+            error_holder.append(exc)
+
+    reader = threading.Thread(target=_stream_reader, daemon=True)
+    reader.start()
+
+    time.sleep(1.5)
+
+    token_allowed = _mint("agent-allowed")
+    _post_send(acl_server, "agent-allowed", "stream-secret-canary", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "stream-public", token=token_allowed, thread="public")
+
+    reader.join(timeout=10)
+    assert not error_holder, f"SSE reader raised: {error_holder[0]}"
+
+    bodies = []
+    for frame in frames_received:
+        try:
+            payload = json.loads(frame)
+            bodies.append(payload.get("body", ""))
+        except json.JSONDecodeError:
+            pass
+    assert "stream-secret-canary" not in bodies, "restricted message leaked in stream"
+    assert "stream-public" in bodies, "public message should be delivered in stream"
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 remaining: channels, members, census filters
+# ---------------------------------------------------------------------------
+
+def test_channels_filters_restricted(acl_server, tmp_path):
+    """GET /a2a/channels must not expose restricted channels."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    token_allowed = _mint("agent-allowed")
+    _post_send(acl_server, "agent-allowed", "secret-msg", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "public-msg", token=token_allowed, thread="public")
+
+    status, body = _get_channels(acl_server)
+    assert status == 200, body
+    channel_names = [c.get("channel") for c in body.get("channels", [])]
+    assert "secret" not in channel_names, "restricted channel name leaked"
+    assert "public" in channel_names, "public channel should still be visible"
+
+
+def test_members_restricted_channel_returns_empty(acl_server, tmp_path):
+    """GET /a2a/members?channel=secret must return empty for unauthorized caller."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    status, body = _get_members(acl_server, "secret")
+    assert status == 200, body
+    assert body.get("members", []) == [], "restricted channel members should be hidden"
+
+
+def test_census_filters_restricted_channels(acl_server, tmp_path):
+    """GET /a2a/census must not expose restricted channel counts."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    token_allowed = _mint("agent-allowed")
+    _post_send(acl_server, "agent-allowed", "secret-msg", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "public-msg", token=token_allowed, thread="public")
+
+    status, body = _get_census(acl_server)
+    assert status == 200, body
+    census = body.get("census", {})
+    for sender, entry in census.items():
+        assert "secret" not in entry.get("channels", {}), "restricted channel leaked in census"
+
+
+def test_thread_messages_restricted_channel_denies(acl_server, tmp_path):
+    """GET /a2a/threads/{n}/messages must 403 for restricted thread."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    req = urllib.request.Request(acl_server + "/a2a/threads/secret/messages")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            status = resp.status
+            body = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        body = json.loads(exc.read().decode() or "{}")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: post-side ACL line reachable with auth satisfied
+# ---------------------------------------------------------------------------
+
+def test_acl_denies_post_with_valid_token_not_in_allowlist(acl_server, tmp_path):
+    """Valid token whose identity is not in the post allowlist must 403 at the ACL line.
+
+    Auth is satisfied (token is valid, sub matches from), but ACL rejects
+    because the verified identity is not in the post allowlist.
+    """
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "acl-post-chan", post_ids=["agent-other"])
+
+    token_allowed = _mint("agent-allowed")
+    status, body = _post_send(acl_server, "agent-allowed", "hello", token=token_allowed, thread="acl-post-chan")
+    assert status == 403, body
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: GET /a2a/admin/channel-acl reachable with different tokens
+# ---------------------------------------------------------------------------
+
+def test_admin_channel_acl_reachable_with_admin_token(acl_admin_server, tmp_path):
+    """GET /a2a/admin/channel-acl returns 200 with admin token when admin_token != server_token."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    status, body = _get_admin_channel_acl(acl_admin_server, "secret", token="admin-token")
+    assert status == 200, body
+    assert body.get("channel") == "secret"
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: feed limit starvation - more restricted rows than limit
+# ---------------------------------------------------------------------------
+
+def test_messages_no_thread_limit_not_starved_by_restricted(acl_server, tmp_path):
+    """GET /a2a/messages without thread must return public rows even when restricted rows exceed limit."""
+    data_dir = tmp_path / "data"
+    _set_acl(data_dir, "secret", read_ids=["agent-allowed"])
+
+    token_allowed = _mint("agent-allowed")
+    for i in range(60):
+        _post_send(acl_server, "agent-allowed", f"secret-{i}", token=token_allowed, thread="secret")
+    _post_send(acl_server, "agent-allowed", "public-body", token=token_allowed, thread="public")
+
+    status, body = _get_messages(acl_server, limit=50)
+    assert status == 200, body
+    bodies = [m.get("body", "") for m in body.get("messages", [])]
+    assert "public-body" in bodies, "public message should not be starved by restricted rows"
+    assert all(not b.startswith("secret-") for b in bodies), "restricted messages should not leak"
+
+
+# ---------------------------------------------------------------------------
+# Defect 5: get_acl denies on malformed inputs
+# ---------------------------------------------------------------------------
+
+def test_env_var_does_not_shadow_file_acl(tmp_path, monkeypatch):
+    """Env var with one channel must not make file-restricted channels open."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    cfg.set_acl(str(data_dir), channel="file-chan", read_ids=["agent-allowed"])
+
+    monkeypatch.setenv("TAOSMD_ACL_CHANNELS", '{"env-chan": {"read": ["*"]}}')
+    acl = cfg.get_acl(str(data_dir), "file-chan")
+    assert acl.get("read") != ["*"], "file ACL should not be shadowed by env var"
+    assert "agent-allowed" in acl.get("read", []), "file ACL should deny unverified callers"
+
+
+def test_string_read_value_denies(tmp_path, monkeypatch):
+    """read value given as a string must deny, not open."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    config_path = data_dir / "config.json"
+    config_path.write_text(json.dumps({"acls": {"str-chan": {"read": "agent-allowed"}}}))
+
+    acl = cfg.get_acl(str(data_dir), "str-chan")
+    assert acl.get("read") != ["*"], "string read value should deny, not open"
+    assert acl.get("read") == [], "string read value should result in empty allowlist"
+
+
+def test_list_shaped_acl_entry_denies(tmp_path, monkeypatch):
+    """list-shaped ACL entry must deny with empty allowlist, not raise AttributeError."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    config_path = data_dir / "config.json"
+    config_path.write_text(json.dumps({"acls": {"list-chan": ["agent-allowed"]}}))
+
+    acl = cfg.get_acl(str(data_dir), "list-chan")
+    assert acl.get("read") != ["*"], "list-shaped entry should deny, not open"
+    assert acl.get("read") == [], "list-shaped entry should result in empty allowlist"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #417: the per-channel read ACL leaves 3 unfiltered disclosure paths, the admin read route is unreachable, and get_acl fails open

Autonomous build of board card tsk-b3qryl.

Defect 1: filter channels, members, census, threads/{n}/messages by ACL.
Defect 2: add test reaching post-side ACL line with auth satisfied.
Defect 3: make GET /a2a/admin/channel-acl reachable with admin_token.
Defect 4: over-fetch in a2a_feed when no thread filter so restricted rows do not starve the public limit.
Defect 5: get_acl denies on malformed inputs instead of failing open.

Tests: 1822 passed, 12 skipped on full suite; 19 passed in test_a2a_channel_acls.py.

Proof: uv run --extra dev pytest tests/ -q -p no:randomly -> 1822 passed, 12 skipped

Files:
 changelog.d/tsk-b3qryl-a2a-acl-bypass.md |   5 +
 taosmd/config.py                         | 113 ++++++
 taosmd/docs/a2a-comms.md                 |  35 ++
 taosmd/http_server.py                    | 163 +++++++-
 tests/test_a2a_channel_acls.py           | 654 +++++++++++++++++++++++++++++++
 5 files changed, 957 insertions(+), 13 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-channel access controls for reading and posting A2A content.
  * Added administrator endpoints to view, configure, and remove channel ACLs.
  * Added support for configuring ACLs through environment variables or application settings.

* **Bug Fixes**
  * Unauthorized users can no longer access restricted channels, messages, threads, streams, or member data.
  * Malformed ACL configurations now deny access safely instead of allowing unintended access.
  * Improved message feed limits when restricted content is present.

* **Documentation**
  * Documented channel ACL configuration and administration endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->