### PR TITLE
grant validates its grantee and revoke validates nothing: the asymmetry is pinned by a test, so fixing it is a deliberate decision

### DIFF
--- a/changelog.d/tsk-cfaf6o-revoke-grantee-validation.md
+++ b/changelog.d/tsk-cfaf6o-revoke-grantee-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `revoke` now validates its grantee and raises `ValueError` on `''`, whitespace-only, `None`, and non-string ids, matching the existing `grant` behaviour. The HTTP surface returns 400 for these cases.

--- a/taosmd/collections.py
+++ b/taosmd/collections.py
@@ -404,6 +404,8 @@ class CollectionStore:
         return self.get(collection_id)
 
     def revoke(self, collection_id: str, canonical_id: str) -> dict:
+        if not isinstance(canonical_id, str) or not canonical_id.strip():
+            raise ValueError("agent (canonical_id) must be a non-empty string")
         self._row(collection_id)
         self._conn.execute(
             "DELETE FROM collection_grants "

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1190,8 +1190,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     rest = path[len("/collections/"):]
                     if "/grants/" in rest:
                         cid, _, agent = rest.partition("/grants/")
-                        if not cid or not agent:
-                            self._send_json(404, {"error": "collection id and agent required"})
+                        if not cid:
+                            self._send_json(404, {"error": "collection id required"})
                         else:
                             self._handle_collections_revoke(cid, agent)
                     elif rest and "/" not in rest:
@@ -2446,7 +2446,11 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"collection": col})
 
         def _handle_collections_revoke(self, collection_id: str, agent: str) -> None:
+            import urllib.parse as _up  # noqa: PLC0415
             from .collections import CollectionNotFoundError  # noqa: PLC0415
+            agent = _up.unquote(agent)
+            if not isinstance(agent, str) or not agent.strip():
+                raise _BadRequest("'agent' (non-empty string) is required")
             try:
                 col = runner.run(
                     service.collections_revoke(collection_id, agent, data_dir=data_dir)

--- a/tests/test_collections_http.py
+++ b/tests/test_collections_http.py
@@ -273,6 +273,28 @@ def test_grants_add_and_revoke(live_server):
     assert body["collection"]["grants"] == []
 
 
+def test_grant_rejects_invalid_agent(live_server):
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    for bad in ("", "   ", None, 5):
+        payload = {"agent": bad} if bad is not None else {}
+        status, _ = _req(
+            "POST", f"{base}/collections/{col['id']}/grants",
+            payload, token=_TOKEN,
+        )
+        assert status == 400, f"grant with {bad!r} should 400, got {status}"
+
+
+def test_revoke_rejects_invalid_agent(live_server):
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    # Whitespace agent in URL path -> 400
+    status, _ = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/%20%20", token=_TOKEN,
+    )
+    assert status == 400
+
+
 # ---------------------------------------------------------------------------
 # Index (async, 202 + poll) and search integration
 # ---------------------------------------------------------------------------

--- a/tests/test_collections_store.py
+++ b/tests/test_collections_store.py
@@ -210,29 +210,41 @@ def test_grantee_match_is_not_case_insensitive(store, source_dir):
     assert store.has_grant("Agent-A", col["id"])
 
 
+def test_grant_rejects_invalid_grantee(store, source_dir):
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    for bad in ("", "   ", None, 5):
+        with pytest.raises(ValueError, match="agent .* must be a non-empty string"):
+            store.grant(col["id"], bad)
+
+
+def test_revoke_rejects_invalid_grantee(store, source_dir):
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    for bad in ("", "   ", None, 5):
+        with pytest.raises(ValueError, match="agent .* must be a non-empty string"):
+            store.revoke(col["id"], bad)
+
+
 def test_grantee_key_preserves_the_pre_existing_non_string_behaviour(store, source_dir):
-    """The ``isinstance`` guard in ``_grantee_key`` is load-bearing, not decoration.
+    """``has_grant`` still accepts non-string ids and returns False, but
+    ``revoke`` now validates its grantee to match ``grant``.
 
-    ``revoke``/``has_grant`` bound the raw argument before the symmetry fix, so a
-    value sqlite binds natively reached the query and matched nothing. Routing
-    both ends through ``.strip()`` would newly raise ``AttributeError`` on those
-    callers, which is a behaviour change the fix does not intend to make. The
-    guard is what keeps it out, and nothing else pins it.
-
-    Measured on ``master`` before this change and on this branch after it: both
-    trees pass ``None`` and an int through to a non-match, and both raise
-    ``sqlite3.ProgrammingError`` on a list. The guard does not widen what sqlite
-    accepts, so that half is asserted too.
+    ``has_grant`` is a read-only membership check, so passing through ``None``
+    and an int to a non-match is harmless and pre-existing. ``revoke`` is a
+    mutator: a caller sending garbage has a bug and should be told, while a
+    caller sending a real-but-ungranted agent still correctly gets
+    ``revoked=False``. Those are different conditions and currently collapse
+    into one response, so the contract was tightened on the write side only.
     """
     col = store.create(name="a", kind="docs", source_path=source_dir)
     store.grant(col["id"], "agent-a")
 
     assert store.has_grant(None, col["id"]) is False
     assert store.has_grant(7, col["id"]) is False
-    assert store.revoke(col["id"], None)["id"] == col["id"]
+    with pytest.raises(ValueError, match="agent .* must be a non-empty string"):
+        store.revoke(col["id"], None)
     assert store.has_grant("agent-a", col["id"]) is True  # control: still granted
 
-    with pytest.raises(sqlite3.ProgrammingError):
+    with pytest.raises(ValueError, match="agent .* must be a non-empty string"):
         store.revoke(col["id"], ["agent-a"])
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): grant validates its grantee and revoke validates nothing: the asymmetry is pinned by a test, so fixing it is a deliberate decision

Autonomous build of board card tsk-cfaf6o.

revoke now raises ValueError on '', whitespace-only, None, and non-string
grantees, matching the existing grant validation. The HTTP handler also
URL-decodes the path agent and validates it, returning 400 for bad input.

The pre-existing test that pinned revoke(None) as non-raising is updated
as a visible decision: revoke is a mutator, so callers sending garbage
should be told, while callers sending a real-but-ungranted agent still
get revoked=False.

cli.py already catches ValueError, so no caller behaviour changes there.

Docs-Reviewed: change is in collections revoke handler only, not A2A comms

Files:
 .../tsk-cfaf6o-revoke-grantee-validation.md        |  3 ++
 taosmd/collections.py                              |  2 ++
 taosmd/http_server.py                              |  8 +++--
 tests/test_collections_http.py                     | 22 ++++++++++++
 tests/test_collections_store.py                    | 40 ++++++++++++++--------
 5 files changed, 59 insertions(+), 16 deletions(-)