### PR TITLE
REVISE PR #443: lint red so CI never ran the tests, the round-trip store re-read test is still missing, and the HTTP guard it adds survives being neutered

### DIFF
--- a/changelog.d/tsk-ujamqn-percent-decode-revoke-agent.md
+++ b/changelog.d/tsk-ujamqn-percent-decode-revoke-agent.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `DELETE /collections/{id}/grants/{agent}` now percent-decodes the `{agent}`
+  path segment before looking up the grant, so agent ids containing spaces,
+  pluses, slashes, non-ASCII bytes, or literal percent signs round-trip
+  correctly through the revoke endpoint.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -64,6 +64,7 @@ POST   /collections/{id}/index             -> 202, then poll GET /collections/{i
 POST   /collections/{id}/link | /unlink    -> {"collection": {...}}
 POST   /collections/{id}/grants            -> {"collection": {...}}
 DELETE /collections/{id}/grants/{agent}    -> {"collection": ..., "revoked": ...}
+                                         ({agent} is percent-decoded)
 DELETE /collections/{id}                   -> {"collection": {...}}  (archived)
 ```
 
@@ -183,6 +184,7 @@ POST   /collections/{id}/link      {"type": "taos"|"git", "id": "..."}
 POST   /collections/{id}/unlink    same body
 POST   /collections/{id}/grants    {"agent": "..."}
 DELETE /collections/{id}/grants/{agent}
+                                         ({agent} is percent-decoded)
 POST   /search                     with collection/collections/collections_only
 ```
 

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -1249,6 +1249,9 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     if "/grants/" in rest:
                         cid, _, agent = rest.partition("/grants/")
                         if not cid or not agent:
+                            # not agent is a dead branch: _dispatch strips
+                            # trailing slashes, so '/grants/' in rest is false
+                            # for an empty agent segment.
                             self._send_json(404, {"error": "collection id and agent required"})
                         else:
                             self._handle_collections_revoke(cid, agent)
@@ -2705,7 +2708,11 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"collection": col})
 
         def _handle_collections_revoke(self, collection_id: str, agent: str) -> None:
+            import urllib.parse as _up  # noqa: PLC0415
             from .collections import CollectionNotFoundError  # noqa: PLC0415
+            agent = _up.unquote(agent)
+            if not agent.strip():
+                raise _BadRequest("'agent' (non-empty string) is required")
             try:
                 col = runner.run(
                     service.collections_revoke(collection_id, agent, data_dir=data_dir)

--- a/tests/test_collections_http.py
+++ b/tests/test_collections_http.py
@@ -312,6 +312,54 @@ def test_revoke_reports_revoked_false_on_non_matching_grantee(live_server):
     assert "revoked" not in body["collection"]
 
 
+@pytest.mark.parametrize("agent_id,question", [
+    ("dev", "control: does a plain ASCII id survive the encode/decode round-trip unchanged?"),
+    ("a b", "does a space survive percent-encoding and decoding?"),
+    ("a+b", "does a plus survive?"),
+    ("a/b", "does a slash survive?"),
+    ("a\xe9", "does a non-ASCII byte (U+00E9) survive?"),
+    ("a%b", "does a literal percent sign survive double-encoding?"),
+    (" a", "does leading whitespace survive?"),
+    ("a ", "does trailing whitespace survive?"),
+])
+def test_revoke_round_trip_hostile_agent_ids(live_server, agent_id, question):
+    base, data_dir, source_dir = live_server
+    col = _create(base, source_dir)
+
+    status, _ = _req(
+        "POST", f"{base}/collections/{col['id']}/grants",
+        {"agent": agent_id}, token=_TOKEN,
+    )
+    assert status == 200, f"grant with {agent_id!r} should succeed, got {status}"
+
+    from urllib.parse import quote
+    encoded = quote(agent_id, safe="")
+    status, _ = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/{encoded}", token=_TOKEN,
+    )
+    assert status == 200, f"revoke with encoded {agent_id!r} should return 200, got {status}"
+
+    from taosmd.collections import CollectionStore
+    store = CollectionStore(data_dir)
+    try:
+        assert not store.has_grant(agent_id, col["id"]), (
+            f"grant for {agent_id!r} should be gone after revoke; "
+            f"control validates: {question}"
+        )
+    finally:
+        store.close()
+
+
+def test_revoke_rejects_whitespace_only_agent(live_server):
+    base, _, source_dir = live_server
+    col = _create(base, source_dir)
+    status, body = _req(
+        "DELETE", f"{base}/collections/{col['id']}/grants/%20%20", token=_TOKEN,
+    )
+    assert status == 400
+    assert body == {"error": "'agent' (non-empty string) is required"}
+
+
 # ---------------------------------------------------------------------------
 # Index (async, 202 + poll) and search integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): REVISE PR #443: lint red so CI never ran the tests, the round-trip store re-read test is still missing, and the HTTP guard it adds survives being neutered

Autonomous build of board card tsk-ujamqn.

D2 round-trip test: added parametrised test_revoke_round_trip_hostile_agent_ids
covering space, plus, slash, non-ASCII, literal percent, leading/trailing
whitespace, plus plain-ASCII control. Grants with raw id, revokes via
percent-encoded DELETE path, asserts grant gone by re-reading
CollectionStore.has_grant on a fresh connection.

D3/D5 HTTP guard: added urllib.parse.unquote to _handle_collections_revoke
and validation on agent.strip(). Dropped dead isinstance(agent, str) clause
because unquote always returns str. Pinned by test_revoke_rejects_whitespace_only_agent
asserting exact body 'agent' (non-empty string) is required for %20%20.

D4 dispatch comment: documented that not agent is a dead branch because
_dispatch strips trailing slashes, making '/grants/' in rest false for an
empty agent segment.

D6 docs: noted {agent} is percent-decoded in docs/collections.md, added
changelog fragment.

Proofs:
- uv run ruff check taosmd/ tests/ benchmarks/ -> All checks passed
- uv run --extra dev pytest tests/test_collections_http.py tests/test_collections_store.py -> 51 passed
- Mutation: guard if not agent.strip(): -> if False: yields 1 failed, 8 passed, 0 errors
- Mutation: dispatch if not cid or not agent: -> if False: yields 26 passed (equivalent mutant survives)

Docs-Reviewed: collections revoke handler only, not A2A comms

Files:
 .../tsk-ujamqn-percent-decode-revoke-agent.md      |  6 +++
 docs/collections.md                                |  2 +
 taosmd/http_server.py                              |  7 ++++
 tests/test_collections_http.py                     | 48 ++++++++++++++++++++++
 4 files changed, 63 insertions(+)