### PR TITLE
DELETE /collections/{cid}/grants/{agent} never percent-decodes {agent}, and no client method encodes it: a third undecoded caller-supplied segment that no card covered

### DIFF
--- a/changelog.d/tsk-vepm4j-decode-revoke-agent.md
+++ b/changelog.d/tsk-vepm4j-decode-revoke-agent.md
@@ -1,0 +1,8 @@
+### Fixed
+- `DELETE /collections/{id}/grants/{agent}` now percent-decodes `{agent}` in the
+  handler before handing it to the store. The segment is caller-supplied, so an
+  agent id carrying a space, `+`, `/`, or a non-ASCII character was revoked under
+  its encoded spelling while `grant` stored the decoded one: the DELETE matched
+  no row and still returned `200` with the grant still live. Decoding at the
+  HTTP boundary (the same place `_handle_a2a_alarms_clear` already decodes its
+  `{key}`) makes revoke and grant agree on the spelling.

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -2446,7 +2446,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"collection": col})
 
         def _handle_collections_revoke(self, collection_id: str, agent: str) -> None:
+            import urllib.parse as _up  # noqa: PLC0415
             from .collections import CollectionNotFoundError  # noqa: PLC0415
+            agent = _up.unquote(agent)
             try:
                 col = runner.run(
                     service.collections_revoke(collection_id, agent, data_dir=data_dir)

--- a/tests/test_collections_http.py
+++ b/tests/test_collections_http.py
@@ -13,6 +13,7 @@ import json
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 import pytest
@@ -20,6 +21,7 @@ import pytest
 from taosmd import api as taosmd_api
 from taosmd import config as taosmd_config
 from taosmd import http_server
+from taosmd.collections import CollectionStore
 
 _TOKEN = "test-admin-token-abc123"
 
@@ -271,6 +273,90 @@ def test_grants_add_and_revoke(live_server):
     )
     assert status == 200
     assert body["collection"]["grants"] == []
+
+
+# ---------------------------------------------------------------------------
+# Percent-decoding of the caller-supplied {agent} segment (tsk-vepm4j)
+# ---------------------------------------------------------------------------
+#
+# DELETE /collections/{cid}/grants/{agent} takes {agent} as a raw URL path
+# segment. A client must percent-encode it; the handler must decode it. The fix
+# lives in _handle_collections_revoke (taosmd/http_server.py), mirroring
+# _handle_a2a_alarms_clear. These tests assert the outcome by re-reading the
+# store directly, never just the 200 response -- a 200 with ok:true has been
+# observed on a payload the server discarded.
+
+_AGENT_SPECIAL = "a +b/c d\xe9"  # space, plus, slash, non-ASCII (U+00E9)
+
+
+def _grant_via_http(base, col_id, agent, token=_TOKEN):
+    status, body = _req(
+        "POST",
+        f"{base}/collections/{col_id}/grants",
+        {"agent": agent},
+        token=token,
+    )
+    assert status == 200, body
+    return body["collection"]
+
+
+def _revoke_via_http(base, col_id, agent, token=_TOKEN):
+    encoded = urllib.parse.quote(agent, safe="")
+    status, body = _req(
+        "DELETE",
+        f"{base}/collections/{col_id}/grants/{encoded}",
+        token=token,
+    )
+    return status, body
+
+
+def _store_has_grant(data_dir, col_id, agent) -> bool:
+    store = CollectionStore(data_dir)
+    try:
+        return store.has_grant(agent, col_id)
+    finally:
+        store.close()
+
+
+def test_revoke_decodes_caller_supplied_agent(live_server):
+    """Grant and revoke an agent id carrying space, +, slash, non-ASCII.
+
+    The grant is written through POST (agent taken from the JSON body, so it
+    is already decoded). The revoke goes through DELETE /collections/{cid}/
+    grants/{agent} as a percent-encoded segment. Before the fix the handler
+    never unquoted {agent}, so the DELETE matched the encoded spelling and
+    matched nothing: the grant stayed live and a 200 was returned anyway.
+    """
+    base, data_dir, source_dir = live_server
+    col = _create(base, source_dir)
+    _grant_via_http(base, col["id"], _AGENT_SPECIAL)
+    # Prove the grant landed before revoking -- a re-read, not the 200 above.
+    assert _store_has_grant(data_dir, col["id"], _AGENT_SPECIAL) is True
+    status, body = _revoke_via_http(base, col["id"], _AGENT_SPECIAL)
+    assert status == 200, body
+    # The verdict: re-read the store. Only this proves the write landed.
+    assert _store_has_grant(data_dir, col["id"], _AGENT_SPECIAL) is False
+    status, body = _req("GET", f"{base}/collections/{col['id']}", token=_TOKEN)
+    assert _AGENT_SPECIAL not in body["collection"]["grants"]
+
+
+def test_revoke_ascii_agent_is_a_control(live_server):
+    """Control: a plain-ASCII agent id (no percent-encoding-sensitive chars)
+    must revoke correctly regardless of whether the handler decodes.
+
+    Which question this validates: it rules out a blind probe. A green here
+    proves nothing about the decode -- ASCII passes through both encoded and
+    decoded unchanged -- so only the special-character test above can prove the
+    fix. It must stay green before and after the mutation so the mutation
+    verdict is a clean kill (special-char FAILs, ASCII survives).
+    """
+    base, data_dir, source_dir = live_server
+    col = _create(base, source_dir)
+    _grant_via_http(base, col["id"], "dev")
+    assert _store_has_grant(data_dir, col["id"], "dev") is True
+    status, body = _revoke_via_http(base, col["id"], "dev")
+    assert status == 200, body
+    assert _store_has_grant(data_dir, col["id"], "dev") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): DELETE /collections/{cid}/grants/{agent} never percent-decodes {agent}, and no client method encodes it: a third undecoded caller-supplied segment that no card covered

