### PR TITLE
mentions.py opens SQLite without check_same_thread=False under ThreadingHTTPServer: the same exposure #421 just closed for receipts

### DIFF
--- a/changelog.d/tsk-wxymim-mention-store-thread-affinity.md
+++ b/changelog.d/tsk-wxymim-mention-store-thread-affinity.md
@@ -1,0 +1,6 @@
+### Fixed
+- MentionStore opened its SQLite connection without `check_same_thread=False`, so
+  the thread-affine connection raised `ProgrammingError` when the A2A mention feed
+  was served from a `ThreadingHTTPServer` request thread other than the one that
+  created it. Routed through `taosmd._db.connect(..., check_same_thread=False)`,
+  matching the ReceiptStore fix.

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -26,14 +26,24 @@ from typing import Union
 BUSY_TIMEOUT_MS = 5000
 
 
-def connect(db_path: Union[str, Path]) -> sqlite3.Connection:
+def connect(
+    db_path: Union[str, Path],
+    *,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
     """Open a SQLite connection in WAL mode with a busy timeout.
 
     Drop-in replacement for ``sqlite3.connect(db_path)``. Callers that need a
     ``row_factory`` or other connection attributes should set them on the
     returned connection as before.
+
+    ``check_same_thread`` defaults to ``True`` to preserve sqlite3's default
+    thread-affinity contract for all existing call sites. Stores driven by
+    async methods that may be awaited from any thread pass
+    ``check_same_thread=False`` explicitly (e.g. ``ReceiptStore``,
+    ``MentionStore``).
     """
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, check_same_thread=check_same_thread)
     # ``PRAGMA journal_mode`` echoes the journal mode actually in effect. WAL
     # can silently refuse to engage on filesystems without shared-memory/mmap
     # support (notably some network mounts), where it falls back to the prior

--- a/taosmd/mentions.py
+++ b/taosmd/mentions.py
@@ -21,14 +21,23 @@ _MENTION_RE = re.compile(r'(?<![\w/])@([a-zA-Z0-9_-]+)')
 
 
 class MentionStore:
-    """Append-only mention index keyed by (mentioned_handle, message_id, ts, thread)."""
+    """Append-only mention index keyed by (mentioned_handle, message_id, ts, thread).
+
+    All methods are async so callers can ``await`` them uniformly; the body
+    runs synchronously against a single SQLite connection. The connection is
+    opened through ``taosmd._db.connect`` (WAL journal mode, 5000 ms busy
+    timeout) with ``check_same_thread=False`` so the connection stays usable
+    from whichever thread drives the event loop -- this differs from the
+    thread-affine stores and is required because the async methods are not
+    guaranteed to run on the creating thread.
+    """
 
     def __init__(self, db_path: str) -> None:
         self._db_path = db_path
         self._conn: sqlite3.Connection | None = None
 
     async def init(self) -> None:
