### PR TITLE
POST /a2a/threads: validate each participants element, not just the container (re-cut of #460)

### DIFF
--- a/changelog.d/tsk-qxme7q-participant-validation.md
+++ b/changelog.d/tsk-qxme7q-participant-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Validated each element of `participants` in `a2a_create_thread` before it reaches the database, rejecting `None`, non-string types, and empty strings with `ValueError` (mapped to HTTP 400) instead of leaking internal schema names via HTTP 500. Duplicate participants are now de-duplicated so that each principal receives exactly one `membership_created` archive event and a single, unchanged `created_at` in the store.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -468,6 +468,14 @@ The caller (`agent` field in the request body) is added as owner on thread
 creation. Adding or removing a member requires the caller to be an owner, and
 the last owner cannot be removed. `PermissionError` denials return HTTP 403.
 
+`participants` is validated per element, not just as a container: every element
+must be a non-empty string, and duplicates are collapsed before any membership
+row is written. A `None`, object, integer or empty-string element is rejected
+with HTTP 400 (`ValueError` mapped by the existing handler) before the database
+is touched, so no driver error or schema detail reaches the caller. Listing the
+same principal twice yields one membership row and one `membership_created`
+archive event, never a second write over the first row's `created_at`.
+
 **Ownership is self-asserted** -- the owner check compares the request body's
 `agent` field against the membership store, not the caller's verified token.
 The sibling A2A read path (`/a2a/mentions`) binds the `reader` query parameter

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -1909,6 +1909,16 @@ async def a2a_create_thread(
         if not participants:
             raise ValueError("participants list cannot be empty")
 
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for participant in participants:
+            if not isinstance(participant, str) or not participant:
+                raise ValueError("each participant must be a non-empty string")
+            if participant not in seen:
+                seen.add(participant)
+                deduped.append(participant)
+        participants = deduped
+
         if await store.has_any_membership(thread):
             raise ValueError(f"thread '{thread}' already exists")
 

--- a/tests/test_a2a_membership.py
+++ b/tests/test_a2a_membership.py
@@ -469,6 +469,90 @@ def test_http_a2a_create_thread_missing_fields(live_server):
     assert status == 400
 
 
+def test_http_a2a_create_thread_invalid_none(live_server):
+    """POST /a2a/threads with participants=[None] returns 400, not 500.
+
+    A None element must be rejected before it reaches the DB driver,
+    which would otherwise raise IntegrityError leaking schema.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "inv-none", "participants": [None], "agent": "carol"},
+    )
+    assert status == 400
+
+
+def test_http_a2a_create_thread_invalid_dict(live_server):
+    """POST /a2a/threads with participants=[{'a': 1}] returns 400, not 500.
+
+    A dict element must be rejected before it reaches the DB driver,
+    which would otherwise raise ProgrammingError leaking the parameter-binding
+    message.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "inv-dict", "participants": [{"a": 1}], "agent": "carol"},
+    )
+    assert status == 400
+
+
+def test_http_a2a_create_thread_invalid_int(live_server):
+    """POST /a2a/threads with participants=[123] returns 400.
+
+    An int element must be rejected rather than silently coerced to '123'.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "inv-int", "participants": [123], "agent": "carol"},
+    )
+    assert status == 400
+
+
+def test_http_a2a_create_thread_invalid_empty_string(live_server):
+    """POST /a2a/threads with participants=[''] returns 400.
+
+    An empty-string principal must be rejected rather than silently stored.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "inv-empty", "participants": [""], "agent": "carol"},
+    )
+    assert status == 400
+
+
+def test_http_a2a_create_thread_control_valid(live_server):
+    """Control: participants=['alice'] returns 200.
+
+    This control validates that the per-element validation is
+    discriminating -- it must still accept valid non-empty string
+    participants, proving the 400s above are genuine rejections of bad
+    input and not a blanket failure of the endpoint.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "ctrl-valid", "participants": ["alice"], "agent": "carol"},
+    )
+    assert status == 200
+    assert body["created"] is True
+
+
+def test_http_a2a_create_thread_duplicate_returns_200(live_server):
+    """POST /a2a/threads with duplicate participants returns 200.
+
+    Duplicates are silently de-duplicated (not rejected), so a valid
+    thread is still created with each principal appearing exactly once.
+    """
+    status, body = _http_post(
+        f"{live_server}/a2a/threads",
+        {"thread": "dup-200", "participants": ["alice", "alice"], "agent": "carol"},
+    )
+    assert status == 200
+    assert body["created"] is True
+    ids = [m["principal_id"] for m in body["active_members"]]
+    assert ids.count("alice") == 1
+    assert ids.count("carol") == 1
+
+
 def test_http_a2a_list_members(live_server):
     """GET /a2a/threads/{thread}/members returns members."""
     _http_post(f"{live_server}/a2a/threads",
@@ -577,6 +661,65 @@ def test_archive_event_lands_on_add_and_remove(isolated_data_dir):
         assert "dave" in created_principals
         assert "carol" in created_principals
         assert "dave" in removed_principals
+    finally:
+        asyncio.run(archive.close())
+
+
+def test_create_thread_duplicate_one_archive_event_unless_created_at(isolated_data_dir):
+    """Duplicate participants must produce exactly ONE membership_created
+    archive event and an unchanged created_at in the store.
+
+    Without de-duplication, the second ``add_membership`` call triggers the
+    ON CONFLICT path (``created_at = excluded.created_at``), overwriting the
+    first value, and ``archive_membership_created`` emits a second event.
+    A 200 from the service is not sufficient evidence -- the archive and
+    store are re-read to confirm exactly one write landed.
+    """
+    dd = str(isolated_data_dir)
+    result = asyncio.run(service.a2a_create_thread(
+        "dup-t", ["alice", "alice"], "carol", data_dir=dd,
+    ))
+    assert result["created"] is True
+
+    store = MembershipStore(dd)
+    try:
+        row = store._conn.execute(
+            "SELECT created_at FROM a2a_membership "
+            "WHERE thread='dup-t' AND principal_id='alice'"
+        ).fetchone()
+        assert row is not None
+        created_at = row["created_at"]
+        assert created_at is not None and created_at > 0
+
+        row_count = store._conn.execute(
+            "SELECT COUNT(*) as n FROM a2a_membership "
+            "WHERE thread='dup-t' AND principal_id='alice'"
+        ).fetchone()
+        assert row_count["n"] == 1
+
+        m = asyncio.run(store.get_membership("dup-t", "alice"))
+        assert m is not None
+        assert m.created_at == created_at
+    finally:
+        asyncio.run(store.close())
+
+    archive = ArchiveStore(
+        archive_dir=str(isolated_data_dir / "archive"),
+        index_path=str(isolated_data_dir / "archive-index.db"),
+    )
+    asyncio.run(archive.init())
+    try:
+        events = asyncio.run(archive.query(event_type=EVENT_A2A, limit=1000))
+        alice_events = [
+            json.loads(e.get("data_json", "{}"))
+            for e in events
+            if json.loads(e.get("data_json", "{}")).get("admin_action") == "membership_created"
+            and json.loads(e.get("data_json", "{}")).get("principal_id") == "alice"
+        ]
+        assert len(alice_events) == 1, (
+            f"expected exactly 1 membership_created event for alice, "
+            f"got {len(alice_events)}"
+        )
     finally:
         asyncio.run(archive.close())
 


### PR DESCRIPTION
Re-cut of #460 on top of the #450 chain.

`POST /a2a/threads` validated the `participants` container (non-empty) but never its elements, so a list holding blanks, non-strings or duplicates was accepted and the bad handles surfaced later as a 500. Each element is now validated at the boundary and duplicates are rejected, with the same 400 shape the other membership routes use.

Why a re-cut: #460 carried #414's whole membership feature (1716 lines) as a parent commit, all of which is already on master via #428/#450, so it can never merge cleanly. This branch is the one unique commit (`0b4130f2`, 156 lines, 3 files) cherry-picked onto `2083d8cc` with zero conflicts.

Verification on this branch:
- positive control: with `taosmd/service.py` reverted to master, 5 of the 7 new tests fail; restored, 7/7 pass
- `compileall` 0, `ruff check taosmd/ tests/ benchmarks/` 0
- full suite: 1905 passed, 12 skipped, 0 failed, 0 errors

Card: tsk-qxme7q. Supersedes and closes #460.