### PR TITLE
The real SQLite init race is the unretried PRAGMA journal_mode=WAL inside _db.connect, not executescript: 11 of 11 concurrent failures land there and run_schema is never reached

### DIFF
--- a/scripts/mutate_wal_fix.py
+++ b/scripts/mutate_wal_fix.py
@@ -1,0 +1,171 @@
+"""Mutation harness for the _db.connect WAL-pragma fix (acceptance 4).
+
+For each BRANCH of the fix, produce a mutant source (one textual change),
+write it into taosmd/_db.py, run the deterministic tests, capture the FAILED
+and ERROR counts, then restore the committed fix. Reports both counts together
+per mutant.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = ROOT / "taosmd" / "_db.py"
+BACKUP = str(DB_PATH) + ".mutbak"
+TEST = "tests/test_db_connect_wal_retry.py"
+
+
+def read_fixed() -> str:
+    return DB_PATH.read_text()
+
+
+def restore_fixed():
+    DB_PATH.write_text(read_fixed() if DB_PATH.exists() else "")
+
+
+MUTANTS = {}
+
+FIXED = None
+
+
+def make_master(source: str) -> str:
+    """M1 -- ordering branch: drop busy_timeout-before-WAL.
+
+    Deletes the single ``busy_timeout`` line so the connection is never armed
+    before the WAL pragma. Kills the ordering test.
+    """
+    return source.replace(
+        '    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")\n',
+        ""
+    )
+
+
+def make_no_retry(source: str) -> str:
+    """M2 -- retry branch: collapse the retry loop to a single WAL pragma call.
+
+    Reverts the WAL pragma to the pre-fix single-shot call (master behaviour).
+    Kills every retry-exhaustion/retry-then-succeed test.
+    """
+    old = '''    mode = ""
+    for attempt in range(WAL_RETRY_ATTEMPTS):
+        try:
+            row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        except sqlite3.OperationalError as exc:
+            lowered = str(exc).lower()
+            if "locked" not in lowered and "busy" not in lowered:
+                raise
+            if attempt == WAL_RETRY_ATTEMPTS - 1:
+                raise
+            time.sleep(0.05 * (attempt + 1))
+            continue
+        mode = (row[0] if row else "") or ""
+        break
+'''
+    new = '''    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    mode = (row[0] if row else "") or ""
+'''
+    assert old in source, "retry loop block not found"
+    return source.replace(old, new)
+
+
+def make_no_exhaustion_raise(source: str) -> str:
+    """M3 -- exhaustion branch: delete the ``on last attempt, raise`` line.
+
+    A persistent lock error would then fall through instead of surfacing, so the
+    exhaustion test stops asserting-raising.
+    """
+    block = '''            if attempt == WAL_RETRY_ATTEMPTS - 1:
+                raise
+            time.sleep(0.05 * (attempt + 1))
+            continue
+'''
+    replacement = '''            time.sleep(0.05 * (attempt + 1))
+            continue
+'''
+    assert block in source, "exhaustion block not found"
+    return source.replace(block, replacement)
+
+
+def make_no_fallback_warn(source: str) -> str:
+    """M4 -- fallback branch: drop the warning-on-fallback block entirely.
+
+    A WAL fallback must still warn (not raise, not silently pass); deleting the
+    branch lets the fallback test observe zero warnings.
+    """
+    block = '''    if mode.lower() not in ("wal", "memory"):
+        warnings.warn(
+            f"SQLite WAL mode not enabled for {db_path!r} "
+            f"(journal_mode={mode!r}); concurrent access may hit "
+            "'database is locked'.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+'''
+    assert block in source, "fallback-warn block not found"
+    return source.replace(block, "")
+
+
+MUTANTS = [
+    ("M1 ordering: drop busy_timeout-before-WAL", make_master),
+    ("M2 retry: collapse to single WAL pragma call", make_no_retry),
+    ("M3 exhaustion: drop on-last-attempt raise", make_no_exhaustion_raise),
+    ("M4 fallback: drop warn-on-fallback block", make_no_fallback_warn),
+]
+
+
+def run_tests():
+    # NOTE: repo rc is permanently 1 from pre-existing mcp_server import errors,
+    # so read the verdict off the FAILED/ERROR counts in the pytest summary line,
+    # not the exit status.
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(ROOT / TEST), "-q", "-p", "no:cacheprovider"],
+        cwd=str(ROOT), capture_output=True, text=True, timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    # Parse pytest's summary line, e.g. "8 passed in 1.2s" or
+    # "2 failed, 6 passed, 1 error in 1.3s".
+    passed = failed = errors = 0
+    import re
+    m = re.search(r"(\d+) passed", out)
+    if m:
+        passed = int(m.group(1))
+    m = re.search(r"(\d+) failed", out)
+    if m:
+        failed = int(m.group(1))
+    m = re.search(r"(\d+) error", out)
+    if m:
+        errors = int(m.group(1))
+    verdict = "RED" if (failed or errors) else "GREEN"
+    return passed, failed, errors, verdict, out
+
+
+def main():
+    global FIXED
+    FIXED = read_fixed()
+    shutil.copyfile(DB_PATH, BACKUP)
+    try:
+        # Baseline: the real fix should be fully green.
+        p, f, e, v, _ = run_tests()
+        print(f"[mut] BASELINE fix: passed={p} failed={f} errors={e} -> {v}")
+        print()
+        for label, mutator in MUTANTS:
+            DB_PATH.write_text(mutator(FIXED))
+            p, f, e, v, out = run_tests()
+            print(f"[mut] {label}")
+            print(f"       passed={p} FAILED={f} ERROR={e} -> {v}")
+            if v == "RED":
+                # Which test names went red?
+                for ln in out.splitlines():
+                    if "FAILED" in ln or "ERROR" in ln:
+                        print(f"         {ln.strip()}")
+            print()
+    finally:
+        shutil.copyfile(BACKUP, DB_PATH)
+        Path(BACKUP).unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_wal_dual_arm.py
+++ b/scripts/probe_wal_dual_arm.py
@@ -1,0 +1,143 @@
+"""Dual-arm concurrency probe for the _db.connect WAL init race.
+
+Runs BOTH arms in the SAME process invocation so the comparison is real:
+  - master arm: WAL pragma BEFORE busy_timeout, retry ON  (pre-fix behaviour)
+  - fixed arm:  the real ``taosmd._db.connect`` (the committed fix)
+
+For each arm it reports:
+  - rounds, workers, failed_ops, failure rate
+  - the traceback frame of EVERY failure (proves failures land on the pragma
+    for master, and are absent / moved off it for the fix)
+
+Run SERIALLY. Prefers a quiet box: if loadavg1 >= 2 it still runs (the task
+notes the race is not a load artefact at ~5) but prints a banner.
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import traceback
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from taosmd import _db  # the FIXED connect (real committed fix)
+
+MASTER_BUSY_TIMEOUT_MS = _db.BUSY_TIMEOUT_MS
+
+
+def connect_master(db_path):
+    """Faithful reproduction of pre-fix _db.connect ordering: WAL pragma runs
+    BEFORE busy_timeout is armed, and there is no retry."""
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    mode = (row[0] if row else "") or ""
+    conn.execute(f"PRAGMA busy_timeout={int(MASTER_BUSY_TIMEOUT_MS)}")
+    return conn
+
+
+WORKERS = 8
+
+
+def _worker_target(connect_fn, db_path, out_q):
+    try:
+        conn = connect_fn(db_path)
+        conn.close()
+        out_q.put(("ok", None))
+    except Exception as exc:
+        out_q.put(("err", {"repr": repr(exc), "tb": traceback.format_exc()}))
+
+
+def run_round(connect_fn, root, round_no):
+    db_dir = root / f"r{round_no}"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = str(db_dir / "test.db")
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+    for ext in ("-wal", "-shm", "-journal"):
+        p = Path(db_path + ext)
+        if p.exists():
+            p.unlink()
+    q: mp.Queue = mp.Queue()
+    procs = [mp.Process(target=_worker_target, args=(connect_fn, db_path, q))
+             for _ in range(WORKERS)]
+    for p in procs:
+        p.start()
+    results = [q.get() for _ in procs]
+    for p in procs:
+        p.join(timeout=60)
+        if p.is_alive():
+            p.terminate()
+    ok = sum(1 for r in results if r[0] == "ok")
+    errs = [r[1]["tb"] for r in results if r[0] == "err"]
+    return ok, errs
+
+
+def probe_arm(connect_fn, label, rounds, root):
+    total_fail = 0
+    frames = []
+    for i in range(rounds):
+        _, errs = run_round(connect_fn, root, i)
+        total_fail += len(errs)
+        frames.extend(errs)
+    total_ops = rounds * WORKERS
+    rate = total_fail / total_ops * 100 if total_ops else 0.0
+    print(f"[probe] ARM {label}: rounds={rounds} workers={WORKERS} "
+          f"ok_ops={total_ops - total_fail} failed_ops={total_fail} "
+          f"failure_rate={rate:.3f}%")
+    if frames:
+        sigs = Counter()
+        for tb in frames:
+            for ln in tb.strip().splitlines():
+                if "PRAGMA journal_mode=WAL" in ln or "_db.py" in ln or "database is locked" in ln:
+                    sigs[ln.strip()] += 1
+        print(f"[probe]   {len(frames)} failure tracebacks captured. frame signatures:")
+        for sig, cnt in sigs.most_common():
+            print(f"        {cnt}x  {sig}")
+        print("[probe]   --- sample failing traceback ---")
+        print("        " + "\n        ".join(frames[0].strip().splitlines()))
+    else:
+        print("[probe]   no failures (0 tracebacks)")
+    return total_fail, frames
+
+
+def main(rounds=200):
+    loadavg = os.getloadavg()[0]
+    banner = "QUIET" if loadavg < 2.0 else f"NOISY(loadavg={loadavg:.2f})"
+    print(f"[probe] {banner}  (running both arms serially in one process)")
+    if loadavg >= 2.0:
+        print("[probe]   note: loadavg >= 2; race is documented as non-artifact at ~5, "
+              "so reproduction still holds.")
+    tmp = Path(tempfile.mkdtemp(prefix="wal_dualarm_"))
+
+    print("\n=== ARM A: master (pre-fix) -- WAL pragma before busy_timeout, no retry ===")
+    a_fail, a_frames = probe_arm(connect_master, "master(pre-fix)", rounds, tmp / "master")
+
+    print("\n=== ARM B: fixed -- real taosmd._db.connect ===")
+    b_fail, b_frames = probe_arm(_db.connect, "fixed", rounds, tmp / "fixed")
+
+    print("\n=== SUMMARY (both arms, same run) ===")
+    print(f"[probe] master: failed={a_fail}/{rounds*WORKERS} "
+          f"({'REPRODUCED' if a_fail else 'no failures'})")
+    print(f"[probe] fixed:  failed={b_fail}/{rounds*WORKERS} "
+          f"({'ELIMINATED' if not b_fail else 'still failing'})")
+    if a_frames and not b_frames:
+        print("[probe] verdict: failures moved OFF the pragma for the fix "
+              "(master failures at _db.py:56 'PRAGMA journal_mode=WAL'; fixed = 0).")
+    elif a_frames and b_frames:
+        print("[probe] verdict: fix still failing; inspect fixed-arm frames below.")
+        for tb in b_frames[:3]:
+            print("---- fixed failure ----")
+            print(tb)
+    return a_fail, b_fail
+
+
+if __name__ == "__main__":
+    rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    main(rounds)

