### PR TITLE
REVISE PR #435: the store and HTTP halves are sound, but the CLI caller discards the new revoked signal so the defect survives

### DIFF
--- a/changelog.d/tsk-d6giky-cli-revoked-signal.md
+++ b/changelog.d/tsk-d6giky-cli-revoked-signal.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `taosmd collections revoke` now exits non-zero and reports to stderr when no
+  grant matched, instead of returning 0 with identical output to a successful
+  revocation. The service layer already carried the `revoked` signal; the CLI
+  caller was discarding it, leaving the false-negative defect from tsk-siwsp7
+  alive on the command surface. Added a CLI test that distinguishes the two
+  cases.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -63,7 +63,7 @@ POST   /collections                        -> {"collection": {...}, "created": t
 POST   /collections/{id}/index             -> 202, then poll GET /collections/{id}
 POST   /collections/{id}/link | /unlink    -> {"collection": {...}}
 POST   /collections/{id}/grants            -> {"collection": {...}}
-DELETE /collections/{id}/grants/{agent}    -> {"collection": {...}}
+DELETE /collections/{id}/grants/{agent}    -> {"collection": ..., "revoked": ...}
 DELETE /collections/{id}                   -> {"collection": {...}}  (archived)
 ```
 

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -1089,6 +1089,10 @@ def _collections_cmd(args: argparse.Namespace) -> int:
             col = asyncio.run(
                 service.collections_revoke(args.collection_id, args.agent, data_dir=data_dir)
             )
+            revoked = col.pop("revoked", False)
+            if not revoked:
+                print(f"noop: no grant matched for {args.agent}", file=sys.stderr)
+                return 1
             print(f"{col['id']} grants: {', '.join(col['grants']) or '(none)'}")
             return 0
     except CollectionNotFoundError as exc:

--- a/taosmd/collections.py
+++ b/taosmd/collections.py
@@ -405,13 +405,16 @@ class CollectionStore:
 
     def revoke(self, collection_id: str, canonical_id: str) -> dict:
         self._row(collection_id)
-        self._conn.execute(
+        cur = self._conn.execute(
             "DELETE FROM collection_grants "
             "WHERE canonical_id = ? AND scope = ? AND collection_id = ?",
             (_grantee_key(canonical_id), GRANT_SCOPE, collection_id),
         )
+        removed = cur.rowcount
         self._conn.commit()
-        return self.get(collection_id)
+        col = self.get(collection_id)
+        col["revoked"] = removed > 0
+        return col
 
     def has_grant(self, canonical_id: str, collection_id: str) -> bool:
         row = self._conn.execute(

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -2454,7 +2454,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             except CollectionNotFoundError as exc:
                 self._send_json(404, {"error": str(exc)})
                 return
-            self._send_json(200, {"collection": col})
+            revoked = col.pop("revoked")
+            self._send_json(200, {"collection": col, "revoked": revoked})
 
         def _handle_collections_delete(self, collection_id: str) -> None:
             if not self._check_admin_token():

--- a/tests/test_collections_cli.py
+++ b/tests/test_collections_cli.py
@@ -77,6 +77,19 @@ def test_link_unlink_grant_revoke(data_dir, source_dir, capsys):
     capsys.readouterr()
 
 
+def test_revoke_noop_returns_nonzero(data_dir, source_dir, capsys):
+    store = CollectionStore(data_dir)
+    col = store.create(name="a", kind="docs", source_path=str(source_dir))
+    cid = col["id"]
+
+    assert main(["collections", "grant", cid, "dev"]) == 0
+    rc = main(["collections", "revoke", cid, "not-dev"])
+    assert rc == 1
+    out = capsys.readouterr().err
+    assert "no grant matched" in out
+    assert store.get(cid)["grants"] == ["dev"]
+
+
 def test_index_runs_synchronously(data_dir, source_dir, capsys, monkeypatch):
     from taosmd import api as taosmd_api
     import asyncio

--- a/tests/test_collections_http.py
+++ b/tests/test_collections_http.py
@@ -273,6 +273,45 @@ def test_grants_add_and_revoke(live_server):
     assert body["collection"]["grants"] == []
 
 
+def test_revoke_reports_revoked_true_on_matching_grant(live_server):
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    _req(
+        "POST", f"{base}/collections/{col['id']}/grants",
+        {"agent": "dev"}, token=_TOKEN,
+    )
+    status, body = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/dev", token=_TOKEN,
+    )
+    assert status == 200
+    assert body["revoked"] is True
+    assert body["collection"]["grants"] == []
+    assert "revoked" not in body["collection"]
+
+
+def test_revoke_reports_revoked_false_on_non_matching_grantee(live_server):
+    """Revoking a grantee that holds no grant is idempotent: 200 with
+    ``revoked`` False and the surviving grant still listed under ``grants``.
+
+    A mis-cased grantee (``not-dev`` vs the granted ``dev``) deletes no row,
+    so the endpoint must not report success to a caller that reads only the
+    status.
+    """
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    _req(
+        "POST", f"{base}/collections/{col['id']}/grants",
+        {"agent": "dev"}, token=_TOKEN,
+    )
+    status, body = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/not-dev", token=_TOKEN,
+    )
+    assert status == 200
+    assert body["revoked"] is False
+    assert body["collection"]["grants"] == ["dev"]
+    assert "revoked" not in body["collection"]
+
+
 # ---------------------------------------------------------------------------
 # Index (async, 202 + poll) and search integration
 # ---------------------------------------------------------------------------

--- a/tests/test_collections_store.py
+++ b/tests/test_collections_store.py
@@ -236,6 +236,32 @@ def test_grantee_key_preserves_the_pre_existing_non_string_behaviour(store, sour
         store.revoke(col["id"], ["agent-a"])
 
 
+def test_revoke_reports_revoked_true_when_a_grant_was_removed(store, source_dir):
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    store.grant(col["id"], "agent-a")
+    result = store.revoke(col["id"], "agent-a")
+    assert result["revoked"] is True
+    assert result["grants"] == []
+    assert not store.has_grant("agent-a", col["id"])
+
+
+def test_revoke_reports_revoked_false_when_no_grant_matched(store, source_dir):
+    """A revoke that matched no row removed nothing, so report it.
+
+    Whitespace is normalised and case is deliberate (see
+    ``test_grantee_match_is_not_case_insensitive``): a mis-cased grantee
+    deletes no row, yet the pre-fix ``revoke`` returned the collection as if
+    it had succeeded. ``revoked`` is False so a caller reading only the store
+    result is not told the grant was taken.
+    """
+    col = store.create(name="a", kind="docs", source_path=source_dir)
+    store.grant(col["id"], "Agent-A")
+    result = store.revoke(col["id"], "agent-a")
+    assert result["revoked"] is False
+    assert result["grants"] == ["Agent-A"]
+    assert store.has_grant("Agent-A", col["id"])
+
+
 # ---------------------------------------------------------------------------
 # archive (delete alias) + status
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #435: the store and HTTP halves are sound, but the CLI caller discards the new revoked signal so the defect survives

Autonomous build of board card tsk-d6giky.

Store layer (collections.py) captures DELETE rowcount and sets
col["revoked"] = removed > 0. HTTP handler pops revoked from the inner
collection and returns it at the envelope top level. CLI caller reads
revoked, prints a distinguishable noop message to stderr, and returns 1
when no grant matched.

docs/collections.md endpoint table updated to reflect {"collection": ...,
"revoked": ...} response shape. HTTP tests assert revoked is True on a
matching grantee, False on a non-matching grantee, and absent from the
inner collection object in both cases. Store tests cover both outcomes.
New CLI test verifies noop revoke returns rc=1 with 'no grant matched'
on stderr while the grant survives.

Verified: tests/test_collections_cli.py 6 passed, tests/test_collections_store.py
+test_collections_http.py 42 passed.

Docs-Reviewed: collections endpoint change is documented in docs/collections.md; A2A handlers in http_server.py are unaffected

Files:
 docs/collections.md                          |  2 +-
 taosmd/cli.py                                |  4 +++
 taosmd/collections.py                        |  7 +++--
 taosmd/http_server.py                        |  3 ++-
 tests/test_collections_cli.py                | 13 ++++++++++
 tests/test_collections_http.py               | 39 ++++++++++++++++++++++++++++
 tests/test_collections_store.py              | 26 +++++++++++++++++++
 8 files changed, 98 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection grant revocation now clearly indicates whether a grant was actually removed.
  * The CLI reports an error and exits non-zero when no grant matches, instead of indicating a successful revocation.
  * HTTP responses now include a top-level `revoked` status while preserving collection details.

* **Documentation**
  * Updated collection API documentation to describe the `revoked` response field.

* **Tests**
  * Added coverage for successful and unmatched revocation scenarios across CLI, HTTP, and collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->