### PR TITLE
_db.connect cannot pass check_same_thread at all, so 16 of 17 store sites are thread-bound: enumerate which are actually cross-thread

### DIFF
--- a/changelog.d/tsk-a2pxc3-check-same-thread-param.md
+++ b/changelog.d/tsk-a2pxc3-check-same-thread-param.md
@@ -1,0 +1,11 @@
+### Added
+- `_db.connect` now accepts a keyword-only `check_same_thread: bool = True` parameter, forwarded to `sqlite3.connect`. This lets a caller explicitly opt into a cross-thread connection without bypassing the shared helper. The default preserves sqlite3's thread-affinity safety check for every existing caller.
+
+### Fixed
+- Thread-affinity audit of the 16 sites that open a store via `_db.connect` (excluding ReceiptStore, which already bypasses with a raw `sqlite3.connect(..., check_same_thread=False)`, and `mentions.py:31`, carded separately as tsk-wxymim). None of the remaining 15 are genuinely cross-thread under ThreadingHTTPServer: every connection is created and used on the single `_ServiceLoop` service-loop thread, because every HTTP handler delegates all DB work through `runner.run()` / `runner.spawn()` and no handler opens a store directly. The 15 sites are single-threaded by design:
+  - `archive.py:119`, `vector_memory.py:234`, `knowledge_graph.py:112`, `claims/store.py:42` -- created in `_ensure_stores` (api.py), cached in the module-level `_stores_cache`, and accessed only via `runner.run(service.xxx(data_dir=...))` on the service-loop thread.
+  - `tasks.py:121` (`_get_db`, module-level `_db_cache`) and `tasks.py:776` (`rebuild_from_archive`) -- accessed only from `service.task_*` wrappers on the service-loop thread.
+  - `pending_decisions.py:92` (api.py:915, api.py:951) -- opened and closed within a single service call on the service-loop thread.
+  - `collections.py:184` (`CollectionStore`) -- opened and closed within a single `_collection_store()` call in the service-layer wrappers.
+  - `access_tracker.py:54`, `browsing_history.py:39`, `crystallize.py:72`, `reflect.py:139`, `session_catalog.py:146` -- not instantiated in the HTTP dispatch table at all; only used in `auto_setup.py` (standalone) or `catalog_pipeline.py` (nightly cron, separate process with its own `asyncio.run`).
+  - `taosmd_backend.py:91` and `taosmd_backend.py:336` -- `TaOSmdBackend` is a MemoryBackend implementation for the taOS Memory app, not wired into the HTTP service dispatch or any background worker.

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -26,14 +26,27 @@ from typing import Union
 BUSY_TIMEOUT_MS = 5000
 
 
-def connect(db_path: Union[str, Path]) -> sqlite3.Connection:
+def connect(
+    db_path: Union[str, Path],
+    *,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
     """Open a SQLite connection in WAL mode with a busy timeout.
 
     Drop-in replacement for ``sqlite3.connect(db_path)``. Callers that need a
     ``row_factory`` or other connection attributes should set them on the
     returned connection as before.
+
+    ``check_same_thread`` is keyword-only and defaults to ``True`` so every
+    existing caller keeps sqlite3's thread-affinity safety check. Set it to
+    ``False`` only when the connection will be shared across threads (e.g.
+    opened on a background loop thread and accessed from a request thread);
+    under the current :class:`~taosmd.http_server.ThreadingHTTPServer` +
+    :class:`~taosmd.http_server._ServiceLoop` design every store connection
+    is created and used on the single service-loop thread, so the default is
+    correct and the parameter is an explicit opt-in, not a blanket flip.
     """
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, check_same_thread=check_same_thread)
     # ``PRAGMA journal_mode`` echoes the journal mode actually in effect. WAL
     # can silently refuse to engage on filesystems without shared-memory/mmap
     # support (notably some network mounts), where it falls back to the prior

