### PR TITLE
collections revoke reports success when it removed nothing: no rowcount signal on a non-matching grantee

### DIFF
--- a/changelog.d/tsk-siwsp7-revoke-rowcount-signal.md
+++ b/changelog.d/tsk-siwsp7-revoke-rowcount-signal.md
@@ -1,0 +1,2 @@
+### Fixed
+- Collection grant revocation now reports whether a row was actually removed. ``CollectionStore.revoke`` captured the ``DELETE`` rowcount but discarded it, so ``DELETE /collections/{id}/grants/{agent}`` returned 200 even when no grant matched, telling an operator the revoke succeeded while the grant stayed live. The endpoint now returns a boolean ``revoked`` field alongside ``collection``; a no-op revoke stays 200 (idempotent), not an error. The grantee match is still case-sensitive and whitespace-normalised, unchanged.

--- a/taosmd/collections.py
+++ b/taosmd/collections.py
@@ -405,13 +405,16 @@ class CollectionStore:
 
     def revoke(self, collection_id: str, canonical_id: str) -> dict:
         self._row(collection_id)
-        self._conn.execute(
+        cur = self._conn.execute(
             "DELETE FROM collection_grants "
             "WHERE canonical_id = ? AND scope = ? AND collection_id = ?",
             (_grantee_key(canonical_id), GRANT_SCOPE, collection_id),
         )
+        removed = cur.rowcount
         self._conn.commit()
-        return self.get(collection_id)
+        col = self.get(collection_id)
+        col["revoked"] = removed > 0
+        return col
 
     def has_grant(self, canonical_id: str, collection_id: str) -> bool:
         row = self._conn.execute(

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -2454,7 +2454,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             except CollectionNotFoundError as exc:
                 self._send_json(404, {"error": str(exc)})
                 return
-            self._send_json(200, {"collection": col})
+            revoked = col.pop("revoked")
+            self._send_json(200, {"collection": col, "revoked": revoked})
 
         def _handle_collections_delete(self, collection_id: str) -> None:
             if not self._check_admin_token():

--- a/tests/test_collections_http.py
+++ b/tests/test_collections_http.py
@@ -273,6 +273,43 @@ def test_grants_add_and_revoke(live_server):
     assert body["collection"]["grants"] == []
 
 
+def test_revoke_reports_revoked_true_on_matching_grant(live_server):
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    _req(
+        "POST", f"{base}/collections/{col['id']}/grants",
+        {"agent": "dev"}, token=_TOKEN,
+    )
+    status, body = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/dev", token=_TOKEN,
+    )
+    assert status == 200
+    assert body["revoked"] is True
+    assert body["collection"]["grants"] == []
+
+
+def test_revoke_reports_revoked_false_on_non_matching_grantee(live_server):
+    """Revoking a grantee that holds no grant is idempotent: 200 with
+    ``revoked`` False and the surviving grant still listed under ``grants``.
+
+    A mis-cased grantee (``not-dev`` vs the granted ``dev``) deletes no row,
+    so the endpoint must not report success to a caller that reads only the
+    status.
+    """
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    _req(
+        "POST", f"{base}/collections/{col['id']}/grants",
+        {"agent": "dev"}, token=_TOKEN,
+    )
+    status, body = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/not-dev", token=_TOKEN,
+    )
+    assert status == 200
+    assert body["revoked"] is False
+    assert body["collection"]["grants"] == ["dev"]
+
+
 # ---------------------------------------------------------------------------
 # Index (async, 202 + poll) and search integration
 # ---------------------------------------------------------------------------

--- a/tests/test_collections_store.py
+++ b/tests/test_collections_store.py
@@ -236,6 +236,32 @@ def test_grantee_key_preserves_the_pre_existing_non_string_behaviour(store, sour
         store.revoke(col["id"], ["agent-a"])
 
 
+def test_revoke_reports_revoked_true_when_a_grant_was_removed(store, source_dir):
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    store.grant(col["id"], "agent-a")
+    result = store.revoke(col["id"], "agent-a")
+    assert result["revoked"] is True
+    assert result["grants"] == []
+    assert not store.has_grant("agent-a", col["id"])
+
+
+def test_revoke_reports_revoked_false_when_no_grant_matched(store, source_dir):
+    """A revoke that matched no row removed nothing, so report it.
+
+    Whitespace is normalised and case is deliberate (see
+    ``test_grantee_match_is_not_case_insensitive``): a mis-cased grantee
+    deletes no row, yet the pre-fix ``revoke`` returned the collection as if
+    it had succeeded. ``revoked`` is False so a caller reading only the store
+    result is not told the grant was taken.
+    """
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    store.grant(col["id"], "Agent-A")
+    result = store.revoke(col["id"], "agent-a")
+    assert result["revoked"] is False
+    assert result["grants"] == ["Agent-A"]
+    assert store.has_grant("Agent-A", col["id"])
+
+
 # ---------------------------------------------------------------------------
 # archive (delete alias) + status
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): collections revoke reports success when it removed nothing: no rowcount signal on a non-matching grantee

Autonomous build of board card tsk-siwsp7.

CollectionStore.revoke captured the DELETE rowcount but discarded it, so a
revoke of a grantee that holds no grant returned the collection as if it had
succeeded and stayed 200. DELETE /collections/{id}/grants/{agent} now
surfaces a top-level boolean `revoked` alongside the existing `collection`
key; a no-op revoke remains 200 (idempotent). The case-sensitive,
whitespace-normalised grantee match and grant validation are unchanged.

Proof (fresh branch off 0baa9af9, worktree taosmd imported from
/tmp/exec-tsk-siwsp7/taosmd/__init__.py):
  ./.venv/bin/python -m pytest -q -p no:randomly tests/test_collections_store.py tests/test_collections_http.py
  -> 42 passed, FAILED=0, ERROR=0, rc=0

Neuter gate, both arms independently live:
  hardcode revoked=True  -> 2 FAILED (non-matching: store + http)
  hardcode revoked=False -> 2 FAILED (matching: store + http)
  drop the revoked field -> 5 FAILED + 3 ERROR

Docs-Reviewed: the only http_server.py edit is _handle_collections_revoke on the collections grant endpoint, which taosmd/docs/a2a-comms.md does not document (it covers only A2A auth and the revoked-agent registry feed), and no A2A behaviour changed. The user-visible fix is recorded in changelog.d/tsk-siwsp7-revoke-rowcount-signal.md.

Files:
 changelog.d/tsk-siwsp7-revoke-rowcount-signal.md |  2 ++
 taosmd/collections.py                            |  7 +++--
 taosmd/http_server.py                            |  3 +-
 tests/test_collections_http.py                   | 37 ++++++++++++++++++++++++
 tests/test_collections_store.py                  | 26 +++++++++++++++++
 5 files changed, 72 insertions(+), 3 deletions(-)