### PR TITLE
The /a2a/inbox docs omit exclude_acked_by, and every auth test builds its verifier with expected_iss=None so the issuer pin production sets is unexercised

### DIFF
--- a/changelog.d/tsk-a526k2-a2a-inbox-unhandled.md
+++ b/changelog.d/tsk-a526k2-a2a-inbox-unhandled.md
@@ -1,0 +1,7 @@
+### Added
+
+- `GET /a2a/inbox/unhandled` returns messages past the consumer's cursor that are addressed to the consumer and have not been acknowledged. Registry auth gates apply; `exclude_acked_by` is forwarded through the remote path so local and remote answers agree. `a2a_inbox_unhandled` is also exported from `taosmd.service`.
+
+### Fixed
+
+- `a2a_inbox` now propagates `acked_by` on envelopes when present, and accepts `exclude_acked_by` to omit acknowledged messages before the limit budget is applied.

--- a/changelog.d/tsk-a526k2-a2a-inbox-unhandled.md
+++ b/changelog.d/tsk-a526k2-a2a-inbox-unhandled.md
@@ -1,7 +1,5 @@
-### Added
-
-- `GET /a2a/inbox/unhandled` returns messages past the consumer's cursor that are addressed to the consumer and have not been acknowledged. Registry auth gates apply; `exclude_acked_by` is forwarded through the remote path so local and remote answers agree. `a2a_inbox_unhandled` is also exported from `taosmd.service`.
-
 ### Fixed
 
 - `a2a_inbox` now propagates `acked_by` on envelopes when present, and accepts `exclude_acked_by` to omit acknowledged messages before the limit budget is applied.
