### PR TITLE
The two GET /a2a/receipts read endpoints are the only ones of ten with NO unknown-parameter validator

### DIFF
--- a/changelog.d/tsk-lwqhql-a2a-receipts-strict-params.md
+++ b/changelog.d/tsk-lwqhql-a2a-receipts-strict-params.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /a2a/receipts` and `GET /a2a/messages/{id}/receipts` now reject unknown query parameters with `400` listing the allowed parameters, matching the other eight `/a2a` GET endpoints. A misspelled or renamed parameter previously failed open and returned a page instead of an error.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -471,6 +471,8 @@ a2a_members(channel="CHANNEL")
 | `POST` | `/a2a/admin/rename-channel` | body JSON `{"from": str, "to": str}` | `{"renamed": true, "from": str, "to": str}`; admin, same token rule |
 | `POST` | `/a2a/admin/supersede-message` | body JSON `{"id": int}` | `{"superseded": true, "id": int}`; admin, same token rule |
 
+All `GET /a2a/*` endpoints reject unknown query parameters with `400`, listing the parameters each one accepts, so a misspelled or renamed parameter fails loud instead of silently returning a page. This contract applies to the receipt read endpoints `GET /a2a/receipts` and `GET /a2a/messages/{id}/receipts` as well as every other read route on the bus.
+
 ### Admin token (separate from the data plane)
 
 The admin routes above (and `POST /shelves`, `POST /shelves/{id}/archive`,

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1104,7 +1104,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_a2a_receipts_seen()
                 elif method == "GET" and path.startswith("/a2a/messages/") and path.endswith("/receipts"):
                     msg_id = path[len("/a2a/messages/"):-len("/receipts")]
-                    self._handle_a2a_message_receipts(msg_id)
+                    self._handle_a2a_message_receipts(msg_id, query)
                 elif method == "GET" and path == "/a2a/receipts":
                     self._handle_a2a_receipts(query)
                 elif method == "POST" and path == "/a2a/admin/prune-receipts":
@@ -1960,8 +1960,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             )
             self._send_json(200, {"ok": True})
 
-        def _handle_a2a_message_receipts(self, msg_id_str: str) -> None:
+        def _handle_a2a_message_receipts(self, msg_id_str: str, qs: dict) -> None:
             """GET /a2a/messages/{id}/receipts -- all receipts for one message."""
+            _validate_a2a_params(qs, frozenset())
             try:
                 message_id = int(msg_id_str)
             except (TypeError, ValueError) as exc:
@@ -1973,6 +1974,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
 
         def _handle_a2a_receipts(self, qs: dict) -> None:
             """GET /a2a/receipts?message_id=X&agent=Y -- a single receipt."""
+            _validate_a2a_params(qs, frozenset({"message_id", "agent"}))
             message_id_raw = (qs.get("message_id") or [None])[0]
             agent_id = (qs.get("agent") or [None])[0]
             if message_id_raw is None or agent_id is None:

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -314,6 +314,22 @@ def test_http_a2a_members_unknown_param_returns_400(live_server):
     assert "bogus" in body["error"]
 
 
+def test_http_a2a_receipts_unknown_param_returns_400(live_server):
+    """Unknown query params on GET /a2a/receipts must 400, not silently page."""
+    status, body = _get(
+        f"{live_server}/a2a/receipts?message_id=1&agent=alice&bogus=1"
+    )
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_message_receipts_unknown_param_returns_400(live_server):
+    """Unknown query params on GET /a2a/messages/{id}/receipts must 400."""
+    status, body = _get(f"{live_server}/a2a/messages/1/receipts?bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
 # ---------------------------------------------------------------------------
 # SSE helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The two GET /a2a/receipts read endpoints are the only ones of ten with NO unknown-parameter validator

Autonomous build of board card tsk-lwqhql.

GET /a2a/receipts and GET /a2a/messages/{id}/receipts were the only two of
ten /a2a GET routes lacking the _validate_a2a_params guard, so a misspelled
or renamed query parameter failed open (200 or 404) instead of 400. Adds the
guard to both handlers; the messages/{id}/receipts handler now receives the
parsed query string (query) so it can validate too. Allowed sets:
frozenset({"message_id", "agent"}) for /a2a/receipts, frozenset() for
/a2a/messages/{id}/receipts (path-only id).

Red-then-green proof (mutations by line number, not anchor text, because the
validator call lines are byte-identical in places):
- Neuter http_server.py:1977 (_handle_a2a_receipts validator) ->
  test_http_a2a_receipts_unknown_param_returns_400 FAILS (404 != 400),
  test_http_a2a_message_receipts_unknown_param_returns_400 stays PASS.
- Neuter http_server.py:1965 (_handle_a2a_message_receipts validator) ->
  test_http_a2a_message_receipts_unknown_param_returns_400 FAILS (200 !=
  400), test_http_a2a_receipts_unknown_param_returns_400 stays PASS.
- Restored -> both PASS. Each test pins its own branch, not a shared one.

Baseline re-measured (2026-08-31T06:05Z, this sandbox; the mcp SDK is absent
so test_mcp_server.py skips cleanly instead of the 7 collection errors seen on
the author baseline):
- clean master 0baa9af9: 1803 passed, 12 skipped, 0 errors
  (author baseline env: 1804 passed, 10 skipped, 7 errors)
- with changes: 1805 passed, 12 skipped, 0 errors
- delta: +2 passed (the two new tests), 0 failures, 0 errors

Docs: taosmd/docs/a2a-comms.md touched to satisfy the a2a-handlers doc-gate
rule; changelog.d/tsk-lwqhql-a2a-receipts-strict-params.md added.

Files:
 changelog.d/tsk-lwqhql-a2a-receipts-strict-params.md |  3 +++
 taosmd/docs/a2a-comms.md                             |  2 ++
 taosmd/http_server.py                                |  6 ++++--
 tests/test_a2a_kinds_strict_params.py                | 16 ++++++++++++++++
 4 files changed, 25 insertions(+), 2 deletions(-)