### PR TITLE
RE-CUT #440/#461 fresh off master: install-skill still raises OSError on a non-empty manifest directory, on BOTH arms, and the two directory tests build the one obstruction that already worked

### DIFF
--- a/changelog.d/tsk-kklxxl-install-skill-manifest-dir.md
+++ b/changelog.d/tsk-kklxxl-install-skill-manifest-dir.md
@@ -1,0 +1,4 @@
+### Fixed
+- `taosmd install-skill` now handles a non-empty directory at the manifest path on both the plain and `--force` arms, removing the obstruction instead of raising `OSrror [Errno 39]`.
+- A failed manifest write no longer leaves `SKILL.md` advanced; the install is rolled back so the on-disk skill and manifest stay coherent.
+- `scripts/install-client.sh` and `scripts/install-client.ps1` no longer auto-clobber local edits by chaining `install-skill --force` on refusal.

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -46,11 +46,8 @@ Write-Host "  Remote server URL set: $ServerUrl"
 # --- Step 3: install the Claude skill ----------------------------------------
 Write-Host ""
 Write-Host "Step 3: Installing taosmd-a2a skill..."
-try {
-    taosmd install-skill
-} catch {
-    taosmd install-skill --force
-}
+taosmd install-skill
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-Host "  Skill installed."
 
 # --- Step 4: health check ----------------------------------------------------

--- a/scripts/install-client.sh
+++ b/scripts/install-client.sh
@@ -45,7 +45,7 @@ echo "  Remote server URL set: $SERVER_URL"
 # --- Step 3: install the Claude skill ----------------------------------------
 echo ""
 echo "Step 3: Installing taosmd-a2a skill..."
-taosmd install-skill || taosmd install-skill --force
+taosmd install-skill
 echo "  Skill installed."
 
 # --- Step 4: health check -----------------------------------------------------

--- a/taosmd/cli.py
+++ b/taosmd/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime, timezone
 
@@ -610,6 +611,187 @@ def _a2a_poll_cmd(args: argparse.Namespace) -> int:
     return 0
 
 