+- A2A inbox auth tests now pin the registry issuer (`expected_iss=REGISTRY_ISS`) instead of leaving it unbound, and reject tokens carrying a different issuer. This covers the `/a2a/inbox`, `/a2a/inbox/advance`, `/a2a/ack`, and `/a2a/inbox/unhandled` auth paths.
+- `GET /a2a/inbox` parameter docs in `taosmd/docs/a2a-comms.md` and the `taosmd/http_server.py` module docstring now list `exclude_acked_by` and state that it omits messages already acknowledged by the named principal.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -466,7 +466,7 @@ a2a_members(channel="CHANNEL")
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
-| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=` | `{"messages": [...]}` |
+| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=&exclude_acked_by=` | `{"messages": [...]}` (`exclude_acked_by` omits messages already acknowledged by the named principal so the limit budget is spent only on unhandled messages) |
 | `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}` |
 | `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}` |
 | `GET`  | `/a2a/inbox/unhandled` | `?consumer=&limit=` | `{"messages": [...]}` |

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -466,6 +466,10 @@ a2a_members(channel="CHANNEL")
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
+| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=` | `{"messages": [...]}` |
+| `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}` |
+| `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}` |
+| `GET`  | `/a2a/inbox/unhandled` | `?consumer=&limit=` | `{"messages": [...]}` |
 | `POST` | `/a2a/alarms/{key}/clear` | path-encoded alarm key | `{"cleared": true, "key": str}` |
 | `POST` | `/a2a/admin/delete-channel` | body JSON `{"channel": str}` | `{"deleted": true, "channel": str}`; admin, requires the admin token (403 if no admin or server token is set) |
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -107,6 +107,10 @@ Endpoints
                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/mentions``    ``?since=&limit=&reader=``                  -> ``{"messages": [...]}`` (requires registry auth; ``reader`` is derived from the verified token ``sub``, or supplied as a query parameter when no verifier is configured)
+``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter)
+``POST /a2a/inbox/advance`` ``{"to_id": int}``                           -> ``{"ok": true}`` (principal derived from the verified token ``sub``)
+``POST /a2a/ack``          ``{"message_id": int}``                      -> ``{"id", "acked_by", "ok"}`` (``by`` derived from the verified token ``sub``)
+``GET  /a2a/inbox/unhandled`` ``?consumer=&limit=``                     -> ``{"messages": [...]}`` (composed query: mentions past cursor minus acks)
 ``GET  /a2a/stream``       ``?thread=&since=``             -> SSE stream (text/event-stream); ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400
 ``GET  /a2a/threads``      ``?principal=``                  -> ``{"threads": [...]}`` thread list for the principal, ordered by latest activity desc; each entry has ``thread``, ``kind``, ``participants``, ``last_message: {id, ts, from, body_preview}`` (see notes below)
 ``GET  /a2a/threads/{thread}/messages`` ``?before=&after=&limit=`` -> ``{"thread", "messages": [...]}`` cursor-paginated message envelope, oldest-first
@@ -1082,6 +1086,14 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_a2a_messages(query)
                 elif method == "GET" and path == "/a2a/mentions":
                     self._handle_a2a_mentions(query)
+                elif method == "GET" and path == "/a2a/inbox":
+                    self._handle_a2a_inbox(query)
+                elif method == "POST" and path == "/a2a/inbox/advance":
+                    self._handle_a2a_inbox_advance()
+                elif method == "POST" and path == "/a2a/ack":
+                    self._handle_a2a_ack()
+                elif method == "GET" and path == "/a2a/inbox/unhandled":
+                    self._handle_a2a_inbox_unhandled(query)
                 elif method == "GET" and path == "/a2a/stream":
                     self._handle_a2a_stream(query)
                     return  # SSE response already sent; skip _send_json error path
@@ -1817,6 +1829,129 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     )
             messages = runner.run(
                 service.a2a_mentions_feed(reader, since=since, limit=limit_i, data_dir=data_dir)
+            )
+            self._send_json(200, {"messages": messages})
+
+        def _handle_a2a_inbox(self, qs: dict) -> None:
+            """GET /a2a/inbox -- messages past the consumer's cursor.
+
+            ``consumer`` is derived from the verified registry token ``sub``
+            when a verifier is configured; otherwise it is required as a
+            query parameter.
+            """
+            _validate_a2a_params(qs, frozenset({"consumer", "limit", "include_kinds", "exclude_acked_by"}))
+            consumer_qp = (qs.get("consumer") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            include_kinds_raw = (qs.get("include_kinds") or [None])[0]
+            exclude_acked_by_raw = (qs.get("exclude_acked_by") or [None])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if _registry_verifier is not None:
+                token_consumer = self._get_authenticated_agent_id()
+                if token_consumer is None:
+                    self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                    return
+                if consumer_qp is not None:
+                    from .mentions import _normalise_handle  # noqa: PLC0415
+                    if _normalise_handle(consumer_qp) != _normalise_handle(token_consumer):
+                        self._send_json(403, {"error": "registry auth: consumer mismatch"})
+                        return
+                consumer = token_consumer
+            else:
+                consumer = consumer_qp
+                if not consumer:
+                    raise _BadRequest(
+                        "'consumer' query parameter is required when no registry verifier is configured"
+                    )
+            include_kinds = None
+            if include_kinds_raw:
+                include_kinds = [s.strip() for s in include_kinds_raw.split(",") if s.strip()]
+            exclude_acked_by = exclude_acked_by_raw if exclude_acked_by_raw else None
+            messages = runner.run(
+                service.a2a_inbox(consumer, limit=limit_i, include_kinds=include_kinds, exclude_acked_by=exclude_acked_by, data_dir=data_dir)
+            )
+            self._send_json(200, {"messages": messages})
+
+        def _handle_a2a_inbox_advance(self) -> None:
+            """POST /a2a/inbox/advance -- advance the caller's inbox cursor.
+
+            The consumer identity is derived from the verified registry token
+            ``sub``; ``to_id`` comes from the JSON body.
+            """
+            body = self._read_json_body()
+            to_id_raw = body.get("to_id")
+            if to_id_raw is None:
+                raise _BadRequest("'to_id' is required")
+            try:
+                to_id = int(to_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'to_id' must be an integer") from exc
+            consumer = self._get_authenticated_agent_id()
+            if consumer is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            runner.run(
+                service.a2a_inbox_advance(consumer, to_id, data_dir=data_dir)
+            )
+            self._send_json(200, {"ok": True})
+
+        def _handle_a2a_ack(self) -> None:
+            """POST /a2a/ack -- record an acknowledgement for a message.
+
+            The ``by`` principal is derived from the verified registry token
+            ``sub``; ``message_id`` comes from the JSON body.
+            """
+            body = self._read_json_body()
+            message_id_raw = body.get("message_id")
+            if message_id_raw is None:
+                raise _BadRequest("'message_id' is required")
+            try:
+                message_id = int(message_id_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'message_id' must be an integer") from exc
+            by = self._get_authenticated_agent_id()
+            if by is None:
+                self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                return
+            result = runner.run(
+                service.a2a_ack(message_id, by, data_dir=data_dir)
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_inbox_unhandled(self, qs: dict) -> None:
+            """GET /a2a/inbox/unhandled -- composed unhandled query.
+
+            Returns messages past the consumer's cursor that are addressed
+            to the consumer and have NOT been acknowledged by the consumer.
+            """
+            _validate_a2a_params(qs, frozenset({"consumer", "limit"}))
+            consumer_qp = (qs.get("consumer") or [None])[0]
+            limit_raw = (qs.get("limit") or [50])[0]
+            try:
+                limit_i = int(limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise _BadRequest("'limit' must be an integer") from exc
+            if _registry_verifier is not None:
+                token_consumer = self._get_authenticated_agent_id()
+                if token_consumer is None:
+                    self._send_json(401, {"error": "registry auth: Bearer token with sub claim required"})
+                    return
+                if consumer_qp is not None:
+                    from .mentions import _normalise_handle  # noqa: PLC0415
+                    if _normalise_handle(consumer_qp) != _normalise_handle(token_consumer):
+                        self._send_json(403, {"error": "registry auth: consumer mismatch"})
+                        return
+                consumer = token_consumer
+            else:
+                consumer = consumer_qp
+                if not consumer:
+                    raise _BadRequest(
+                        "'consumer' query parameter is required when no registry verifier is configured"
+                    )
+            messages = runner.run(
+                service.a2a_inbox_unhandled(consumer, limit=limit_i, data_dir=data_dir)
             )
             self._send_json(200, {"messages": messages})
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -107,7 +107,7 @@ Endpoints
                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/mentions``    ``?since=&limit=&reader=``                  -> ``{"messages": [...]}`` (requires registry auth; ``reader`` is derived from the verified token ``sub``, or supplied as a query parameter when no verifier is configured)
-``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter)
+``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=&exclude_acked_by=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter; ``exclude_acked_by`` omits messages already acknowledged by the named principal)
 ``POST /a2a/inbox/advance`` ``{"to_id": int}``                           -> ``{"ok": true}`` (principal derived from the verified token ``sub``)
 ``POST /a2a/ack``          ``{"message_id": int}``                      -> ``{"id", "acked_by", "ok"}`` (``by`` derived from the verified token ``sub``)
 ``GET  /a2a/inbox/unhandled`` ``?consumer=&limit=``                     -> ``{"messages": [...]}`` (composed query: mentions past cursor minus acks)

--- a/taosmd/remote.py
+++ b/taosmd/remote.py
@@ -245,6 +245,74 @@ class RemoteClient:
             "POST", f"/a2a/alarms/{urllib.parse.quote(alarm_key, safe='')}/clear", {},
         )
 
+    async def a2a_inbox(
+        self,
+        consumer: str,
+        *,
+        limit: int = 50,
+        include_kinds: list | None = None,
+        exclude_acked_by: str | None = None,
+        **_opts,
+    ) -> list[dict]:
+        """GET /a2a/inbox: return messages past ``consumer``'s cursor.
+
+        Returns the ``messages`` list from the server response.
+        """
+        params: dict = {"consumer": consumer, "limit": limit}
+        if include_kinds is not None:
+            params["include_kinds"] = ",".join(include_kinds)
+        if exclude_acked_by is not None:
+            params["exclude_acked_by"] = exclude_acked_by
+        resp = await self._run("GET", "/a2a/inbox", params=params)
+        return resp.get("messages", [])
+
+    async def a2a_inbox_advance(
+        self,
+        consumer: str,
+        to_id: int,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/inbox/advance: advance ``consumer``'s cursor to ``to_id``.
+
+        The ``consumer`` argument is accepted for API symmetry but is ignored
+        on the remote path; the server derives the principal from the
+        verified registry token ``sub``.
+
+        Returns ``{"ok": True}``.
+        """
+        return await self._run("POST", "/a2a/inbox/advance", {"to_id": to_id})
+
+    async def a2a_ack(
+        self,
+        message_id: int,
+        by: str,
+        **_opts,
+    ) -> dict:
+        """POST /a2a/ack: record that ``by`` has acknowledged ``message_id``.
+
+        The ``by`` argument is accepted for API symmetry but is ignored on
+        the remote path; the server derives the principal from the verified
+        registry token ``sub``.
+
+        Returns ``{"id", "acked_by", "ok"}``.
+        """
+        return await self._run("POST", "/a2a/ack", {"message_id": message_id})
+
+    async def a2a_inbox_unhandled(
+        self,
+        consumer: str,
+        *,
+        limit: int = 50,
+        **_opts,
+    ) -> list[dict]:
+        """GET /a2a/inbox/unhandled: return unhandled messages for ``consumer``.
+
+        Returns the ``messages`` list from the server response.
+        """
+        params: dict = {"consumer": consumer, "limit": limit}
+        resp = await self._run("GET", "/a2a/inbox/unhandled", params=params)
+        return resp.get("messages", [])
+
     async def a2a_feed(
         self,
         *,

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1204,6 +1204,7 @@ async def a2a_inbox(
     limit: int = 50,
     include_kinds: list | None = None,
     data_dir=None,
+    exclude_acked_by: str | None = None,
 ) -> list[dict]:
     """Return messages past ``consumer``'s cursor that are addressed to it.
 
@@ -1216,7 +1217,20 @@ async def a2a_inbox(
     ``alarm``, ``ack``, ``receipt``, and ``digest`` are excluded; pass
     ``include_kinds`` to widen the set.  Results are oldest-first.  Reading
     does NOT advance the cursor.
+
+    When ``exclude_acked_by`` is supplied, any message whose ``acked_by``
+    list contains that principal is omitted, so the caller's ``limit``
+    budget is spent only on messages that still need attention.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox(
+            consumer, limit=limit, include_kinds=include_kinds,
+            exclude_acked_by=exclude_acked_by,
+        )
     if not isinstance(consumer, str) or not consumer:
         raise ValueError("consumer must be a non-empty string")
     stores = await _api._ensure_stores(data_dir)
@@ -1262,6 +1276,10 @@ async def a2a_inbox(
                     break
         if not addressed:
             continue
+        if exclude_acked_by is not None:
+            acked_by = data.get("acked_by")
+            if isinstance(acked_by, list) and exclude_acked_by in acked_by:
+                continue
         msg = {
             "id": row["id"],
             "ts": row["timestamp"],
@@ -1275,6 +1293,8 @@ async def a2a_inbox(
             msg["refs"] = data["refs"]
         if "blocks" in data:
             msg["blocks"] = data["blocks"]
+        if "acked_by" in data:
+            msg["acked_by"] = data["acked_by"]
         result.append(msg)
 
     result.sort(key=lambda m: (m["ts"], m["id"]))
@@ -1292,7 +1312,13 @@ async def a2a_inbox_advance(
 
     The cursor is persisted in the archive store so it survives restarts
     and is visible to every process sharing the same data dir.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox_advance(consumer, to_id)
     if not isinstance(consumer, str) or not consumer:
         raise ValueError("consumer must be a non-empty string")
     if not isinstance(to_id, int) or to_id < 0:
@@ -1301,6 +1327,35 @@ async def a2a_inbox_advance(
     archive = stores["archive"]
     await archive.set_a2a_inbox_cursor(consumer, to_id)
     return {"ok": True}
+
+
+async def a2a_inbox_unhandled(
+    consumer: str,
+    *,
+    limit: int = 50,
+    data_dir=None,
+) -> list[dict]:
+    """Return unhandled messages for ``consumer``: addressed messages past the
+    consumer's cursor that the consumer has NOT yet acknowledged.
+
+    This is the composed "unhandled for X" query: it combines the server-side
+    cursor from :func:`a2a_inbox` with the ack state from :func:`a2a_ack`
+    so callers see only the messages that still need attention.  Because the
+    ack filter is applied before the ``limit``, acked messages do not consume
+    the caller's budget.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
+    """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_inbox_unhandled(consumer, limit=limit)
+    if not isinstance(consumer, str) or not consumer:
+        raise ValueError("consumer must be a non-empty string")
+    msgs = await a2a_inbox(
+        consumer, limit=limit, data_dir=data_dir, exclude_acked_by=consumer,
+    )
+    return msgs
 
 
 async def a2a_record_delivered(
@@ -1419,7 +1474,13 @@ async def a2a_ack(message_id: int, by: str, *, data_dir=None) -> dict:
     acks) is deferred to slice 2c, which needs 2a's server-side cursor.
 
     Returns ``{"id", "acked_by", "ok"}``.
+
+    When a remote server URL is configured the call is forwarded to
+    :class:`~taosmd.remote.RemoteClient` transparently.
     """
+    remote = _get_remote(data_dir)
+    if remote is not None:
+        return await remote.a2a_ack(message_id, by)
     if not isinstance(by, str) or not by:
         raise ValueError("by must be a non-empty string")
     stores = await _api._ensure_stores(data_dir)
@@ -1873,7 +1934,7 @@ __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "
            "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
-           "a2a_inbox", "a2a_inbox_advance",
+           "a2a_inbox", "a2a_inbox_advance", "a2a_inbox_unhandled",
            "task_create", "task_list", "task_ready", "task_prime",
            "task_update", "task_add_edge", "task_remove_edge", "task_projects",
            "admin_shelf_create", "admin_shelf_archive", "admin_shelf_unarchive",

--- a/tests/test_a2a_inbox_auth.py
+++ b/tests/test_a2a_inbox_auth.py
@@ -8,7 +8,6 @@ Covers:
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import threading
 import urllib.error
@@ -25,6 +24,7 @@ from cryptography.hazmat.primitives import serialization
 
 from taosmd import api as taosmd_api
 from taosmd import config as cfg, http_server, registry_auth
+from taosmd.registry_auth import REGISTRY_ISS
 
 
 # ---------------------------------------------------------------------------
@@ -49,10 +49,8 @@ REG_PRIV_PEM, REG_PUB_PEM = _keypair()
 OTHER_PRIV_PEM, _OTHER_PUB_PEM = _keypair()
 
 
-def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=None):
-    claims = {"sub": sub}
-    if iss is not None:
-        claims["iss"] = iss
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=REGISTRY_ISS):
+    claims = {"sub": sub, "iss": iss}
     return pyjwt.encode(claims, priv_pem, algorithm="EdDSA")
 
 
@@ -104,7 +102,7 @@ def authed_server(tmp_path, monkeypatch):
         return json.dumps([])
 
     verifier = registry_auth.verifier_from_url(
-        "http://reg.test", opener=fake_opener, expected_iss=None,
+        "http://reg.test", opener=fake_opener, expected_iss=registry_auth.REGISTRY_ISS,
     )
     httpd = http_server.make_server(
         "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
@@ -282,7 +280,6 @@ def test_inbox_unhandled_with_valid_matching_token_succeeds(authed_server, tmp_p
         token=token,
     )
     assert send_status == 200
-    msg_id = send_body["id"]
 
     status, body = _get(
         f"{authed_server}/a2a/inbox/unhandled",
@@ -293,7 +290,35 @@ def test_inbox_unhandled_with_valid_matching_token_succeeds(authed_server, tmp_p
 
 
 # ---------------------------------------------------------------------------
-# Gate (e): unknown query parameter -> 400 on unhandled
+# Gate (e): wrong issuer -> 401 on all endpoints
+# ---------------------------------------------------------------------------
+
+def test_inbox_with_wrong_issuer_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _get(f"{authed_server}/a2a/inbox", token=bad_token)
+    assert status == 401
+
+
+def test_inbox_advance_with_wrong_issuer_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5}, token=bad_token)
+    assert status == 401
+
+
+def test_ack_with_wrong_issuer_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1}, token=bad_token)
+    assert status == 401
+
+
+def test_inbox_unhandled_with_wrong_issuer_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled", token=bad_token)
+    assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# Gate (f): unknown query parameter -> 400 on unhandled
 # ---------------------------------------------------------------------------
 
 def test_inbox_unhandled_unknown_param_is_rejected(authed_server):

--- a/tests/test_a2a_inbox_auth.py
+++ b/tests/test_a2a_inbox_auth.py
@@ -1,0 +1,302 @@
+"""Registry auth guards for the A2A inbox, advance, ack, and unhandled HTTP endpoints.
+
+Covers:
+  (a) missing Bearer token -> 401 on all four endpoints
+  (b) token ``sub`` mismatch against the requested consumer -> 403 on inbox and unhandled
+  (c) bad-signature token -> 401 on advance, ack, and unhandled
+  (d) valid matching token -> 200 on all four endpoints
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as cfg, http_server, registry_auth
+
+
+# ---------------------------------------------------------------------------
+# Keypair / token helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+REG_PRIV_PEM, REG_PUB_PEM = _keypair()
+OTHER_PRIV_PEM, _OTHER_PUB_PEM = _keypair()
+
+
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=None):
+    claims = {"sub": sub}
+    if iss is not None:
+        claims["iss"] = iss
+    return pyjwt.encode(claims, priv_pem, algorithm="EdDSA")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _request(url, method, payload=None, token=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode()
+        try:
+            return exc.code, json.loads(body)
+        except json.JSONDecodeError:
+            return exc.code, {"error": body}
+
+
+def _get(url, token=None):
+    return _request(url, "GET", None, token)
+
+
+def _post(url, payload, token=None):
+    return _request(url, "POST", payload, token)
+
+
+# ---------------------------------------------------------------------------
+# Server fixture with registry verifier (enforce mode)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-inbox-auth"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None,
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): missing token -> 401
+# ---------------------------------------------------------------------------
+
+def test_inbox_without_token_is_rejected(authed_server):
+    status, _ = _get(f"{authed_server}/a2a/inbox")
+    assert status == 401
+
+
+def test_inbox_advance_without_token_is_rejected(authed_server):
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5})
+    assert status == 401
+
+
+def test_ack_without_token_is_rejected(authed_server):
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1})
+    assert status == 401
+
+
+def test_inbox_unhandled_without_token_is_rejected(authed_server):
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled")
+    assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# Gate (b): token sub mismatch against requested consumer -> 403 on inbox and unhandled
+# ---------------------------------------------------------------------------
+
+def test_inbox_consumer_mismatch_is_rejected(authed_server):
+    token = _make_token("agent-A")
+    status, _ = _get(f"{authed_server}/a2a/inbox?consumer=agent-B", token=token)
+    assert status == 403
+
+
+def test_inbox_unhandled_consumer_mismatch_is_rejected(authed_server):
+    token = _make_token("agent-A")
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled?consumer=agent-B", token=token)
+    assert status == 403
+
+
+# ---------------------------------------------------------------------------
+# Gate (c): bad-signature token -> 401 on advance, ack, and unhandled
+# ---------------------------------------------------------------------------
+
+def test_inbox_advance_with_bad_token_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", priv_pem=OTHER_PRIV_PEM)
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5}, token=bad_token)
+    assert status == 401
+
+
+def test_ack_with_bad_token_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", priv_pem=OTHER_PRIV_PEM)
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1}, token=bad_token)
+    assert status == 401
+
+
+def test_inbox_unhandled_with_bad_token_is_rejected(authed_server):
+    bad_token = _make_token("agent-1", priv_pem=OTHER_PRIV_PEM)
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled", token=bad_token)
+    assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# Gate (d): valid matching token -> 200 on all four endpoints
+# ---------------------------------------------------------------------------
+
+def test_inbox_with_valid_matching_token_succeeds(authed_server):
+    token = _make_token("agent-1")
+    status, body = _get(f"{authed_server}/a2a/inbox", token=token)
+    assert status == 200
+    assert "messages" in body
+
+
+def test_inbox_advance_with_valid_matching_token_succeeds(authed_server, tmp_path, monkeypatch):
+    dd = tmp_path / "inbox-advance-ok"
+    dd.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(dd)))
+    vmem = stores["vector"]
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+    token = _make_token("agent-1")
+    send_status, send_body = _post(
+        f"{authed_server}/a2a/send",
+        {"from": "agent-1", "body": "hello @agent-1", "thread": "general"},
+        token=token,
+    )
+    assert send_status == 200
+    msg_id = send_body["id"]
+
+    inbox_status, inbox_body = _get(f"{authed_server}/a2a/inbox", token=token)
+    assert inbox_status == 200
+    assert inbox_body.get("messages") == []
+
+    status, body = _post(
+        f"{authed_server}/a2a/inbox/advance",
+        {"to_id": msg_id},
+        token=token,
+    )
+    assert status == 200
+    assert body.get("ok") is True
+
+
+def test_ack_with_valid_matching_token_succeeds(authed_server, tmp_path, monkeypatch):
+    dd = tmp_path / "ack-ok"
+    dd.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(dd)))
+    vmem = stores["vector"]
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+    token = _make_token("agent-1")
+    send_status, send_body = _post(
+        f"{authed_server}/a2a/send",
+        {"from": "agent-1", "body": "ack me", "thread": "acks"},
+        token=token,
+    )
+    assert send_status == 200
+    msg_id = send_body["id"]
+
+    status, body = _post(
+        f"{authed_server}/a2a/ack",
+        {"message_id": msg_id},
+        token=token,
+    )
+    assert status == 200
+    assert body.get("ok") is True
+    assert body.get("id") == msg_id
+
+
+def test_inbox_unhandled_with_valid_matching_token_succeeds(authed_server, tmp_path, monkeypatch):
+    dd = tmp_path / "unhandled-ok"
+    dd.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(dd)))
+    vmem = stores["vector"]
+
+    async def _fake_embed(text, task="search_document"):
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+    token = _make_token("agent-1")
+    send_status, send_body = _post(
+        f"{authed_server}/a2a/send",
+        {"from": "agent-1", "body": "hello @agent-1", "thread": "general"},
+        token=token,
+    )
+    assert send_status == 200
+    msg_id = send_body["id"]
+
+    status, body = _get(
+        f"{authed_server}/a2a/inbox/unhandled",
+        token=token,
+    )
+    assert status == 200
+    assert "messages" in body
+
+
+# ---------------------------------------------------------------------------
+# Gate (e): unknown query parameter -> 400 on unhandled
+# ---------------------------------------------------------------------------
+
+def test_inbox_unhandled_unknown_param_is_rejected(authed_server):
+    token = _make_token("agent-1")
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled?foo=bar", token=token)
+    assert status == 400

--- a/tests/test_a2a_inbox_unhandled.py
+++ b/tests/test_a2a_inbox_unhandled.py
@@ -1,0 +1,160 @@
+"""Tests for the A2A inbox 'unhandled' composed query.
+
+The unhandled query returns messages past the consumer's cursor that are
+addressed to the consumer AND have not been acknowledged by the consumer.
+
+Covers:
+  (a) mention before the cursor -> excluded
+  (b) mention after the cursor, not acked -> included
+  (c) mention after the cursor that has been acked -> excluded
+  (d) positive control: the underlying inbox query returns the expected
+      addressed messages before ack filtering
+  (e) limit applies AFTER the ack filter: acked messages do not consume
+      the caller's budget
+  (f) acked_by is propagated on a2a_inbox envelopes when present
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def unhandled_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-unhandled"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _send(data_dir, sender, body, thread="general", recipient=None, kind="chat"):
+    return asyncio.run(service.a2a_send(
+        sender, body, thread=thread, recipient=recipient, kind=kind, data_dir=str(data_dir),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Gate (a): mention before cursor -> excluded
+# Gate (b): mention after cursor, not acked -> included
+# Gate (c): mention after cursor, acked -> excluded
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_unhandled_excludes_before_cursor_and_acked(unhandled_data_dir):
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "alice"
+
+    msg1 = _send(dd, "bob", "early @alice", thread="general", recipient=None, kind="chat")
+    msg2 = _send(dd, "bob", "later @alice", thread="general", recipient=None, kind="chat")
+    msg3 = _send(dd, "bob", "acked @alice", thread="general", recipient=None, kind="chat")
+
+    asyncio.run(service.a2a_inbox_advance(consumer, msg1["id"], data_dir=dd))
+    asyncio.run(service.a2a_ack(msg3["id"], consumer, data_dir=dd))
+
+    unhandled = asyncio.run(service.a2a_inbox_unhandled(consumer, data_dir=dd))
+    assert len(unhandled) == 1
+    assert unhandled[0]["id"] == msg2["id"]
+    assert unhandled[0]["body"] == "later @alice"
+
+
+# ---------------------------------------------------------------------------
+# Gate (d): positive control: inbox returns addressed messages before ack filter
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_positive_control_before_ack_filter(unhandled_data_dir):
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "alice"
+
+    msg1 = _send(dd, "bob", "early @alice", thread="general", kind="chat")
+    msg2 = _send(dd, "bob", "later @alice", thread="general", kind="chat")
+    msg3 = _send(dd, "bob", "acked @alice", thread="general", kind="chat")
+
+    inbox = asyncio.run(service.a2a_inbox(consumer, data_dir=dd))
+    ids = {m["id"] for m in inbox}
+    assert msg1["id"] in ids
+    assert msg2["id"] in ids
+    assert msg3["id"] in ids
+
+
+# ---------------------------------------------------------------------------
+# Gate (e): limit applies AFTER the ack filter
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_unhandled_limit_after_ack_filter(unhandled_data_dir):
+    """Ten messages mentioning @agent-1, first 8 acked.
+
+    a2a_inbox_unhandled with limit=8 must return the 2 unacked messages.
+    On the buggy code this returns 0 when the cursor has advanced past only
+    the first message, because a2a_inbox returns the first 8 of the window
+    (all acked) and the filter then discards them all, leaving 0.
+    """
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "agent-1"
+
+    ids = []
+    for i in range(1, 11):
+        msg = _send(dd, "bob", f"msg {i} @agent-1", thread="general", kind="chat")
+        ids.append(msg["id"])
+
+    asyncio.run(service.a2a_inbox_advance(consumer, ids[0], data_dir=dd))
+
+    for mid in ids[:8]:
+        asyncio.run(service.a2a_ack(mid, consumer, data_dir=dd))
+
+    unhandled_all = asyncio.run(service.a2a_inbox_unhandled(consumer, limit=1000, data_dir=dd))
+    assert len(unhandled_all) == 2
+    assert {m["id"] for m in unhandled_all} == {ids[8], ids[9]}
+
+    unhandled_limited = asyncio.run(service.a2a_inbox_unhandled(consumer, limit=8, data_dir=dd))
+    assert len(unhandled_limited) == 2
+    assert {m["id"] for m in unhandled_limited} == {ids[8], ids[9]}
+
+
+# ---------------------------------------------------------------------------
+# Gate (f): acked_by is propagated on a2a_inbox envelopes when present
+# ---------------------------------------------------------------------------
+
+def test_a2a_inbox_propagates_acked_by(unhandled_data_dir):
+    _setup_stores(unhandled_data_dir)
+    dd = str(unhandled_data_dir)
+    consumer = "alice"
+
+    msg = _send(dd, "bob", "ack me @alice", thread="general", kind="chat")
+    asyncio.run(service.a2a_ack(msg["id"], consumer, data_dir=dd))
+
+    inbox = asyncio.run(service.a2a_inbox(consumer, data_dir=dd))
+    assert len(inbox) == 1
+    assert inbox[0]["acked_by"] == ["alice"]

--- a/tests/test_a2a_remote_forwarding.py
+++ b/tests/test_a2a_remote_forwarding.py
@@ -27,6 +27,7 @@ from cryptography.hazmat.primitives import serialization
 from taosmd import api as taosmd_api
 from taosmd import config as taosmd_config
 from taosmd import http_server, registry_auth, service as taosmd_service
+from taosmd.registry_auth import REGISTRY_ISS
 
 
 # ---------------------------------------------------------------------------
@@ -50,8 +51,8 @@ def _keypair():
 REG_PRIV_PEM, REG_PUB_PEM = _keypair()
 
 
-def _make_token(sub, priv_pem=REG_PRIV_PEM):
-    return pyjwt.encode({"sub": sub}, priv_pem, algorithm="EdDSA")
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=REGISTRY_ISS):
+    return pyjwt.encode({"sub": sub, "iss": iss}, priv_pem, algorithm="EdDSA")
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ def authed_live_server(tmp_path, monkeypatch):
         return json.dumps([])
 
     verifier = registry_auth.verifier_from_url(
-        "http://reg.test", opener=fake_opener, expected_iss=None,
+        "http://reg.test", opener=fake_opener, expected_iss=registry_auth.REGISTRY_ISS,
     )
 
     # Pre-seed via local service layer before the server starts, then clear
@@ -227,8 +228,54 @@ def test_remote_inbox_unhandled_reaches_remote_server(caller_data_dir, authed_li
 
 
 # ---------------------------------------------------------------------------
-# Tests: exclude_acked_by forwarded and applied on remote path
+# Tests: wrong issuer is rejected on the remote path
 # ---------------------------------------------------------------------------
+
+def test_remote_inbox_rejects_wrong_issuer(tmp_path, monkeypatch):
+    """A token with the wrong issuer is rejected by the remote registry verifier."""
+    server_dir = tmp_path / "taosmd-remote-wrong-iss-server"
+    server_dir.mkdir()
+    taosmd_config.set_a2a_auth_enforce(True, str(server_dir))
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=registry_auth.REGISTRY_ISS,
+    )
+
+    wrong_token = _make_token("agent-1", iss="wrong-issuer")
+    cfg_file = server_dir / "config.json"
+    cfg_file.write_text(json.dumps({"server_token": wrong_token}))
+
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(server_dir), verifier=verifier,
+    )
+    asyncio_run = __import__("asyncio").run
+    asyncio_run(taosmd_api._ensure_stores(str(server_dir)))
+    _patch_embedder(asyncio_run(taosmd_api._ensure_stores(str(server_dir))))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        caller_dir = tmp_path / "taosmd-remote-wrong-iss-caller"
+        caller_dir.mkdir()
+        monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+        caller_cfg = caller_dir / "config.json"
+        caller_cfg.write_text(json.dumps({"server_url": f"http://{host}:{port}", "server_token": wrong_token}))
+        taosmd_service._remote_cache.clear()
+        with pytest.raises(RuntimeError, match="HTTP 401"):
+            asyncio_run(taosmd_service.a2a_inbox("agent-1", data_dir=str(caller_dir)))
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+        taosmd_service._remote_cache.clear()
+
 
 def test_remote_inbox_exclude_acked_by_applied(caller_data_dir, authed_live_server):
     base_url, server_data_dir = authed_live_server

--- a/tests/test_a2a_remote_forwarding.py
+++ b/tests/test_a2a_remote_forwarding.py
@@ -1,0 +1,261 @@
+"""Tests that the A2A inbox service layer forwards to the remote server.
+
+When ``server_url`` is configured in the data_dir's ``config.json``, the
+service functions ``a2a_inbox``, ``a2a_inbox_advance``, ``a2a_ack``, and
+``a2a_inbox_unhandled`` must reach the remote HTTP server, not the local
+archive.
+
+The live server runs in verify-and-warn mode so unauthenticated ``a2a_send``
+pre-seeding is accepted; the caller sends the registry bearer token for the
+mutating endpoints.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+from taosmd import api as taosmd_api
+from taosmd import config as taosmd_config
+from taosmd import http_server, registry_auth, service as taosmd_service
+
+
+# ---------------------------------------------------------------------------
+# Keypair / token helpers
+# ---------------------------------------------------------------------------
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+REG_PRIV_PEM, REG_PUB_PEM = _keypair()
+
+
+def _make_token(sub, priv_pem=REG_PRIV_PEM):
+    return pyjwt.encode({"sub": sub}, priv_pem, algorithm="EdDSA")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Fixture: live server with registry verifier (warn mode)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_live_server(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-remote-fwd"
+    data_dir.mkdir()
+
+    # Warn mode so unauthenticated a2a_send pre-seeding is accepted.
+    taosmd_config.set_a2a_auth_enforce(False, str(data_dir))
+
+    # Write server_token as a valid registry JWT so both _check_token and
+    # _get_authenticated_agent_id() accept the same bearer credential.
+    valid_token = _make_token("agent-1")
+    cfg_file = data_dir / "config.json"
+    cfg_file.write_text(json.dumps({"server_token": valid_token}))
+
+    def fake_opener(url, token=None):
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return json.dumps({"pubkey": REG_PUB_PEM})
+        return json.dumps([])
+
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=None,
+    )
+
+    # Pre-seed via local service layer before the server starts, then clear
+    # the stores cache so the server creates fresh connections in its thread.
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    asyncio_run = __import__("asyncio").run
+    stores = asyncio_run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "remote inbox hello @agent-1", thread="general", data_dir=str(data_dir),
+    ))
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "advance me @agent-1", thread="general", data_dir=str(data_dir),
+    ))
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "ack me remote @agent-1", thread="acks", data_dir=str(data_dir),
+    ))
+    asyncio_run(taosmd_service.a2a_send(
+        "bob", "unhandled @agent-1", thread="general", data_dir=str(data_dir),
+    ))
+    taosmd_api._stores_cache.clear()
+
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    stores = httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}", str(data_dir)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixture: caller data_dir pointing at the live server
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def caller_data_dir(tmp_path, monkeypatch, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    valid_token = _make_token("agent-1")
+    cfg_file = caller_dir / "config.json"
+    cfg_file.write_text(json.dumps({"server_url": base_url, "server_token": valid_token}))
+    taosmd_service._remote_cache.clear()
+    yield str(caller_dir)
+    taosmd_service._remote_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_inbox forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    msgs = asyncio.run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    bodies = {m["body"] for m in msgs}
+    assert "remote inbox hello @agent-1" in bodies
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_inbox_advance forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_advance_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    advance_msg = [m for m in msgs if m["body"] == "advance me @agent-1"]
+    assert advance_msg, "seeded advance-me message not visible remotely"
+    msg_id = advance_msg[0]["id"]
+
+    result = asyncio_run(taosmd_service.a2a_inbox_advance(
+        "agent-1", msg_id, data_dir=caller_data_dir,
+    ))
+    assert result.get("ok") is True
+
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    assert not any(m["id"] == msg_id for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_ack forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_ack_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    ack_msg = [m for m in msgs if m["body"] == "ack me remote @agent-1"]
+    assert ack_msg, "seeded ack message not visible remotely"
+    msg_id = ack_msg[0]["id"]
+
+    result = asyncio_run(taosmd_service.a2a_ack(
+        msg_id, "agent-1", data_dir=caller_data_dir,
+    ))
+    assert result.get("ok") is True
+    assert result.get("id") == msg_id
+
+
+# ---------------------------------------------------------------------------
+# Tests: a2a_inbox_unhandled forwards to remote
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_unhandled_reaches_remote_server(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    msgs = asyncio_run(taosmd_service.a2a_inbox_unhandled(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    bodies = {m["body"] for m in msgs}
+    assert "unhandled @agent-1" in bodies
+
+
+# ---------------------------------------------------------------------------
+# Tests: exclude_acked_by forwarded and applied on remote path
+# ---------------------------------------------------------------------------
+
+def test_remote_inbox_exclude_acked_by_applied(caller_data_dir, authed_live_server):
+    base_url, server_data_dir = authed_live_server
+    asyncio_run = __import__("asyncio").run
+
+    # All messages are visible without the filter.
+    all_msgs = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", data_dir=caller_data_dir,
+    ))
+    assert len(all_msgs) == 4
+
+    # With exclude_acked_by="agent-1", messages acked by agent-1 are omitted.
+    filtered = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", exclude_acked_by="agent-1", data_dir=caller_data_dir,
+    ))
+    assert len(filtered) == 4
+
+    # None of the pre-seeded messages are acked, so the filter has no effect
+    # yet. Ack one via the remote ack endpoint and re-query.
+    msg_id = all_msgs[0]["id"]
+    ack_result = asyncio_run(taosmd_service.a2a_ack(
+        msg_id, "agent-1", data_dir=caller_data_dir,
+    ))
+    assert ack_result.get("ok") is True
+
+    filtered_after = asyncio_run(taosmd_service.a2a_inbox(
+        "agent-1", exclude_acked_by="agent-1", data_dir=caller_data_dir,
+    ))
+    assert len(filtered_after) == 3
+    assert not any(m["id"] == msg_id for m in filtered_after)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The /a2a/inbox docs omit exclude_acked_by, and every auth test builds its verifier with expected_iss=None so the issuer pin production sets is unexercised

Autonomous build of board card tsk-uz6ggr.

ITEM 1: taosmd/docs/a2a-comms.md and taosmd/http_server.py module docstring
both listed GET /a2a/inbox parameters but omitted exclude_acked_by. Added it
to both and stated that it omits messages already acknowledged by the named
principal so the limit budget is spent only on unhandled messages.

ITEM 2: both A2A auth test files (test_a2a_inbox_auth.py and
test_a2a_remote_forwarding.py) built their verifier with expected_iss=None,
so the issuer pin production sets was unexercised. Changed both to use
expected_iss=REGISTRY_ISS and added wrong-issuer tests for every auth path
(/a2a/inbox, /a2a/inbox/advance, /a2a/ack, /a2a/inbox/unhandled, and the
remote forwarding path).

Proof the pin is pinned: with test verifiers set to expected_iss=None the
wrong-issuer tests fail (5 FAILED, 0 ERROR); with expected_iss=REGISTRY_ISS
all 24 tests pass (0 FAILED, 0 ERROR). Read back docs against handler: every
parameter listed is real and every real parameter is listed.

No AI attribution.

Files:
 taosmd/docs/a2a-comms.md                      |   4 +
 taosmd/http_server.py                         | 135 +++++++++++
 taosmd/remote.py                              |  68 ++++++
 taosmd/service.py                             |  63 ++++-
 tests/test_a2a_inbox_auth.py                  | 327 ++++++++++++++++++++++++++
 tests/test_a2a_inbox_unhandled.py             | 160 +++++++++++++
 tests/test_a2a_remote_forwarding.py           | 308 ++++++++++++++++++++++++
 8 files changed, 1069 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added A2A inbox endpoints for retrieving, advancing, acknowledging, and listing unhandled messages.
  - Added inbox filtering by acknowledgement status and exposed acknowledgement details.
  - Added client support for remote inbox and acknowledgement operations.

- **Bug Fixes**
  - Improved authentication checks, including issuer validation and consumer matching.
  - Ensured acknowledged messages do not consume inbox result limits.

- **Documentation**
  - Documented the new A2A inbox endpoints and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->