### PR TITLE
GET /memories?limit=-1 is unbounded: the THIRD floorless-limit site, and the first outside /a2a and /tasks

### DIFF
--- a/changelog.d/tsk-au6qkw-memories-unbounded-limit.md
+++ b/changelog.d/tsk-au6qkw-memories-unbounded-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /memories` now rejects a negative `limit` with HTTP 400 (previously `limit=-1` flowed straight to SQLite `LIMIT ?`, where -1 means unbounded, leaking the entire archive). `limit=0` returns zero rows as documented, and positive limits are capped at 500.

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -247,6 +247,11 @@ _A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "
 _A2A_MSG_DEFAULT_LIMIT = 50
 _A2A_MSG_MAX_LIMIT = 200
 
+# Upper cap for GET /memories?limit=. Negative values are rejected (400), and
+# limit=0 yields zero rows (SQLite LIMIT 0). See tsk-au6qkw.
+_MEMORY_DEFAULT_LIMIT = 50
+_MEMORY_MAX_LIMIT = 500
+
 
 def _validate_a2a_params(qs: dict, allowed: frozenset[str]) -> None:
     unknown = set(qs.keys()) - allowed
@@ -1463,11 +1468,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
 
         def _handle_memories(self, qs: dict) -> None:
             scope = (qs.get("scope") or [None])[0]
-            limit = (qs.get("limit") or [50])[0]
+            limit = (qs.get("limit") or [_MEMORY_DEFAULT_LIMIT])[0]
             try:
                 limit_i = int(limit)
             except (TypeError, ValueError) as exc:
                 raise _BadRequest("'limit' must be an integer") from exc
+            if limit_i < 0:
+                raise _BadRequest("'limit' must be a non-negative integer")
+            limit_i = min(limit_i, _MEMORY_MAX_LIMIT)
             memories = runner.run(
                 service.list_memories(scope=scope, limit=limit_i, data_dir=data_dir)
             )

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1316,3 +1316,76 @@ def test_task_list_edges_limit_over_500_is_clamped(live_server):
     status, body = _get(f"{live_server}/tasks/edges?limit=9999")
     assert status == 200, body
     assert len(body["edges"]) == 9
+
+
+def _seed_memories(ctx, n: int, agent: str = "user") -> None:
+    """Seed *n* conversation rows directly into the archive index.
+
+    Used by bound tests that must seed more rows than the asserted cap.
+    """
+    arc = ctx.stores["archive"]
+
+    async def _seed() -> None:
+        for i in range(n):
+            await arc.record(
+                event_type="conversation",
+                data={"text": f"seed memory {i}"},
+                agent_name=agent,
+                summary=f"seed memory {i}",
+            )
+
+    ctx.run(_seed())
+
+
+_SEED_COUNT = 600
+
+
+@pytest.fixture
+def memories_server(live_server_ctx):
+    """Live server pre-seeded with 600 memories (more than the 500 cap)."""
+    _seed_memories(live_server_ctx, _SEED_COUNT)
+    return live_server_ctx.url
+
+
+def test_memories_negative_limit_rejected(memories_server):
+    """limit < 0 returns 400, not an unbounded dump (tsk-au6qkw).
+
+    The bug: -1 flowed straight to SQLite LIMIT ?, which treats -1 as
+    'no limit' and returned every row.
+    """
+    for bad in ("-1", "-999"):
+        status, body = _get(f"{memories_server}/memories?limit={bad}")
+        assert status == 400, body
+        assert "limit" in body["error"].lower()
+
+
+def test_memories_limit_zero_returns_empty(memories_server):
+    """limit=0 returns zero rows (settled contract, matches /a2a/messages)."""
+    status, body = _get(f"{memories_server}/memories?limit=0")
+    assert status == 200, body
+    assert len(body["memories"]) == 0
+
+
+def test_memories_default_limit(memories_server):
+    """No limit param -> default page size of 50."""
+    status, body = _get(f"{memories_server}/memories")
+    assert status == 200, body
+    assert len(body["memories"]) == 50
+
+
+def test_memories_limit_clamped_to_max(memories_server):
+    """limit > cap is clamped so callers cannot pull the whole archive.
+
+    Seeded _SEED_COUNT (600) rows, strictly more than _MEMORY_MAX_LIMIT
+    (500), so absent the cap this assertion would receive 600, not 500.
+    """
+    status, body = _get(f"{memories_server}/memories?limit=9999")
+    assert status == 200, body
+    assert len(body["memories"]) == 500
+
+
+def test_memories_limit_at_cap(memories_server):
+    """limit == cap returns exactly the cap."""
+    status, body = _get(f"{memories_server}/memories?limit=500")
+    assert status == 200, body
+    assert len(body["memories"]) == 500


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): GET /memories?limit=-1 is unbounded: the THIRD floorless-limit site, and the first outside /a2a and /tasks

Autonomous build of board card tsk-au6qkw.

Mechanism: _handle_memories passed limit_i straight through
service.list_memories -> api.list_memories ->
archive.list_memories, which interpolates it as SQLite
LIMIT ?. SQLite treats LIMIT -1 as unbounded, so
limit=-1 (and -999, etc.) returned the entire archive.

Fix: reject limit < 0 with HTTP 400 (floor), cap to
_MEMORY_MAX_LIMIT=500 (upper bound), and let limit=0
fall through to SQLite LIMIT 0 (zero rows) per the
settled /a2a/messages contract.

Tests seed 600 rows (> the 500 cap) so absent the cap the
clamped assertion would see 600, not 500. Mutant kills:
removing the floor makes test_memories_negative_limit_rejected
fail (1 FAILED, 0 ERROR); removing the cap makes
test_memories_limit_clamped_to_max fail (1 FAILED, 0 ERROR).

WHILE YOU ARE IN THERE report: GET /a2a/threads/{t}/messages
accepts limit=-1 with a 200 and returns 1 row of 60. This is
an inconsistency, not a disclosure: service.a2a_thread_messages
queries with a fixed limit=100_000 then applies
max(1, min(limit, 200)), silently clamping -1 to 1 row. No
data beyond what limit=1 returns is leaked, but the behavior
is inconsistent with /a2a/messages (400 on negative) and the
new /memories fix (400 on negative). Deserves its own card.

Docs-Reviewed: no files under tinyagentos/routes/ were modified;
the /memories endpoint is not in the http_server docstring table
(consistent with /stats, /graph, /generator-profile) so no doc
update is needed.

changelog: changelog.d/tsk-au6qkw-memories-unbounded-limit.md

Files:
 changelog.d/tsk-au6qkw-memories-unbounded-limit.md |  3 +
 taosmd/http_server.py                              | 10 ++-
 tests/test_http_server.py                          | 73 ++++++++++++++++++++++
 3 files changed, 85 insertions(+), 1 deletion(-)