### PR TITLE
Decide: should GET /a2a/* reject an unknown parameter with an EMPTY value? parse_qs drops it before the validator, repo-wide

### DIFF
--- a/changelog.d/tsk-hkiy66-a2a-blank-unknown-params.md
+++ b/changelog.d/tsk-hkiy66-a2a-blank-unknown-params.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /a2a/*` endpoints now reject unknown query parameters that carry an empty value (e.g. `?since_id=`). Previously `parse_qs(keep_blank_values=False)` dropped blank parameters before the strict-params validator could see them, so a misspelt cursor like `since_id=` was silently ignored instead of returning 400.

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -261,7 +261,19 @@ _MEMORY_DEFAULT_LIMIT = 50
 _MEMORY_MAX_LIMIT = 500
 
 
-def _validate_a2a_params(qs: dict, allowed: frozenset[str]) -> None:
+def _qs_param_names(query: str) -> set[str]:
+    names: set[str] = set()
+    for pair in query.split("&"):
+        if not pair:
+            continue
+        if "=" in pair:
+            names.add(pair.split("=", 1)[0])
+        else:
+            names.add(pair)
+    return names
+
+
+def _validate_a2a_params(qs: dict, allowed: frozenset[str], raw_query: str = "") -> None:
     """Reject query parameters not in *allowed* with HTTP 400.
 
     General rule established here and on the authenticated controller proxy
@@ -271,8 +283,15 @@ def _validate_a2a_params(qs: dict, allowed: frozenset[str]) -> None:
     not infer it from results that look plausible.  The error message names
     both the offending parameters and the accepted set so the caller can
     self-correct in one round-trip.
+
+    ``parse_qs`` drops parameters with blank values before they reach this
+    function.  To catch that case, the raw query string is passed via
+    *raw_query* and its parameter names are validated against the same
+    allowlist.
     """
     unknown = set(qs.keys()) - allowed
+    if raw_query:
+        unknown |= _qs_param_names(raw_query) - allowed
     if unknown:
         raise _BadRequest(
             f"unknown query parameters: {sorted(unknown)}; allowed: {sorted(allowed)}"
@@ -1033,6 +1052,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             parts = urlsplit(self.path)
             path = parts.path.rstrip("/") or "/"
             query = parse_qs(parts.query)
+            self._raw_qs = parts.query
             # Token gate: check before routing so even unknown paths are
             # protected (prevents enumeration without a token). Admin write
             # routes are exempt here (#154): they enforce their own, stricter
@@ -1613,17 +1633,17 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, result)
 
         def _handle_a2a_channels(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset())
+            _validate_a2a_params(qs, frozenset(), self._raw_qs)
             channels = runner.run(service.a2a_channels(data_dir=data_dir))
             self._send_json(200, {"channels": channels})
 
         def _handle_a2a_census(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset())
+            _validate_a2a_params(qs, frozenset(), self._raw_qs)
             census = runner.run(service.a2a_sender_census(data_dir=data_dir))
             self._send_json(200, {"census": census})
 
         def _handle_a2a_members(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset({"channel"}))
+            _validate_a2a_params(qs, frozenset({"channel"}), self._raw_qs)
             channel = (qs.get("channel") or [None])[0]
             if not channel:
                 raise _BadRequest("'channel' query parameter is required")
@@ -1789,7 +1809,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, result)
 
         def _handle_a2a_messages(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset({"thread", "since", "limit", "fields", "format"}))
+            _validate_a2a_params(qs, frozenset({"thread", "since", "limit", "fields", "format"}), self._raw_qs)
             thread = (qs.get("thread") or [None])[0]
             since_raw = (qs.get("since") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
@@ -1830,7 +1850,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"messages": messages})
 
         def _handle_a2a_mentions(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset({"since", "limit", "reader"}))
+            _validate_a2a_params(qs, frozenset({"since", "limit", "reader"}), self._raw_qs)
             since_raw = (qs.get("since") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
             try:
@@ -1893,7 +1913,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             when a verifier is configured; otherwise it is required as a
             query parameter.
             """
-            _validate_a2a_params(qs, frozenset({"consumer", "limit", "include_kinds", "exclude_acked_by"}))
+            _validate_a2a_params(qs, frozenset({"consumer", "limit", "include_kinds", "exclude_acked_by"}), self._raw_qs)
             consumer_qp = (qs.get("consumer") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
             include_kinds_raw = (qs.get("include_kinds") or [None])[0]
@@ -1980,7 +2000,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             Returns messages past the consumer's cursor that are addressed
             to the consumer and have NOT been acknowledged by the consumer.
             """
-            _validate_a2a_params(qs, frozenset({"consumer", "limit"}))
+            _validate_a2a_params(qs, frozenset({"consumer", "limit"}), self._raw_qs)
             consumer_qp = (qs.get("consumer") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
             try:
@@ -2025,7 +2045,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             subscribers that carry no identifying token produce no delivered
             mark.
             """
-            _validate_a2a_params(qs, frozenset({"thread", "since"}))
+            _validate_a2a_params(qs, frozenset({"thread", "since"}), self._raw_qs)
             thread = (qs.get("thread") or [None])[0]
             since_raw = (qs.get("since") or [None])[0]
             last_ts = _parse_since(since_raw)
@@ -2075,7 +2095,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                 return
 
         def _handle_a2a_threads(self, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset({"principal"}))
+            _validate_a2a_params(qs, frozenset({"principal"}), self._raw_qs)
             principal = (qs.get("principal") or [None])[0]
             threads = runner.run(
                 service.a2a_threads(principal=principal, data_dir=data_dir)
@@ -2083,7 +2103,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
             self._send_json(200, {"threads": threads})
 
         def _handle_a2a_thread_messages(self, thread: str, qs: dict) -> None:
-            _validate_a2a_params(qs, frozenset({"before", "after", "limit"}))
+            _validate_a2a_params(qs, frozenset({"before", "after", "limit"}), self._raw_qs)
             before_raw = (qs.get("before") or [None])[0]
             after_raw = (qs.get("after") or [None])[0]
             limit_raw = (qs.get("limit") or [50])[0]
@@ -2126,7 +2146,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
         def _handle_a2a_list_members(self, thread: str, qs: dict) -> None:
             """GET /a2a/threads/{thread}/members: list active members."""
             thread = unquote(thread)
-            _validate_a2a_params(qs, frozenset())
+            _validate_a2a_params(qs, frozenset(), self._raw_qs)
             members = runner.run(
                 service.a2a_list_members(thread=thread, data_dir=data_dir)
             )
@@ -2219,7 +2239,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
 
         def _handle_a2a_message_receipts(self, msg_id_str: str, qs: dict) -> None:
             """GET /a2a/messages/{id}/receipts -- all receipts for one message."""
-            _validate_a2a_params(qs, frozenset())
+            _validate_a2a_params(qs, frozenset(), self._raw_qs)
             try:
                 message_id = int(msg_id_str)
             except (TypeError, ValueError) as exc:
@@ -2231,7 +2251,7 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
 
         def _handle_a2a_receipts(self, qs: dict) -> None:
             """GET /a2a/receipts?message_id=X&agent=Y -- a single receipt."""
-            _validate_a2a_params(qs, frozenset({"message_id", "agent"}))
+            _validate_a2a_params(qs, frozenset({"message_id", "agent"}), self._raw_qs)
             message_id_raw = (qs.get("message_id") or [None])[0]
             agent_id = (qs.get("agent") or [None])[0]
             if message_id_raw is None or agent_id is None:

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -616,3 +616,78 @@ def _stream_status_code(live_server: str, path: str, timeout: float = 3.0) -> in
             line += chunk
     status_line = line.decode("utf-8", "replace").splitlines()[0]
     return int(status_line.split()[1])
+
+
+# ---------------------------------------------------------------------------
+# Blank-value unknown params: parse_qs(keep_blank_values=False) used to drop
+# them before the validator.  After the fix they must 400.
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_messages_blank_unknown_param_returns_400(live_server):
+    """?bogus= on /a2a/messages must 400, not silently page."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "blank-bogus"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=blank-bogus&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_messages_blank_since_id_returns_400(live_server):
+    """?since_id= on /a2a/messages must 400 (the cursor-shaped typo case)."""
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "blank-since-id"})
+    status, body = _get(f"{live_server}/a2a/messages?thread=blank-since-id&since_id=")
+    assert status == 400, body
+    assert "since_id" in body["error"]
+
+
+def test_http_a2a_mentions_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/mentions?reader=agentA&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_stream_blank_unknown_param_returns_400(live_server):
+    status = _stream_status_code(live_server, "/a2a/stream?thread=any&bogus=")
+    assert status == 400
+
+
+def test_http_a2a_threads_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/threads?principal=agentA&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_channels_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/channels?bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_census_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/census?bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_members_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/members?channel=general&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_message_receipts_blank_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "blank-rcpt"})
+    msg_id = _post(f"{live_server}/a2a/send",
+                   {"from": "agentA", "body": "msg2", "thread": "blank-rcpt"})[1]["id"]
+    status, body = _get(f"{live_server}/a2a/messages/{msg_id}/receipts?bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_receipts_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/receipts?message_id=1&agent=agentB&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Decide: should GET /a2a/* reject an unknown parameter with an EMPTY value? parse_qs drops it before the validator, repo-wide

Autonomous build of board card tsk-hkiy66.

Option 3 from tsk-hkiy66: keep parse_qs as-is for value extraction, but
separately collect raw parameter names from the query string and validate
them against the per-endpoint allowlist.  This catches ?since_id= and
similar blank-value typos that parse_qs(keep_blank_values=False) drops
before the existing validator can see them.

Changes:
- Added _qs_param_names() to extract names from the raw query string
- Extended _validate_a2a_params() to accept raw_query and check those
  names against the allowlist
- Stored parts.query as self._raw_qs in _dispatch, passed it through
  to all 13 _validate_a2a_params() call sites
- Added 10 red-first tests covering blank unknown params across every
  GET /a2a/* endpoint

Tests: 10 new blank-param tests added; verified they FAIL before the
fix and PASS after.  All 45 tests in test_a2a_kinds_strict_params.py
pass.

Docs-Reviewed: no routes files changed

Files:
 changelog.d/tsk-hkiy66-a2a-blank-unknown-params.md |  3 +
 taosmd/http_server.py                              | 48 ++++++++++----
 tests/test_a2a_kinds_strict_params.py              | 75 ++++++++++++++++++++++
 3 files changed, 112 insertions(+), 14 deletions(-)