### PR TITLE
Re-land ONLY the doc-gate trigger half of PR #457: the scripts/merge-gate/** entry is proven correct, but the must-FAIL list must stay at NINE because #190 still fails

### DIFF
--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -84,7 +84,7 @@ hint = "changes to the A2A handlers (taosmd/http_server.py, taosmd/service.py) r
 # documented in docs/pr-verification.md (this rule fires on that doc itself,
 # so gutting a required section here is caught, not just add/delete).
 name = "contributor-surface"
-when_changed = [".github/workflows/**", "pyproject.toml", "docs/pr-verification.md"]
+when_changed = [".github/workflows/**", "pyproject.toml", "docs/pr-verification.md", "scripts/merge-gate/**"]
 on_modify = true
 require_doc = ["docs/pr-verification.md"]
 hint = "changes to .github/workflows or pyproject require docs/pr-verification.md reviewed"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Re-land ONLY the doc-gate trigger half of PR #457: the scripts/merge-gate/** entry is proven correct, but the must-FAIL list must stay at NINE because #190 still fails

Autonomous build of board card tsk-24s6yt.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

Adds the scripts/merge-gate/** entry to the contributor-surface rule in
docs/doc-gate.toml. The must-FAIL list in docs/pr-verification.md is
untouched (stays at nine, including #190).

Proofs captured in this tree:

Bot anchoring (check_bot_anchoring.sh):
  #190 -> rc=10 FAILED: no anchored substantive bot review found
  #230 -> rc=0  SUCCESS: anchored substantive bot review found

Doc-gate differential (scripts/check_doc_gate.py diff-gate --staged):
  master config + staged scripts/merge-gate/ edit -> rc=0 clean
  merged config + staged scripts/merge-gate/ edit -> rc=1 DOC-GATE FAIL: contributor-surface
  merged config + empty index                   -> rc=0 clean

Pytest baseline (./.venv/bin/python -m pytest -q -p no:randomly):
  1898 passed, 10 skipped, 7 errors
  taosmd.__file__ = /tmp/exec-tsk-24s6yt/taosmd/__init__.py

Ruff 0.16.3 over taosmd/ tests/ benchmarks/: all checks passed
No em dashes in added diff lines.

Files:
 docs/doc-gate.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documentation validation now also runs when merge-gate scripts are changed.
  - This helps keep related documentation checks aligned with updates to repository automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->