### PR TITLE
RE-CUT #454 fresh off master: the migrations.py _db.connect one-liner is correct, but its test cannot fail and it silently drops live coverage

### DIFF
--- a/changelog.d/tsk-7oqygo-status-all-uses-db-helper.md
+++ b/changelog.d/tsk-7oqygo-status-all-uses-db-helper.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `migrations.status_all()` now opens each present database through the shared
+  `taosmd._db.connect` helper, so it picks up the package-wide WAL journal
+  mode and busy timeout instead of taking a bare `sqlite3.connect`. The
+  absent-database branch is still skipped, and the new test in
+  `tests/test_migrations.py` fails if the bare connect is restored.

--- a/taosmd/migrations.py
+++ b/taosmd/migrations.py
@@ -642,7 +642,8 @@ def status_all(data_dir: Union[str, Path]) -> list[dict]:
                 "pending": [m.name for m in REGISTRY[db]],
             })
             continue
-        conn = sqlite3.connect(str(path))
+        from taosmd import _db
+        conn = _db.connect(path)
         try:
             row = status(conn, db)
         finally:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -453,6 +453,35 @@ def test_status_all_skips_absent_databases(tmp_path):
     assert all(r["current"] is False for r in rows)
 
 
+def test_status_all_opens_databases_via_the_shared_db_helper(tmp_path):
+    """``status_all`` must route through ``_db.connect`` so the connection
+    picks up the package-wide WAL mode and busy timeout that every other
+    store path receives. The fixture starts as a bare ``sqlite3.connect``
+    on a fresh file so the journal mode is ``delete``; only ``status_all``
+    can flip it to ``wal`` by re-opening the file via ``_db.connect``.
+    """
+    from taosmd.archive import INDEX_SCHEMA
+
+    path = tmp_path / "archive-index.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(INDEX_SCHEMA)
+    conn.commit()
+    conn.close()
+
+    mode_before = sqlite3.connect(path).execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode_before.lower() == "delete", (
+        "fixture must start in rollback-journal mode so only status_all can move it"
+    )
+
+    rows = [r for r in migrations.status_all(tmp_path) if r["exists"]]
+    assert len(rows) == 1
+
+    mode_after = sqlite3.connect(path).execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode_after.lower() == "wal", (
+        f"status_all must open the database via _db.connect, but journal_mode={mode_after!r}"
+    )
+
+
 def test_migrate_all_brings_every_present_database_current(tmp_path):
     from taosmd.archive import INDEX_SCHEMA
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): RE-CUT #454 fresh off master: the migrations.py _db.connect one-liner is correct, but its test cannot fail and it silently drops live coverage

Autonomous build of board card tsk-7oqygo.

WHAT THIS CHANGES
- taosmd/migrations.py: status_all now opens each present database with
  taosmd._db.connect instead of a bare sqlite3.connect, picking up the
  package-wide WAL mode and busy timeout. The absent-database branch is
  unchanged.
- tests/test_migrations.py: new test_status_all_opens_databases_via_the_shared_db_helper
  builds its fixture with a bare sqlite3.connect on a fresh file (journal
  mode 'delete'), runs status_all, then re-opens the file with a bare
  sqlite3.connect and asserts the journal mode flipped to 'wal'. That
  proves the helper was used; a bare sqlite3.connect on a fresh file
  cannot move the journal mode to wal, so the test fails on the previous
  bare-connect code path.
- changelog.d/tsk-7oqygo-status-all-uses-db-helper.md: fragment for the
  doc gate. Last byte 0x0a, verified with tail -c1 | xxd.

ACCEPTANCE PROOFS (measured on the branch, by line-number mutation)

1. Reverting only taosmd/migrations.py:646 from _db.connect(path) to
   sqlite3.connect(str(path)) and running tests/test_migrations.py:
   FAILED=1 (test_status_all_opens_databases_via_the_shared_db_helper),
   ERROR=0. Control: the same line numbers on master (no test) stayed at
   FAILED=0 ERROR=0, so the failure is attributable to this card.

2. Mutant taosmd/migrations.py:641 'current': False -> True: KILLED.
   test_status_all_skips_absent_databases (already on master, kept here)
   fails: assert all(r['current'] is False for r in rows) -> assert False.
   FAILED=1, ERROR=0.

3. tail -c1 changelog.d/tsk-7oqygo-status-all-uses-db-helper.md | xxd
   returns 0a. scripts/check_trailing_newline.py exits 0 (clean).

4. Full suite on this branch: 1898 passed, 12 skipped, 0 failed
   (the 7 pre-existing mcp_server collection errors on master did not
   reproduce in this run; the key constraint is FAILED=0 and passed
   strictly higher than the 1806 baseline recorded on bb8dfc09).

OUT OF SCOPE
- taosmd/receipts.py:56 is a separate bare sqlite3.connect that
  belongs to the open _db cluster (tsk-a2pxc3). The changelog prose is
  scoped to status_all and does not claim 'every other path'.

Files:
 .../tsk-7oqygo-status-all-uses-db-helper.md        |  7 ++++++
 taosmd/migrations.py                               |  3 ++-
 tests/test_migrations.py                           | 29 ++++++++++++++++++++++
 3 files changed, 38 insertions(+), 1 deletion(-)