### PR TITLE
check_bot_anchoring.sh: the review-state branch has no fixture, so deleting it leaves every test green

### DIFF
--- a/changelog.d/tsk-6pc3tu-merge-gate-review-state-fixture.md
+++ b/changelog.d/tsk-6pc3tu-merge-gate-review-state-fixture.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pinned the review-state filter in `scripts/merge-gate/check_bot_anchoring.sh` with a `tests/fixtures/merge_gate/pr_bot_dismissed.json` fixture and `test_bot_dismissed_at_head_fails`: a bot review in a `DISMISSED` state at head is now asserted to make the gate exit rc=10. The filter was behaviourally live but unpinned, so a mutant replacing it with `if False:` survived and left the whole test set green.

--- a/tests/fixtures/merge_gate/pr_bot_dismissed.json
+++ b/tests/fixtures/merge_gate/pr_bot_dismissed.json
@@ -1,0 +1,14 @@
+{
+  "number": 218,
+  "headRefOid": "abc123def456",
+  "reviews": [
+    {
+      "author": {"login": "coderabbitai"},
+      "state": "DISMISSED",
+      "body": "<details><summary>Nitpick comments (1)</summary><blockquote>\n\n**Add coverage for the new import-tracking table.**\n</blockquote></details>",
+      "commit": {"oid": "abc123def456"},
+      "includesCreatedEdit": false,
+      "submittedAt": "2026-07-28T12:21:45Z"
+    }
+  ]
+}

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -95,6 +95,17 @@ def test_human_only_fails(tmp_path):
     assert result.stdout.startswith("FAILED:")
 
 
+def test_bot_dismissed_at_head_fails(tmp_path):
+    result = _run(
+        "check_bot_anchoring.sh",
+        ["218"],
+        str(tmp_path),
+        pr=_read("pr_bot_dismissed.json"),
+    )
+    assert result.returncode == 10, result.stdout + result.stderr
+    assert result.stdout.startswith("FAILED:")
+
+
 def test_rate_limited_fails(tmp_path):
     result = _run(
         "check_fake_green.sh",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_bot_anchoring.sh: the review-state branch has no fixture, so deleting it leaves every test green

Autonomous build of board card tsk-6pc3tu.

The bot-anchoring gate's review-state filter was behaviourally live but
unpinned by its own tests: a bot review in a DISMISSED state at head makes the
gate exit rc=10, yet no fixture exercised that branch. That is why a 9-mutant
campaign survivor on the filter (mutating line 34 to `if False:`) left every
test green, deleting the filter while the suite still reported PASSED.

Add pr_bot_dismissed.json, a coderabbitai review in DISMISSED state at head
with a non-empty body, and test_bot_dismissed_at_head_fails asserting the gate
rejects it (rc=10, "FAILED: ...").

Red-first proof (counts read from the pytest summary, never from $? -- the
pre-existing taosmd.mcp_server.build_server import errors pin exit status at 1):
  - Mutate line 34 `if state not in (...)` to `if False:` by line number via
    sed, then: uv run --extra dev pytest tests/test_merge_gate.py -q -> 1 failed,
    6 passed (FAILED_COUNT=1, ERROR_COUNT=0). The mutated gate emits
    "SUCCESS: anchored substantive bot review found" (rc=0) for the dismissed
    review, and the new test catches it.
  - Restore line 34: uv run --extra dev pytest tests/test_merge_gate.py -q ->
    7 passed.

Anchoring and author filter branches are untouched; they are already pinned.

changelog: tsk-6pc3tu-merge-gate-review-state-fixture

Files:
 changelog.d/tsk-6pc3tu-merge-gate-review-state-fixture.md |  3 +++
 tests/fixtures/merge_gate/pr_bot_dismissed.json           | 14 ++++++++++++++
 tests/test_merge_gate.py                                  | 11 +++++++++++
 3 files changed, 28 insertions(+)