Autonomous build of board card tsk-vepm4j.

{agent} on the revoke route is caller-supplied and was never decoded in the
handler, unlike the same segment shape on the A2A alarm and thread routes. A
grant is written via POST /collections/{id}/grants with the agent taken from the
JSON body (already decoded), so an agent id containing a space, +, slash, or a
non-ASCII byte was stored under its decoded spelling while the DELETE matched it
against the still-encoded path segment: no row matched, the grant stayed live,
and the handler returned 200 with the grant still listed. That is a silent
revocation failure on a permission-bearing path.

Decode {agent} at the HTTP boundary in _handle_collections_revoke, mirroring the
existing _handle_a2a_alarms_clear pattern (local `import urllib.parse as _up`
then `_up.unquote(agent)`). Scope is the single encode/decode defect only: no
store-layer validation or `revoked` signal is added, so this does not textually
collide with PR #443 (grantee validation in collections.py) or PR #445 (the
`revoked` rowcount boolean in collections.py), both of which own the
collections.py grant/revoke surface.

Callers of the revoke path, each confirmed to propagate the outcome:
- CollectionStore.revoke (taosmd/collections.py:406) returns the post-revoke
  collection dict (incl. `grants`).
- service.collections_revoke (taosmd/service.py:1854) passes the store result
  through unchanged.
- _handle_collections_revoke (taosmd/http_server.py:2448) returns 200
  {"collection": col} carrying the post-revoke grant list.
- CLI `taosmd collections revoke` (taosmd/cli.py:1088) prints col['grants'].
No in-repo HTTP client method encodes {agent}: RemoteClient (taosmd/remote.py)
exposes no collections revoke call, and the CLI calls the local service loop
directly (no encoding needed). The test harness itself is the HTTP caller and
encodes with urllib.parse.quote(agent, safe="").

Tests (tests/test_collections_http.py):
- test_revoke_decodes_caller_supplied_agent grants "a +b/c d\xe9" (space, +,
  slash, non-ASCII U+00E9), then DELETEs the percent-encoded segment and asserts
  the grant is GONE by re-reading CollectionStore.has_grant directly, not by the
  200 response. Also re-GETs the collection and asserts the id is absent from
  `grants`.
- test_revoke_ascii_agent_is_a_control grants and revokes a plain ASCII id
  ("dev") and re-reads the store. This validates the question: is the fix
  surgical? ASCII passes through both encoded and decoded unchanged, so a green
  on this control alone cannot prove the decode landed; only the special-char
  test distinguishes the two. It must stay green before and after the mutation so
  the verdict is a clean kill rather than a blind probe.

Mutation verdict (decode line mutated by LINE NUMBER, line 2451
`agent = _up.unquote(agent)` removed, then restored):
- baseline with the fix present: 2 passed, FAILED COUNT: 0, ERROR COUNT: 0
- decode mutated out: 1 failed (special-char test), 1 passed (ASCII control),
  FAILED COUNT: 1, ERROR COUNT: 0
The special-char test fails when the decode is removed (decode is load-bearing)
while the ASCII control survives (mutation is surgical). Verdict: mutation
killed. Counts parsed from the pytest summary, not from exit status.

Docs-Reviewed: No route file was added under tinyagentos/routes/ (none exists in
this repo; collections HTTP handlers live in taosmd/http_server.py), so the
tinyagentos/routes doc-gate in AGENTS.md does not apply.

Files:
 changelog.d/tsk-vepm4j-decode-revoke-agent.md |  8 +++
 taosmd/http_server.py                         |  2 +
 tests/test_collections_http.py                | 86 +++++++++++++++++++++++++++
 3 files changed, 96 insertions(+)