### PR TITLE
The GET /a2a/census param validator is unpinned: deleting its validate call leaves the full suite green at 1821 passed

### DIFF
--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -308,6 +308,18 @@ def test_http_a2a_channels_unknown_param_returns_400(live_server):
     assert "bogus" in body["error"]
 
 
+def test_http_a2a_census_unknown_param_returns_400(live_server):
+    """Unknown query params on /a2a/census must 400 naming the param and allowed set.
+
+    The param carries a non-empty value so that parse_qs(keep_blank_values=False)
+    does not drop it before it reaches the validator.
+    """
+    status, body = _get(f"{live_server}/a2a/census?bogus=probe")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+    assert "allowed" in body["error"]
+
+
 def test_http_a2a_members_unknown_param_returns_400(live_server):
     status, body = _get(f"{live_server}/a2a/members?channel=general&bogus=1")
     assert status == 400, body


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The GET /a2a/census param validator is unpinned: deleting its validate call leaves the full suite green at 1821 passed

Autonomous build of board card tsk-54omyt.

The census handler's parameter validator had no test pinning it, unlike
every sibling /a2a GET endpoint (channels, members, messages, mentions,
stream, threads, thread_messages). Neutralizing its validate call left
the full suite green at 1821 passed, 10 skipped, 7 pre-existing errors.

Add test_http_a2a_census_unknown_param_returns_400, which sends
GET /a2a/census?bogus=probe -- a param carrying a non-empty value so
parse_qs(keep_blank_values=False) does not drop it before the validator
-- and asserts a 400 whose body names the offending parameter and the
allowed set.

Proof (mutation test): neutralizing the validate call on
http_server.py (card ref :1567, current line 1557) by replacing it with a
no-op, then running
  ./.venv/bin/python -m pytest -q -p no:randomly tests/test_a2a_kinds_strict_params.py
yields FAILED=1, ERRORS=0 -- only the new census test goes red, all 14
siblings stay green. On pristine source the same file passes 15. The 7
pre-existing suite-level import errors (rc=1) are identical across both
runs, confirming the red is the validator pin and not collateral damage.

Docs-Reviewed: test-only change, no feature or route code modified, not
user-visible

Files:
 tests/test_a2a_kinds_strict_params.py | 12 ++++++++++++
 1 file changed, 12 insertions(+)