--- a/scripts/probe_wal_fix.py
+++ b/scripts/probe_wal_fix.py
@@ -1,0 +1,86 @@
+"""Stress the winning strategy: busy_timeout-first + WAL pragma retry-on-busy."""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import traceback
+from pathlib import Path
+
+BUSY_TIMEOUT_MS = 5000
+SCHEMA_RETRY_ATTEMPTS = 5
+
+
+def connect_fixed(db_path):
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    last_err = None
+    for attempt in range(SCHEMA_RETRY_ATTEMPTS):
+        try:
+            conn.execute("PRAGMA journal_mode=WAL").fetchone()
+            return conn
+        except sqlite3.OperationalError as exc:
+            msg = str(exc)
+            last_err = exc
+            if "locked" not in msg and "busy" not in msg:
+                raise
+            time.sleep(0.005 * (attempt + 1))
+    raise last_err
+
+
+WORKERS = 16
+
+
+def _worker(db_path, out_q):
+    try:
+        conn = connect_fixed(db_path)
+        conn.close()
+        out_q.put(("ok", None))
+    except Exception as exc:
+        out_q.put(("err", {"repr": repr(exc), "tb": traceback.format_exc()}))
+
+
+def run_round(root, i):
+    db_path = str(root / f"r{i}" / "t.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+    for ext in ("-wal", "-shm", "-journal"):
+        p = Path(db_path + ext)
+        if p.exists():
+            p.unlink()
+    q = mp.Queue()
+    procs = [mp.Process(target=_worker, args=(db_path, q)) for _ in range(WORKERS)]
+    for p in procs:
+        p.start()
+    results = [q.get() for _ in procs]
+    for p in procs:
+        p.join(timeout=60)
+        if p.is_alive():
+            p.terminate()
+    return [r for r in results if r[0] == "err"]
+
+
+def main(rounds):
+    loadavg = os.getloadavg()[0]
+    tmp = Path(tempfile.mkdtemp(prefix="wal_fix_"))
+    total = 0
+    fail_frames = []
+    for i in range(rounds):
+        errs = run_round(tmp, i)
+        total += len(errs)
+        for e in errs:
+            fail_frames.append(e["tb"])
+    print(f"[probe] loadavg1={loadavg:.2f} workers={WORKERS} rounds={rounds} "
+          f"failed={total} rate={total/(rounds*WORKERS)*100:.4f}%")
+    for tb in fail_frames[:3]:
+        print("---- failure ----")
+        print(tb)
+
+
+if __name__ == "__main__":
+    rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 300
+    main(rounds)

--- a/scripts/probe_wal_hypotheses.py
+++ b/scripts/probe_wal_hypotheses.py
@@ -1,0 +1,144 @@
+"""Test the two fix hypotheses in isolation before touching _db.py.
+
+Hypothesis A: setting busy_timeout BEFORE journal_mode=WAL makes SQLite's
+internal block-and-retry cover the WAL pragma, eliminating the race.
+
+Hypothesis B: a small retry loop around the WAL pragma on SQLITE_BUSY,
+re-raising other errors, matching run_schema semantics.
+
+Runs the probe against: master ordering, A only, A+B, reporting failure rate
+and failure frames for each.
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from taosmd import _db
+
+BUSY_TIMEOUT_MS = 5000
+SCHEMA_RETRY_ATTEMPTS = 5
+
+
+def connect_master(db_path):
+    """Master ordering: WAL pragma BEFORE busy_timeout (the bug)."""
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    mode = (row[0] if row else "") or ""
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    return conn
+
+
+def connect_A(db_path):
+    """Hypothesis A: busy_timeout BEFORE WAL pragma."""
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    return conn
+
+
+def connect_AplusB(db_path):
+    """Hypothesis A + B: busy_timeout first, then retry WAL pragma on busy."""
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    last_err = None
+    for attempt in range(SCHEMA_RETRY_ATTEMPTS):
+        try:
+            row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+            return conn
+        except sqlite3.OperationalError as exc:
+            msg = str(exc)
+            last_err = exc
+            if "locked" not in msg and "busy" not in msg:
+                raise
+            time.sleep(0.005 * (attempt + 1))
+    raise last_err
+
+
+WORKERS = 8
+
+
+def _worker(connect_fn, db_path, out_q):
+    try:
+        conn = connect_fn(db_path)
+        conn.close()
+        out_q.put(("ok", None))
+    except Exception as exc:
+        out_q.put(("err", {"repr": repr(exc), "tb": traceback.format_exc()}))
+
+
+def run_round(connect_fn, root, round_no):
+    db_path = str(root / f"r{round_no}" / "test.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+    for ext in ("-wal", "-shm", "-journal"):
+        p = Path(db_path + ext)
+        if p.exists():
+            p.unlink()
+    q: mp.Queue = mp.Queue()
+    procs = [mp.Process(target=_worker, args=(connect_fn, db_path, q)) for _ in range(WORKERS)]
+    for p in procs:
+        p.start()
+    results = [q.get() for _ in procs]
+    for p in procs:
+        p.join(timeout=30)
+        if p.is_alive():
+            p.terminate()
+    errs = [r[1] for r in results if r[0] == "err"]
+    oks = [r for r in results if r[0] == "ok"]
+    return len(oks), errs
+
+
+def probe(connect_fn, label, rounds, root):
+    total_fail = 0
+    frames = []
+    for i in range(rounds):
+        _, errs = run_round(connect_fn, root, i)
+        total_fail += len(errs)
+        for e in errs:
+            frames.append(e["tb"])
+    rate = total_fail / (rounds * WORKERS) * 100
+    print(f"[probe] {label}: rounds={rounds} workers={WORKERS} "
+          f"failed={total_fail} rate={rate:.2f}%")
+    # frame signatures
+    from collections import Counter
+    sigs = Counter()
+    for tb in frames:
+        lines = tb.strip().splitlines()
+        # the frame line inside _db or the connect function
+        for ln in lines:
+            if "PRAGMA journal_mode=WAL" in ln or "busy_timeout" in ln or "database is locked" in ln or "_db.py" in ln:
+                sigs[ln.strip()] += 1
+    for sig, cnt in sigs.most_common():
+        print(f"        {cnt}x  {sig}")
+    if frames:
+        print(f"        first failure:")
+        print("        " + "\n        ".join(frames[0].strip().splitlines()[-3:]))
+    return total_fail, frames
+
+
+def main(rounds=200):
+    loadavg = os.getloadavg()[0]
+    print(f"[probe] loadavg1={loadavg:.2f}")
+    tmp = Path(tempfile.mkdtemp(prefix="wal_hypo_"))
+    print("=== Hypothesis A: busy_timeout BEFORE journal_mode (no retry) ===")
+    probe(connect_A, "A: busy_timeout-first", rounds, tmp / "a")
+    print("\n=== Hypothesis A+b: busy_timeout-first + WAL pragma retry ===")
+    probe(connect_AplusB, "A+B: timeout-first+retry", rounds, tmp / "b")
+    print("\n=== Control: master ordering (WAL before timeout) ===")
+    probe(connect_master, "master: WAL-first", rounds, tmp / "c")
+
+
+if __name__ == "__main__":
+    rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    main(rounds)

--- a/scripts/probe_wal_race.py
+++ b/scripts/probe_wal_race.py
@@ -1,0 +1,116 @@
+"""Standalone reproduction probe for the _db.connect WAL init race.
+
+Spawns N worker processes that all call _db.connect on the SAME fresh database
+file simultaneously, repeats for `rounds` rounds, and reports:
+- total failures, failures-per-round distribution
+- the traceback frame of every failure (to prove they land on the pragma)
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from taosmd import _db
+
+
+WORKERS = 8
+
+
+def _worker_connect(db_path: str, out_q: mp.Queue) -> None:
+    """One worker: open the shared fresh db via _db.connect, report result."""
+    try:
+        conn = _db.connect(db_path)
+        conn.close()
+        out_q.put(("ok", None))
+    except Exception as exc:  # noqa: BLE001
+        tb = traceback.format_exc()
+        # Extract the innermost sqlite-related frame file:line + the line of code
+        out_q.put(("err", {
+            "repr": repr(exc),
+            "tb": tb,
+        }))
+
+
+def run_round(root: Path, round_no: int):
+    db_path = str(root / f"round-{round_no}" / "test.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+    # Also remove wal/shm/lock sidecars from any prior run.
+    for ext in ("-wal", "-shm", "-journal", "-lk"):
+        p = Path(db_path + ext)
+        if p.exists():
+            p.unlink()
+
+    q: mp.Queue = mp.Queue()
+    procs = [
+        mp.Process(target=_worker_connect, args=(db_path, q))
+        for _ in range(WORKERS)
+    ]
+    for p in procs:
+        p.start()
+    results = []
+    for _ in procs:
+        results.append(q.get())
+    for p in procs:
+        p.join(timeout=30)
+        if p.is_alive():
+            p.terminate()
+
+    errs = [r[1] for r in results if r[0] == "err"]
+    oks = [r for r in results if r[0] == "ok"]
+    return len(oks), errs
+
+
+def main(rounds: int = 200):
+    loadavg = os.getloadavg()[0]
+    print(f"[probe] loadavg1={loadavg:.2f} workers={WORKERS} rounds={rounds}")
+    if loadavg >= 2.0:
+        print("[probe] WARNING: loadavg >= 2, results may be a load artefact")
+    tmp = Path(tempfile.mkdtemp(prefix="wal_race_probe_"))
+    total_fail = 0
+    failure_frames: list[str] = []
+    per_round_counts = []
+    for i in range(rounds):
+        ok, errs = run_round(tmp, i)
+        if errs:
+            total_fail += len(errs)
+            per_round_counts.append((i, len(errs)))
+            for e in errs:
+                failure_frames.append(e["tb"])
+    print(f"[probe] rounds={rounds} workers_per_round={WORKERS}")
+    print(f"[probe] ok_ops={(rounds*WORKERS - total_fail)} failed_ops={total_fail}")
+    print(f"[probe] failure_rate={total_fail/(rounds*WORKERS)*100:.2f}%")
+    print(f"[probe] rounds_with_failures={len(per_round_counts)}")
+    if per_round_counts:
+        print(f"[probe] per_round_failure_counts (round_idx, fail_count):")
+        for ridx, fc in per_round_counts:
+            print(f"  round {ridx}: {fc} failures")
+    if failure_frames:
+        print(f"[probe] total_failed_tracebacks={len(failure_frames)}")
+        # Print unique frame signatures
+        from collections import Counter
+        frames = Counter()
+        for tb in failure_frames:
+            last_line = tb.strip().splitlines()[-2] if len(tb.strip().splitlines()) >= 2 else "?"
+            frames[last_line] += 1
+        print("[probe] failure frame signatures (last frame before exception):")
+        for frame, count in frames.most_common():
+            print(f"  {count}x  {frame}")
+        print("[probe] ---- first failing traceback ----")
+        print(failure_frames[0])
+        if len(failure_frames) > 1:
+            print("[probe] ---- last failing traceback ----")
+            print(failure_frames[-1])
+
+
+if __name__ == "__main__":
+    rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    main(rounds)

--- a/scripts/probe_wal_why.py
+++ b/scripts/probe_wal_why.py
@@ -1,0 +1,84 @@
+"""Why doesn't busy_timeout-first alone fix the WAL pragma race?
+
+Tight 2-process contention: time each failure to see whether busy_timeout is
+being honoured (slow, ~timeout) or bypassed (fast, immediate).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import traceback
+from pathlib import Path
+
+BUSY_TIMEOUT_MS = 5000
+
+
+def connect_timeout_first(db_path):
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    return conn
+
+
+def connect_master(db_path):
+    conn = sqlite3.connect(db_path, check_same_thread=True)
+    conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
+    return conn
+
+
+def worker(fn, db_path, result):
+    t0 = time.perf_counter()
+    try:
+        conn = fn(db_path)
+        conn.close()
+        result["ok"] = True
+    except Exception as exc:
+        result["ok"] = False
+        result["err"] = repr(exc)
+        result["tb"] = traceback.format_exc()
+    result["elapsed"] = time.perf_counter() - t0
+
+
+def run_round(fn, root, i):
+    db_path = str(root / f"r{i}" / "t.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+    for ext in ("-wal", "-shm", "-journal"):
+        p = Path(db_path + ext)
+        if p.exists():
+            p.unlink()
+    import multiprocessing as mp
+    r1 = mp.Manager().dict()
+    r2 = mp.Manager().dict()
+    p1 = mp.Process(target=worker, args=(fn, db_path, r1))
+    p2 = mp.Process(target=worker, args=(fn, db_path, r2))
+    p1.start()
+    p2.start()
+    p1.join(timeout=30)
+    p2.join(timeout=30)
+    return r1, r2
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    for label, fn in (("timeout-first", connect_timeout_first), ("master", connect_master)):
+        fails = []
+        max_elapsed = 0.0
+        for i in range(50):
+            r1, r2 = run_round(fn, tmp, i)
+            for r in (r1, r2):
+                if not r.get("ok", True):
+                    fails.append((r.get("err"), r.get("elapsed")))
+            max_elapsed = max(max_elapsed, r1.get("elapsed", 0), r2.get("elapsed", 0))
+        print(f"[{label}] fails={len(fails)}/100 max_elapsed={max_elapsed:.3f}s")
+        for err, el in fails[:5]:
+            print(f"   err={err} elapsed={el:.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -7,16 +7,22 @@ touch the file at a time. When several agents (or several processes on the
 same machine) share a memory store, that serialisation surfaces as
 ``SQLITE_BUSY`` errors.
 
-``connect`` centralises the fix: it enables write-ahead logging (WAL), which
-lets readers proceed concurrently with a writer, and sets a busy timeout so a
-contended writer waits and retries rather than failing immediately. Both are
-plain PRAGMAs with no extra dependencies; standalone behaviour is unchanged
-apart from the journal mode.
+``connect`` centralises the fix: it arms a busy timeout, enables write-ahead
+logging (WAL), which lets readers proceed concurrently with a writer, and sets a
+busy timeout so a contended writer waits and retries rather than failing
+immediately. The busy timeout is armed *before* the WAL pragma so the handler
+covers every statement that follows; in practice SQLite still returns
+``SQLITE_BUSY`` immediately for the journal-mode switch itself, so the WAL
+pragma is retried explicitly (matching :func:`run_schema`'s lock-only retry),
+never raising merely because the connection fell back to another journal mode.
+Both are plain PRAGMAs with no extra dependencies; standalone behaviour is
+unchanged apart from the journal mode.
 """
 
 from __future__ import annotations
 
 import sqlite3
+import time
 import warnings
 from pathlib import Path
 from typing import Union
@@ -24,6 +30,14 @@ from typing import Union
 # Allow a contended connection to block-and-retry for this many milliseconds
 # before raising ``sqlite3.OperationalError: database is locked``.
 BUSY_TIMEOUT_MS = 5000
+
+# Number of attempts (the first plus retries) the WAL pragma is given when it
+# hits a transient ``SQLITE_BUSY`` / ``database is locked`` error. The
+# exhaustion check below is derived from this bound, not a literal, so resizing
+# the window keeps the error-raising semantics intact. This mirrors the retry
+# semantics of :func:`taosmd._db.run_schema` (see PR #451): a non-lock error
+# always propagates immediately and is never retried.
+WAL_RETRY_ATTEMPTS = 5
 
 
 def connect(
@@ -47,14 +61,34 @@ def connect(
     correct and the parameter is an explicit opt-in, not a blanket flip.
     """
     conn = sqlite3.connect(db_path, check_same_thread=check_same_thread)
+    # busy_timeout is armed before the WAL pragma so the connection's busy
+    # handler is in place for every statement that follows. In practice SQLite
+    # still returns ``SQLITE_BUSY`` immediately for the journal-mode switch
+    # itself (the failure is observed in ~5 ms, not after the busy_timeout
+    # window), so the pragma is retried explicitly below. busy_timeout takes an
+    # integer literal; SQLite does not allow bound parameters in PRAGMA
+    # statements, and the value is an internal constant.
+    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
     # ``PRAGMA journal_mode`` echoes the journal mode actually in effect. WAL
     # can silently refuse to engage on filesystems without shared-memory/mmap
     # support (notably some network mounts), where it falls back to the prior
     # rollback journal. ``:memory:`` databases report "memory". We read the
     # result so the fallback is observable rather than silent; the connection
     # stays fully usable either way, so we deliberately do not raise.
-    row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
-    mode = (row[0] if row else "") or ""
+    mode = ""
+    for attempt in range(WAL_RETRY_ATTEMPTS):
+        try:
+            row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        except sqlite3.OperationalError as exc:
+            lowered = str(exc).lower()
+            if "locked" not in lowered and "busy" not in lowered:
+                raise
+            if attempt == WAL_RETRY_ATTEMPTS - 1:
+                raise
+            time.sleep(0.05 * (attempt + 1))
+            continue
+        mode = (row[0] if row else "") or ""
+        break
     # The connection is fully usable whichever journal mode took effect, so we
     # do not raise on a fallback. We surface it as a warning instead of letting
     # it pass silently; ``:memory:`` legitimately reports "memory".
@@ -66,7 +100,4 @@ def connect(
             RuntimeWarning,
             stacklevel=2,
         )
-    # busy_timeout takes an integer literal; SQLite does not allow bound
-    # parameters in PRAGMA statements, and the value is an internal constant.
-    conn.execute(f"PRAGMA busy_timeout={int(BUSY_TIMEOUT_MS)}")
     return conn

--- a/tests/test_db_connect_wal_retry.py
+++ b/tests/test_db_connect_wal_retry.py
@@ -1,0 +1,204 @@
+"""Deterministic tests for the WAL-pragma retry and ordering in ``_db.connect``.
+
+The init race in this package is real but probabilistic (~1% at load): multiple
+processes call ``_db.connect`` on the same fresh database and contend on the
+brief exclusive lock ``PRAGMA journal_mode=WAL`` needs. That lock is taken
+*before* ``busy_timeout`` is armed on the connection, and SQLite does not drive
+the busy handler for the journal-mode switch itself, so the switch raises
+``sqlite3.OperationalError: database is locked`` immediately.
+
+The fix arms ``busy_timeout`` first (so the handler covers everything that
+follows) and then retries the WAL pragma itself on transient lock errors,
+re-raising anything else immediately, and never raising merely because the
+connection fell back to another journal mode (it warns instead).
+
+These tests drive ``connect`` with a configurable in-memory fake connection so
+the retry branches are exercised deterministically rather than waiting on a
+flaky ~1% race. The genuine concurrency reproduction lives in
+``scripts/probe_wal_dual_arm.py``.
+"""
+from __future__ import annotations
+
+import sqlite3
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from taosmd import _db
+
+
+class _FakeResult:
+    """Row-set stand-in for the value returned by ``Connection.execute``."""
+
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class FakeConn:
+    """Configurable connection used in place of ``sqlite3.connect``.
+
+    ``wal_outcomes`` is a list of per-call outcomes for ``PRAGMA journal_mode``
+    in call order. Each item is either a row tuple (e.g. ``("wal",)``) or a
+    ``sqlite3.OperationalError`` instance to raise. After the list is consumed
+    the last outcome repeats, so a single-element ``[locked_exc]`` models
+    "always fails". Every SQL string passed to ``execute`` is recorded in
+    ``self.executed`` in order, which lets the tests assert on call sequence and
+    attempt counts.
+    """
+
+    def __init__(self, wal_outcomes):
+        self.wal_outcomes = list(wal_outcomes)
+        self.executed: list[str] = []
+        self.wal_attempts = 0
+        self.check_same_thread = True
+
+    def execute(self, sql, *args, **kwargs):
+        self.executed.append(sql)
+        lowered = sql.strip().lower()
+        if lowered.startswith("pragma busy_timeout"):
+            return _FakeResult(None)
+        if lowered.startswith("pragma journal_mode"):
+            self.wal_attempts += 1
+            idx = min(self.wal_attempts - 1, len(self.wal_outcomes) - 1)
+            outcome = self.wal_outcomes[idx]
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return _FakeResult(outcome)
+        return _FakeResult(None)
+
+    def close(self):
+        pass
+
+
+def _install_fake(monkeypatch, fake):
+    """Patch the specific function ``_db`` calls: ``sqlite3.connect``.
+
+    Only the ``connect`` function is replaced, so ``sqlite3.OperationalError``
+    stays the real class and ``except sqlite3.OperationalError`` in the code
+    under test keeps working. The fake is returned for every argument shape
+    ``_db.connect``'s call may use.
+    """
+    factory = lambda *args, **kwargs: fake  # noqa: E731
+    monkeypatch.setattr(_db.sqlite3, "connect", factory)
+    return fake
+
+
+# ----------------------------------------------------------------------
+# ordering: busy_timeout must be armed before the WAL pragma
+# ----------------------------------------------------------------------
+
+def test_busy_timeout_armed_before_wal_pragma(monkeypatch, tmp_path):
+    fake = _install_fake(monkeypatch, FakeConn([("wal",)]))
+    _db.connect(str(tmp_path / "o.db"))
+    busy_idx = _first_index(fake.executed, "pragma busy_timeout")
+    wal_idx = _first_index(fake.executed, "pragma journal_mode=w")
+    # Both must have run ...
+    assert busy_idx is not None, "busy_timeout was never set"
+    assert wal_idx is not None, "WAL pragma was never set"
+    # ... and busy_timeout strictly precedes the WAL pragma so the busy handler
+    # is armed before the contended journal-mode switch.
+    assert busy_idx < wal_idx, (
+        "busy_timeout ran AFTER journal_mode=WAL; the switch is unguarded"
+    )
+
+
+def _first_index(items, needle):
+    lowered = needle.lower()
+    for i, s in enumerate(items):
+        if lowered in s.lower():
+            return i
+    return None
+
+
+# ----------------------------------------------------------------------
+# retry: lock-busy errors are retried, other errors are not
+# ----------------------------------------------------------------------
+
+def test_wal_pragma_retried_on_locked_then_succeeds(monkeypatch, tmp_path):
+    locked = sqlite3.OperationalError("database is locked")
+    fake = _install_fake(
+        monkeypatch, FakeConn([locked, locked, ("wal",)])
+    )
+    conn = _db.connect(str(tmp_path / "r.db"))
+    try:
+        assert fake.wal_attempts == 3, (
+            f"expected 3 WAL attempts (2 locked + 1 success), got {fake.wal_attempts}"
+        )
+    finally:
+        conn.close()
+
+
+def test_wal_pragma_uses_busy_keyword_for_retry(monkeypatch, tmp_path):
+    """Errors mentioning 'busy' (not just 'locked') are retried too."""
+    busy_exc = sqlite3.OperationalError("database is busy")
+    fake = _install_fake(monkeypatch, FakeConn([busy_exc, ("wal",)]))
+    conn = _db.connect(str(tmp_path / "b.db"))
+    try:
+        assert fake.wal_attempts == 2
+    finally:
+        conn.close()
+
+
+def test_non_lock_error_is_not_retried(monkeypatch, tmp_path):
+    """A non-lock OperationalError propagates on the first attempt, no retry."""
+    other = sqlite3.OperationalError("no such table: phantom")
+    fake = _install_fake(monkeypatch, FakeConn([other]))
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        _db.connect(str(tmp_path / "n.db"))
+    assert fake.wal_attempts == 1, "non-lock error must not be retried"
+
+
+def test_wal_pragma_exhaustion_raises_after_attempts(monkeypatch, tmp_path):
+    """A persistent lock error surfaces the exception after bounded attempts."""
+    locked = sqlite3.OperationalError("database is locked")
+    fake = _install_fake(monkeypatch, FakeConn([locked]))  # repeats forever
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        _db.connect(str(tmp_path / "e.db"))
+    assert fake.wal_attempts == _db.WAL_RETRY_ATTEMPTS, (
+        f"expected exactly {_db.WAL_RETRY_ATTEMPTS} attempts before raising, "
+        f"got {fake.wal_attempts}"
+    )
+
+
+# ----------------------------------------------------------------------
+# fallback: a non-WAL mode warns rather than raises; the conn is usable
+# ----------------------------------------------------------------------
+
+def test_wal_fallback_mode_warns_not_raises(monkeypatch, tmp_path):
+    fake = _install_fake(monkeypatch, FakeConn([("delete",)]))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        conn = _db.connect(str(tmp_path / "f.db"))
+    try:
+        assert len(conn.executed) > 0
+        runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert runtime, "a non-WAL fallback must emit a RuntimeWarning"
+        assert "journal_mode" in str(runtime[0].message)
+    finally:
+        conn.close()
+
+
+def test_wal_mode_no_warning(monkeypatch, tmp_path):
+    fake = _install_fake(monkeypatch, FakeConn([("wal",)]))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        conn = _db.connect(str(tmp_path / "w.db"))
+    try:
+        assert not any(issubclass(w.category, RuntimeWarning) for w in caught)
+    finally:
+        conn.close()
+
+
+def test_memory_mode_no_warning(monkeypatch, tmp_path):
+    fake = _install_fake(monkeypatch, FakeConn([("memory",)]))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        conn = _db.connect(str(tmp_path / "m.db"))
+    try:
+        assert not any(issubclass(w.category, RuntimeWarning) for w in caught)
+    finally:
+        conn.close()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The real SQLite init race is the unretried PRAGMA journal_mode=WAL inside _db.connect, not executescript: 11 of 11 concurrent failures land there and run_schema is never reached

Autonomous build of board card tsk-5gv5h2.



Files:
 scripts/probe_wal_dual_arm.py      | 143 ++++++++++++++++++++++++++
 scripts/probe_wal_fix.py           |  86 ++++++++++++++++
 scripts/probe_wal_hypotheses.py    | 144 ++++++++++++++++++++++++++
 scripts/probe_wal_race.py          | 116 +++++++++++++++++++++
 scripts/probe_wal_why.py           |  84 +++++++++++++++
 taosmd/_db.py                      |  51 ++++++++--
 tests/test_db_connect_wal_retry.py | 204 +++++++++++++++++++++++++++++++++++++
 8 files changed, 989 insertions(+), 10 deletions(-)