+MANIFEST_NAME = ".taosmd-skill-manifest.json"
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in v.split("."))
+
+
+def _parse_skill_version(skill_md_path: Path) -> str | None:
+    from pathlib import Path  # noqa: PLC0415
+    text = skill_md_path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("---", 3)
+    if end == -1:
+        return None
+    frontmatter = text[3:end]
+    for line in frontmatter.splitlines():
+        line = line.strip()
+        if line.startswith("version:"):
+            ver = line[len("version:"):].strip()
+            return ver or None
+    return None
+
+
+def _write_skill_manifest(dest_dir: Path, version: str, skill_md_path: Path) -> None:
+    import hashlib
+    from pathlib import Path  # noqa: PLC0415
+
+    sha = hashlib.sha256(skill_md_path.read_bytes()).hexdigest()
+    data = {"version": version, "skill_md_sha256": sha}
+    manifest_path = Path(dest_dir) / MANIFEST_NAME
+    tmp = manifest_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.replace(str(tmp), str(manifest_path))
+
+
+def _run_install_skill(src: Path, dest: Path, force: bool = False) -> int:
+    import hashlib
+    import shutil
+    from pathlib import Path  # noqa: PLC0415
+
+    src_path = Path(src)
+    dest_path = Path(dest)
+
+    src_skill = src_path / "SKILL.md"
+    if not src_skill.exists():
+        return 1
+
+    version = _parse_skill_version(src_skill)
+    src_hash = hashlib.sha256(src_skill.read_bytes()).hexdigest()
+
+    dest_skill = dest_path / "SKILL.md"
+    manifest_path = dest_path / MANIFEST_NAME
+
+    if manifest_path.is_dir():
+        shutil.rmtree(str(manifest_path))
+
+    had_manifest_file = manifest_path.is_file()
+    manifest = None
+    if had_manifest_file:
+        try:
+            raw = manifest_path.read_text(encoding="utf-8")
+            manifest = json.loads(raw)
+            if not isinstance(manifest, dict):
+                manifest = None
+        except (json.JSONDecodeError, OSError):
+            manifest = None
+
+    if not dest_skill.exists():
+        dest_path.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(str(src_path), str(dest_path), dirs_exist_ok=True)
+        if version is not None:
+            _write_skill_manifest(dest_path, version, dest_path / "SKILL.md")
+        return 0
+
+    installed_hash = hashlib.sha256(dest_skill.read_bytes()).hexdigest()
+    installed_version = _parse_skill_version(dest_skill) or "0.0.0"
+
+    def _upgrade(new_version: str) -> int:
+        if new_version is not None:
+            try:
+                _write_skill_manifest(dest_path, new_version, src_skill)
+            except OSError:
+                return 1
+        shutil.copytree(str(src_path), str(dest_path), dirs_exist_ok=True)
+        return 0
+
+    if had_manifest_file and manifest is not None:
+        recorded_version = manifest.get("version", "0.0.0")
+        recorded_hash = manifest.get("skill_md_sha256")
+
+        if recorded_hash == installed_hash:
+            if _version_tuple(version) < _version_tuple(recorded_version):
+                if not force:
+                    print(
+                        f"error: package version {version} is older than installed {recorded_version}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                rc = _upgrade(version)
+                if rc != 0:
+                    return rc
+                print(f"Downgraded from {recorded_version} to {version}")
+                return 0
+            if _version_tuple(version) == _version_tuple(recorded_version):
+                if src_hash == installed_hash:
+                    print("up to date")
+                    return 0
+                rc = _upgrade(version)
+                if rc != 0:
+                    return rc
+                print(f"Upgraded {version}")
+                return 0
+            rc = _upgrade(version)
+            if rc != 0:
+                return rc
+            print(f"Upgraded from {recorded_version} to {version}")
+            return 0
+
+        if not force:
+            print(f"error: local edits detected in {dest_skill}", file=sys.stderr)
+            print("  Use --force to overwrite.", file=sys.stderr)
+            return 1
+        rc = _upgrade(version)
+        if rc != 0:
+            return rc
+        print("overwriting local edits")
+        return 0
+
+    if had_manifest_file:
+        if installed_hash != src_hash:
+            if not force:
+                print(f"error: local edits detected in {dest_skill}", file=sys.stderr)
+                print("  Use --force to overwrite.", file=sys.stderr)
+                return 1
+            rc = _upgrade(version)
+            if rc != 0:
+                return rc
+            print("overwriting local edits")
+            return 0
+
+    if version is None:
+        if src_hash == installed_hash:
+            print("up to date")
+            return 0
+        if not force:
+            print(f"error: local edits detected in {dest_skill}", file=sys.stderr)
+            print("  Use --force to overwrite.", file=sys.stderr)
+            return 1
+        shutil.copytree(str(src_path), str(dest_path), dirs_exist_ok=True)
+        print("overwriting local edits")
+        return 0
+
+    if _version_tuple(version) < _version_tuple(installed_version):
+        if not force:
+            print(
+                f"error: package version {version} is older than installed {installed_version}",
+                file=sys.stderr,
+            )
+            return 1
+        rc = _upgrade(version)
+        if rc != 0:
+            return rc
+        print(f"Downgraded from {installed_version} to {version}")
+        return 0
+    if _version_tuple(version) == _version_tuple(installed_version):
+        if src_hash == installed_hash:
+            print("up to date")
+            return 0
+        rc = _upgrade(version)
+        if rc != 0:
+            return rc
+        print(f"Upgraded {version}")
+        return 0
+    rc = _upgrade(version)
+    if rc != 0:
+        return rc
+    print(f"Upgraded from {installed_version} to {version}")
+    return 0
+
+
 def _install_skill_cmd(args: argparse.Namespace) -> int:
     """Handle ``taosmd install-skill``: copy the packaged skill into ~/.claude/skills/."""
     import shutil  # noqa: PLC0415
@@ -620,10 +802,8 @@ def _install_skill_cmd(args: argparse.Namespace) -> int:
     skill_src_dir = Path(__file__).parent / "skills" / "taosmd-a2a"
 
     if not skill_src_dir.is_dir():
-        # Fallback: try importlib.resources (wheel installs)
         try:
             _ref = _pkg_files("taosmd").joinpath("skills/taosmd-a2a")
-            # Convert Traversable to a concrete path via __file__ approach.
             skill_src_dir = Path(__file__).parent / "skills" / "taosmd-a2a"
         except Exception:
             pass
@@ -634,16 +814,7 @@ def _install_skill_cmd(args: argparse.Namespace) -> int:
         return 2
 
     force = getattr(args, "force", False)
-    skill_md = dest_dir / "SKILL.md"
-    if skill_md.exists() and not force:
-        print(f"Skill already installed at {dest_dir}")
-        print("  Re-run with --force to overwrite.")
-        return 0
-
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(str(skill_src_dir), str(dest_dir), dirs_exist_ok=True)
-    print(f"taosmd-a2a skill installed at {dest_dir}")
-    return 0
+    return _run_install_skill(skill_src_dir, dest_dir, force=force)
 
 
 def _setup_prompt_cmd(args: argparse.Namespace) -> int:

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,494 @@
+"""Tests for the versioned ``taosmd install-skill`` path.
+
+``taosmd install-skill`` compares the packaged skill ``version`` (read from
+the SKILL.md frontmatter) against the installed copy and records a content
+hash in a ``.taosmd-skill-manifest.json`` at install time. The behaviours
+under test:
+
+* a stale install with a newer package upgrades by default (non-silent, the
+  file actually changes);
+* identical copies stay quiet and exit 0;
+* a locally-edited copy is never clobbered without ``--force``;
+* versions are ordered numerically, so an older package is refused rather
+  than installed under the word "upgraded";
+* an unreadable manifest degrades to the no-manifest path instead of raising;
+* a non-empty directory at the manifest path is removed so the install
+  completes cleanly on both arms;
+* a failed manifest write leaves SKILL.md unchanged (no half-apply).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from taosmd.cli import _parse_skill_version, _run_install_skill, _version_tuple
+
+
+MANIFEST_NAME = ".taosmd-skill-manifest.json"
+
+
+def _write_skill(dest_dir, version, body="skill body"):
+    """Write a SKILL.md with the given frontmatter version into dest_dir."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    text = f"---\nname: taosmd-a2a\nversion: {version}\n---\n{body}\n"
+    (dest_dir / "SKILL.md").write_text(text)
+    return text
+
+
+def _sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _corrupt_manifest(dest_dir):
+    """Leave the manifest present but unparseable, as a half-written file would."""
+    (dest_dir / MANIFEST_NAME).write_text("{ truncated")
+
+
+def test_fresh_install_writes_skill_and_manifest(tmp_path):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+
+    rc = _run_install_skill(src, dest, force=False)
+    assert rc == 0
+    assert (dest / "SKILL.md").exists()
+    assert (dest / MANIFEST_NAME).exists()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.0.0"
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_identical_copy_is_quiet_and_exits_zero(tmp_path, capsys):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src, dest, force=False)  # fresh install
+    capsys.readouterr()  # clear
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "up to date" in out.out
+    assert out.err == ""
+
+
+def test_stale_clean_copy_upgrades_by_default(tmp_path, capsys):
+    """A stale install whose content still matches the recorded hash upgrades."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)  # install v1.0.0
+    before = (dest / "SKILL.md").read_text()
+
+    # Packaged skill evolves: newer version + new content.
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body\nnew a2a-watch / a2a-bridge lines")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "upgrad" in out.out.lower()  # non-silent
+    after = (dest / "SKILL.md").read_text()
+    assert after != before  # non-zero-change: the file actually advanced
+    assert "1.1.0" in after
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_locally_edited_copy_not_clobbered_without_force(tmp_path, capsys):
+    """Newer package + a user edit is refused without --force (zero-loss)."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)  # install v1.0.0 baseline
+
+    # User edits the installed copy.
+    local_edit = "# LOCAL EDIT BY USER\n"
+    skill_md = dest / "SKILL.md"
+    skill_md.write_text(skill_md.read_text() + local_edit)
+
+    # Packaged skill evolves: newer version + new content.
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body\nnew a2a-watch / a2a-bridge lines")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 1
+    assert "local edits" in out.err
+    assert local_edit in (dest / "SKILL.md").read_text()
+    # Manifest must remain the original one.
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.0.0"
+
+
+def test_force_overwrites_local_edits(tmp_path, capsys):
+    """--force clobbers local edits and records the new manifest."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    local_edit = "# LOCAL EDIT BY USER\n"
+    skill_md = dest / "SKILL.md"
+    skill_md.write_text(skill_md.read_text() + local_edit)
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "new body")
+
+    rc = _run_install_skill(src_v2, dest, force=True)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "overwriting local edits" in out.out
+    assert local_edit not in (dest / "SKILL.md").read_text()
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_downgrade_refused_without_force(tmp_path, capsys):
+    """An older packaged copy is refused unless --force is set."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.1.0", "newer body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    src_v0 = tmp_path / "pkg-v0"
+    _write_skill(src_v0, "1.0.0", "older body")
+
+    rc = _run_install_skill(src_v0, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 1
+    assert "older" in out.err.lower()
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_force_allows_downgrade(tmp_path, capsys):
+    """--force installs an older copy and records the downgrade."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.1.0", "newer body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    src_v0 = tmp_path / "pkg-v0"
+    _write_skill(src_v0, "1.0.0", "older body")
+
+    rc = _run_install_skill(src_v0, dest, force=True)
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "downgraded" in out.out.lower()
+    assert "1.0.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.0.0"
+
+
+def test_corrupt_manifest_does_not_raise_without_force(tmp_path, capsys):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src, dest, force=False)
+    _corrupt_manifest(dest)
+    capsys.readouterr()
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0, out.err
+    assert "up to date" in out.out
+
+
+def test_corrupt_manifest_does_not_raise_with_force(tmp_path, capsys):
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+    _corrupt_manifest(dest)
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "new body")
+    capsys.readouterr()
+
+    rc = _run_install_skill(src_v2, dest, force=True)
+    out = capsys.readouterr()
+    assert rc == 0, out.err
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["skill_md_sha256"] == _sha(dest / "SKILL.md")
+
+
+def test_corrupt_manifest_falls_back_to_the_content_comparison(tmp_path, capsys):
+    """Degrading means the no-manifest path, not 'assume the copy is clean'."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    edited = (dest / "SKILL.md").read_text() + "\n# local edit by user\n"
+    (dest / "SKILL.md").write_text(edited)
+    _corrupt_manifest(dest)
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body")
+    capsys.readouterr()
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    out = capsys.readouterr()
+    assert rc != 0
+    assert "local edits" in out.err
+    assert (dest / "SKILL.md").read_text() == edited
+
+
+def test_manifest_that_is_not_an_object_degrades(tmp_path, capsys):
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src, dest, force=False)
+    (dest / MANIFEST_NAME).write_text("[]\n")  # valid JSON, wrong shape
+    capsys.readouterr()
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0, out.err
+    assert "up to date" in out.out
+
+
+def test_unreadable_manifest_directory_degrades(tmp_path, capsys):
+    """A directory at the manifest path degrades to the no-manifest path."""
+    src = tmp_path / "pkg"
+    _write_skill(src, "1.0.0", "packaged body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src, dest, force=False)
+    manifest = dest / MANIFEST_NAME
+    manifest.unlink()
+    manifest.mkdir()  # a directory where a file belongs
+    capsys.readouterr()
+
+    rc = _run_install_skill(src, dest, force=False)
+    out = capsys.readouterr()
+    assert rc == 0, out.err
+    assert "up to date" in out.out
+
+
+def test_parse_skill_version_empty_version_line_does_not_consume_next_line(tmp_path):
+    """An empty 'version:' line must not consume the next line as the version."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text(
+        "---\n"
+        "name: taosmd-a2a\n"
+        "version:\n"
+        "description: some description\n"
+        "---\n"
+        "Body text.\n"
+    )
+    assert _parse_skill_version(skill_md) is None
+
+
+# --- Manifest write path must not raise on both arms ------------------------
+
+
+def test_empty_manifest_directory_positive_control(tmp_path):
+    """Positive control: empty manifest directory is removed and replaced by a file."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    manifest_dir = dest / MANIFEST_NAME
+    manifest_dir.unlink()
+    manifest_dir.mkdir()  # empty directory
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    assert rc == 0
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    assert (dest / MANIFEST_NAME).is_file()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_non_empty_manifest_directory_non_force_arm(tmp_path):
+    """Non-force arm with a genuinely non-empty manifest directory."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    manifest_dir = dest / MANIFEST_NAME
+    manifest_dir.unlink()
+    manifest_dir.mkdir()
+    (manifest_dir / "occupant.txt").write_text("obstruction")
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    assert rc == 0
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    assert (dest / MANIFEST_NAME).is_file()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_non_empty_manifest_directory_force_arm(tmp_path):
+    """Force arm with a genuinely non-empty manifest directory."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    manifest_dir = dest / MANIFEST_NAME
+    manifest_dir.unlink()
+    manifest_dir.mkdir()
+    (manifest_dir / "occupant.txt").write_text("obstruction")
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "new body")
+
+    rc = _run_install_skill(src_v2, dest, force=True)
+    assert rc == 0
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    assert (dest / MANIFEST_NAME).is_file()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_failed_manifest_write_does_not_advance_skill_md(tmp_path):
+    """If the manifest cannot be written, SKILL.md must be left unchanged."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+    original_skill_md = (dest / "SKILL.md").read_bytes()
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "new body")
+
+    # Simulate a manifest write failure by patching _write_skill_manifest.
+    def boom(*args, **kwargs):
+        raise OSError("simulated manifest write failure")
+
+    with patch("taosmd.cli._write_skill_manifest", side_effect=boom):
+        rc = _run_install_skill(src_v2, dest, force=False)
+    assert rc == 1
+    # SKILL.md must be unchanged.
+    assert (dest / "SKILL.md").read_bytes() == original_skill_md
+    # Manifest must still be the original one.
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.0.0"
+
+
+def test_read_only_manifest_non_force_arm(tmp_path):
+    """Non-force arm with a stale clean copy and read-only manifest."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    manifest = dest / MANIFEST_NAME
+    manifest.chmod(0o444)
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "old body")
+
+    rc = _run_install_skill(src_v2, dest, force=False)
+    assert rc == 0
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+def test_read_only_manifest_force_arm(tmp_path):
+    """Force arm with a stale copy and read-only manifest."""
+    src_v1 = tmp_path / "pkg-v1"
+    _write_skill(src_v1, "1.0.0", "old body")
+    dest = tmp_path / "dest"
+    _run_install_skill(src_v1, dest, force=False)
+
+    manifest = dest / MANIFEST_NAME
+    manifest.chmod(0o444)
+
+    src_v2 = tmp_path / "pkg-v2"
+    _write_skill(src_v2, "1.1.0", "new body")
+
+    rc = _run_install_skill(src_v2, dest, force=True)
+    assert rc == 0
+    assert "1.1.0" in (dest / "SKILL.md").read_text()
+    data = json.loads((dest / MANIFEST_NAME).read_text())
+    assert data["version"] == "1.1.0"
+
+
+# --- D1: install-client.sh must not auto-force on refusal -------------------
+
+
+class TestInstallClientScript:
+    """End-to-end probe for scripts/install-client.sh refusal handling."""
+
+    def test_refusal_does_not_auto_force(self, tmp_path, monkeypatch):
+        """When taosmd install-skill refuses, install-client.sh must not force."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+
+        fake_taosmd = bin_dir / "taosmd"
+        fake_taosmd.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "install-skill" ]; then\n'
+            "    if [ \"$2\" = \"--force\" ]; then\n"
+            "        DEST=\"$HOME/.claude/skills/taosmd-a2a\"\n"
+            "        mkdir -p \"$DEST\"\n"
+            "        echo \"packaged skill\" > \"$DEST/SKILL.md\"\n"
+            "        echo '{\"skill\":\"taosmd-a2a\",\"version\":\"1.0.0\"}' > \"$DEST/.taosmd-skill-manifest.json\"\n"
+            "    else\n"
+            "        echo \"error: local edits\" >&2\n"
+            "        echo \"  taosmd install-skill --force\" >&2\n"
+            "        exit 1\n"
+            "    fi\n"
+            "elif [ \"$1\" = \"config\" ]; then\n"
+            "    exit 0\n"
+            "elif [ \"$1\" = \"--version\" ]; then\n"
+            "    echo \"1.0.0\"\n"
+            "else\n"
+            "    exit 0\n"
+            "fi\n"
+        )
+        fake_taosmd.chmod(0o755)
+
+        fake_pip = bin_dir / "pip"
+        fake_pip.write_text("#!/usr/bin/env bash\nexit 0\n")
+        fake_pip.chmod(0o755)
+
+        fake_curl = bin_dir / "curl"
+        fake_curl.write_text('#!/usr/bin/env bash\necho \'{"status": "ok"}\'')
+        fake_curl.chmod(0o755)
+
+        skill_dir = fake_home / ".claude" / "skills" / "taosmd-a2a"
+        skill_dir.mkdir(parents=True)
+        local_edit_marker = "# LOCAL EDIT BY USER\n"
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: taosmd-a2a\nversion: 1.0.0\n---\n{local_edit_marker}"
+        )
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv(
+            "PATH", str(bin_dir) + ":" + os.environ.get("PATH", "")
+        )
+
+        script_path = Path(__file__).parent.parent / "scripts" / "install-client.sh"
+        subprocess.run(
+            ["bash", str(script_path), "http://localhost:7900"],
+            capture_output=True,
+            text=True,
+        )
+
+        skill_md = (skill_dir / "SKILL.md").read_text()
+        assert local_edit_marker in skill_md, (
+            "Local edit was clobbered by auto-forced reinstall"
+        )

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -437,8 +437,8 @@ def test_install_skill_copies_skill(tmp_path, monkeypatch):
     assert "taosmd-a2a" in content
 
 
-def test_install_skill_idempotent_without_force(tmp_path, monkeypatch):
-    """Second install-skill call without --force returns 0 and does not overwrite."""
+def test_install_skill_idempotent_without_force(tmp_path, monkeypatch, capsys):
+    """A locally-modified install is not overwritten without --force; it warns and exits non-zero."""
     import argparse  # noqa: PLC0415
     from taosmd.cli import _install_skill_cmd  # noqa: PLC0415
     import pathlib  # noqa: PLC0415
@@ -459,15 +459,17 @@ def test_install_skill_idempotent_without_force(tmp_path, monkeypatch):
     args_first = argparse.Namespace(force=False)
     _install_skill_cmd(args_first)
 
-    # Write a sentinel into the destination to verify idempotency.
+    # Corrupting the installed file means it no longer matches the recorded hash.
     skill_dest = fake_home / ".claude" / "skills" / "taosmd-a2a" / "SKILL.md"
     skill_dest.write_text("sentinel content")
 
     args_second = argparse.Namespace(force=False)
     rc = _install_skill_cmd(args_second)
-    assert rc == 0
-    # Content should still be the sentinel (not overwritten).
+    assert rc != 0
     assert skill_dest.read_text() == "sentinel content"
+    err = capsys.readouterr().err
+    assert "local edits" in err
+    assert "--force" in err
 
 
 def test_install_skill_force_overwrites(tmp_path, monkeypatch):


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): RE-CUT #440/#461 fresh off master: install-skill still raises OSError on a non-empty manifest directory, on BOTH arms, and the two directory tests build the one obstruction that already worked

Autonomous build of board card tsk-kklxxl.

Handle a non-empty manifest directory on both the plain and --force arms
by removing the tree with shutil.rmtree before writing the manifest.

Do not leave a half-applied install: write the manifest to a temp file
before copying skill files, so a manifest write failure leaves SKILL.md
unchanged.

Rewrite install-skill as a versioned installer that compares the packaged
SKILL.md version against the installed copy and records a content hash in
.taosmd-skill-manifest.json. Both arms now refuse unforced downgrades and
local edits, and --force overwrites cleanly.

Remove the auto-force fallback from scripts/install-client.sh and
install-client.ps1 so a refused install is not silently clobbered.

RED-FIRST proof: tests fail on master because _run_install_skill and
helpers do not exist there.

```
ERROR tests/test_install_skill.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 error in 0.47s
```

Green after fix:

```
20 passed in 0.28s
```

Full suite: 1958 passed, 12 skipped, 0 failed.

Files:
 .../tsk-kklxxl-install-skill-manifest-dir.md       |   4 +
 scripts/install-client.ps1                         |   7 +-
 scripts/install-client.sh                          |   2 +-
 taosmd/cli.py                                      | 195 +++++++-
 tests/test_install_skill.py                        | 494 +++++++++++++++++++++
 tests/test_remote.py                               |  12 +-
 6 files changed, 691 insertions(+), 23 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `install-skill` now tracks installed versions and content integrity to manage upgrades, downgrades, and repeated installations more reliably.
  - Installation supports atomic updates, preserving consistency between the skill file and its manifest.

- **Bug Fixes**
  - Non-empty manifest directories are handled correctly, including with `--force`.
  - Failed manifest updates now roll back the skill installation.
  - Local edits are no longer overwritten automatically; installation scripts now respect refusal errors instead of retrying with `--force`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->