### PR TITLE
.venv is not gitignored, and a lane committed it as a symlink to an absolute developer path in PR #436

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.venv/
+.venv
 __pycache__/
 *.pyc
 *.egg-info/

--- a/changelog.d/tsk-c6k5pu-venv-gitignore.md
+++ b/changelog.d/tsk-c6k5pu-venv-gitignore.md
@@ -1,0 +1,5 @@
+### Fixed
+- Added `.venv/` and a bare `.venv` pattern to `.gitignore` so both a real
+  `.venv` directory and a `.venv` symlink are ignored. The trailing-slash
+  form alone does not match a symlink named `.venv`, which is the shape that
+  was committed into PR #436 as a symlink to an absolute machine path.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): .venv is not gitignored, and a lane committed it as a symlink to an absolute developer path in PR #436

Autonomous build of board card tsk-c6k5pu.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

PR #436 committed .venv as a symlink to an absolute machine path because
.gitignore lacked both the directory form (.venv/) and the bare form (.venv).
The trailing-slash form alone does not match a symlink, so both patterns
are required.

Acceptance proof (scratch clone of this worktree):
  Directory arm:
    check-ignore .venv with both patterns   -> rc=0 (ignored)
    check-ignore .venv without the patterns -> rc=1 (not ignored)
  Symlink arm:
    check-ignore .venv with both patterns   -> rc=0 (ignored)
    check-ignore .venv without the patterns -> rc=1 (not ignored)
  RED control (only .venv/, no bare form):
    symlink .venv   -> rc=1 (NOT ignored, proving bare form is required)
    dir .venv       -> rc=0 (ignored)

rc captured directly, never via a pipeline. Both arms green; RED arm
confirms the bare form is necessary.

Files:
 .gitignore                               | 2 ++
 changelog.d/tsk-c6k5pu-venv-gitignore.md | 5 +++++
 2 files changed, 7 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local Python virtual environments by ensuring `.venv` directories and symlinks are excluded from version control.

* **Documentation**
  * Added a changelog entry documenting the virtual environment ignore rule update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->