--- a/tests/test_db_check_same_thread.py
+++ b/tests/test_db_check_same_thread.py
@@ -1,0 +1,77 @@
+"""Tests for the ``check_same_thread`` parameter on :func:`_db.connect`.
+
+Under the ThreadingHTTPServer + _ServiceLoop design every store connection is
+created and used on the single service-loop thread, so the default
+``check_same_thread=True`` is correct for all current call sites. But the
+parameter must be a real, behavioural opt-in -- not a no-op -- so callers that
+genuinely need cross-thread access (e.g. ReceiptStore today, future store
+refactors tomorrow) can request it.
+
+These tests prove the parameter actually changes sqlite3's behaviour: the
+default raises ``sqlite3.ProgrammingError`` when a connection is touched from a
+thread other than the one that opened it, while ``check_same_thread=False``
+permits it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+from taosmd import _db
+
+
+def test_default_check_same_thread_raises_on_foreign_thread(tmp_path):
+    """Without the opt-in, sqlite3 enforces thread affinity.
+
+    On master this raises ``sqlite3.ProgrammingError``; after the fix it still
+    does, because the default stays ``True`` and no caller was changed.
+    """
+    db_path = str(tmp_path / "thread_bound.db")
+    conn = _db.connect(db_path)
+    result: dict = {}
+
+    def worker():
+        try:
+            conn.execute("CREATE TABLE IF NOT EXISTS t (x INTEGER)")
+            conn.execute("INSERT INTO t VALUES (1)")
+            conn.commit()
+            result["count"] = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        except sqlite3.ProgrammingError as exc:
+            result["error"] = exc
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=10)
+    conn.close()
+
+    assert "error" in result, "expected sqlite3.ProgrammingError on cross-thread use"
+    assert "count" not in result, "connection should not have succeeded"
+
+
+def test_check_same_thread_false_allows_cross_thread(tmp_path):
+    """The explicit opt-in disables the thread-affinity check.
+
+    Fails on master with ``TypeError`` (the parameter does not exist yet);
+    passes after the fix.
+    """
+    db_path = str(tmp_path / "thread_free.db")
+    conn = _db.connect(db_path, check_same_thread=False)
+    result: dict = {}
+
+    def worker():
+        try:
+            conn.execute("CREATE TABLE IF NOT EXISTS t (x INTEGER)")
+            conn.execute("INSERT INTO t VALUES (1)")
+            conn.commit()
+            result["count"] = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        except sqlite3.ProgrammingError as exc:
+            result["error"] = exc
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=10)
+    conn.close()
+
+    assert "error" not in result, result.get("error")
+    assert result.get("count") == 1


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): _db.connect cannot pass check_same_thread at all, so 16 of 17 store sites are thread-bound: enumerate which are actually cross-thread

Autonomous build of board card tsk-a2pxc3.

Add a keyword-only check_same_thread parameter to _db.connect (defaulting
to True), forwarded to sqlite3.connect. This lets a caller explicitly opt
into a cross-thread connection without bypassing the shared helper.

Enumeration from the ThreadingHTTPServer dispatch table: ZERO of the 16
_db.connect call sites are genuinely cross-thread. Every HTTP handler
delegates all DB work through runner.run() or runner.spawn(), which
dispatches to the single _ServiceLoop background thread. No handler opens
a store directly. The 15 sites (excluding mentions.py:31, carded as
tsk-wxymim) are single-threaded by design:

  - _ensure_stores stores (archive, vector_memory, knowledge_graph,
    claims): created and cached on the service-loop thread, all access
    via runner.run(service.xxx(data_dir=...))
  - tasks._get_db + rebuild_from_archive: accessed only from
    service.task_* wrappers on the service-loop thread
  - pending_decisions: opened and closed within a single service call
  - collections.CollectionStore: opened and closed within
    _collection_store() per call
  - access_tracker, browsing_history, crystallize, reflect,
    session_catalog: not in the HTTP dispatch table at all
  - taosmd_backend: not wired into the HTTP service dispatch

A blanket flip to check_same_thread=False across all 16 would silently
remove sqlite3 thread-affinity safety check from stores that do not need
it. No call sites changed; the parameter is an explicit opt-in.

Tests: test_default_check_same_thread_raises_on_foreign_thread (passes
on master and fix, demonstrating the default ProgrammingError) and
test_check_same_thread_false_allows_cross_thread (fails on master with
TypeError, passes after fix). On master: 1 passed, 1 failed. After fix:
2 passed.

Files:
 changelog.d/tsk-a2pxc3-check-same-thread-param.md | 11 ++++
 taosmd/_db.py                                     | 17 ++++-
 tests/test_db_check_same_thread.py                | 77 +++++++++++++++++++++++
 3 files changed, 103 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control SQLite connection thread affinity.
  - Connections remain restricted to their creating thread by default.
  - Callers can opt in to safely using a connection across threads.

- **Documentation**
  - Documented the new connection option and reviewed existing connection usage.

- **Tests**
  - Added coverage for both default thread restrictions and cross-thread access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->