-        self._conn = _db.connect(self._db_path)
+        self._conn = _db.connect(self._db_path, check_same_thread=False)
         self._conn.executescript("""
             CREATE TABLE IF NOT EXISTS mentions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/test_a2a_mentions.py
+++ b/tests/test_a2a_mentions.py
@@ -16,11 +16,13 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 import pytest
 
 from taosmd import api as taosmd_api
 from taosmd import http_server, service
+from taosmd import mentions as mentions_module
 from taosmd.registry_auth import REGISTRY_ISS
 
 pytest.importorskip("jwt")
@@ -236,6 +238,73 @@ def test_mention_store_multiple_handles_in_body(isolated_data_dir):
     bob_ids = asyncio.run(mentions.get_mentioned_message_ids("bob"))
     assert [r["message_id"] for r in alice_ids] == [1]
     assert [r["message_id"] for r in bob_ids] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Connection configuration: WAL + busy_timeout via _db.connect
+# ---------------------------------------------------------------------------
+
+def test_mention_store_uses_wal_and_busy_timeout():
+    """MentionStore must open via _db.connect so WAL + busy_timeout are set.
+
+    A direct sqlite3.connect bypass would leave the database in
+    rollback-journal mode with a zero busy timeout, surfacing
+    ``sqlite3.OperationalError: database is locked`` under contention instead
+    of waiting up to 5000 ms. This pins that regression.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "a2a-mentions.db")
+        store = mentions_module.MentionStore(db_path=db_path)
+        asyncio.run(store.init())
+        try:
+            mode = store._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            timeout = store._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            assert mode == "wal", mode
+            assert int(timeout) == 5000, timeout
+        finally:
+            asyncio.run(store.close())
+
+
+# ---------------------------------------------------------------------------
+# Thread-affinity: connection must stay usable across threads
+# ---------------------------------------------------------------------------
+
+def test_mention_store_usable_from_non_creating_thread():
+    """check_same_thread=False keeps the connection usable cross-thread.
+
+    MentionStore's async methods may be driven by any event loop or thread
+    (the A2A mention feed is served by ThreadingHTTPServer, which hands each
+    request to its own thread), so the connection must not demand thread
+    affinity (the default for ``sqlite3.connect``). This pins that behaviour
+    so a naive swap back to the default does not turn the concurrency fix into
+    a thread-affinity crash.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "a2a-mentions.db")
+        store = mentions_module.MentionStore(db_path=db_path)
+        asyncio.run(store.init())  # connection created on the main thread
+        outcome: dict = {}
+
+        def worker() -> None:
+            try:
+                asyncio.run(store.record_mentions(
+                    message_id=1, body="hello @bob", thread="t1", ts=100.0,
+                ))
+                ids = asyncio.run(store.get_mentioned_message_ids("bob"))
+                outcome["ok"] = [r["message_id"] for r in ids]
+            except Exception as exc:  # noqa: BLE001
+                outcome["err"] = repr(exc)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        try:
+            assert "err" not in outcome, outcome.get("err")
+            assert outcome["ok"] == [1]
+        finally:
+            asyncio.run(store.close())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): mentions.py opens SQLite without check_same_thread=False under ThreadingHTTPServer: the same exposure #421 just closed for receipts

Autonomous build of board card tsk-wxymim.

MentionStore.init() opened its SQLite connection via _db.connect(db_path),
which defaults to sqlite3.connect check_same_thread=True. The connection is
stored on the instance and reused across all async method calls (the store is
cached in _ensure_stores), so it is genuinely shared. Under the
ThreadingHTTPServer model (each request on its own thread) the connection
raised ProgrammingError when used from a thread other than the one that
created it. This is the same exposure PR #421 closed for ReceiptStore.

The fix:
- _db.connect gains a keyword-only check_same_thread parameter (default
  True), leaving all 15 existing single-arg call sites untouched -- zero
  blast radius on the shared helper.
- MentionStore.init passes check_same_thread=False, matching ReceiptStore.

Tests: two new tests in tests/test_a2a_mentions.py:
- test_mention_store_uses_wal_and_busy_timeout: pins WAL + 5000 ms timeout.
- test_mention_store_usable_from_non_creating_thread: spawns a real
  threading.Thread, writes, and reads back. RED with check_same_thread
  removed (ProgrammingError), GREEN with the fix.

Proof (pytest -p no:randomly tests/test_a2a_mentions.py):
  32 passed, 0 failed, 0 errors

Negative control (check_same_thread=True trap):
  1 failed, ProgrammingError: SQLite objects created in a thread can
  only be used in that same thread.

ruff check on changed files: All checks passed!

Files:
 .../tsk-wxymim-mention-store-thread-affinity.md    |  6 ++
 taosmd/_db.py                                      | 14 ++++-
 taosmd/mentions.py                                 | 13 +++-
 tests/test_a2a_mentions.py                         | 69 ++++++++++++++++++++++
 4 files changed, 98 insertions(+), 4 deletions(-)