### PR TITLE
RE-CUT tsk-dw2qwt fresh off master: PR #477 inverted the card. Finding A wanted the MISSING TEST added, not the validator deleted, and Finding B shipped an unauthenticated identity fallback

### DIFF
--- a/changelog.d/tsk-qhijcw-a2a-inbox-param-pin.md
+++ b/changelog.d/tsk-qhijcw-a2a-inbox-param-pin.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pin the `/a2a/inbox` strict-param validator with a test and document that `POST /a2a/inbox/advance` and `POST /a2a/ack` require a verified registry token with no standalone `?consumer=` fallback.

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -512,8 +512,8 @@ because SQLite treats `LIMIT -1` as unbounded, so a cap written as
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
 | `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=` | `{"messages": [...]}` |
-| `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}` |
-| `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}` |
+| `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}` (principal derived from the verified registry token `sub`; no standalone `?consumer=` fallback) |
+| `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}` (principal derived from the verified registry token `sub`; no standalone `?consumer=` fallback) |
 | `GET`  | `/a2a/inbox/unhandled` | `?consumer=&limit=` | `{"messages": [...]}` |
 | `POST` | `/a2a/threads` | body JSON `{"thread", "participants", "agent"}` | `{"thread", "created", "active_members"}`; create a thread (caller becomes owner, participants become members; ownership is self-asserted from the `agent` body field, see notes) |
 | `GET`  | `/a2a/threads` | `?principal=` | `{"threads": [...]}`; sender-derived filter: returns only threads this principal has sent to |

--- a/tests/test_a2a_inbox_auth.py
+++ b/tests/test_a2a_inbox_auth.py
@@ -299,6 +299,12 @@ def test_inbox_unhandled_with_valid_matching_token_succeeds(authed_server, tmp_p
 # Gate (e): unknown query parameter -> 400 on unhandled
 # ---------------------------------------------------------------------------
 
+def test_inbox_unknown_param_is_rejected(authed_server):
+    token = _make_token("agent-1")
+    status, _ = _get(f"{authed_server}/a2a/inbox?foo=bar", token=token)
+    assert status == 400
+
+
 def test_inbox_unhandled_unknown_param_is_rejected(authed_server):
     token = _make_token("agent-1")
     status, _ = _get(f"{authed_server}/a2a/inbox/unhandled?foo=bar", token=token)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): RE-CUT tsk-dw2qwt fresh off master: PR #477 inverted the card. Finding A wanted the MISSING TEST added, not the validator deleted, and Finding B shipped an unauthenticated identity fallback

Autonomous build of board card tsk-qhijcw.

- Add test_inbox_unknown_param_is_rejected to pin the existing /a2a/inbox
  strict-param validator, mirroring the sibling test_inbox_unhandled_unknown_param_is_rejected
- Document in a2a-comms.md that POST /a2a/inbox/advance and POST /a2a/ack
  derive identity from the verified registry token sub with no standalone ?consumer= fallback

Test suite: 1943 passed, 12 skipped

Files:
 changelog.d/tsk-qhijcw-a2a-inbox-param-pin.md | 3 +++
 taosmd/docs/a2a-comms.md                      | 4 ++--
 tests/test_a2a_inbox_auth.py                  | 6 ++++++
 3 files changed, 11 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened A2A authentication by requiring a verified registry token for inbox advancement and acknowledgment requests.
  * Removed support for using a standalone `consumer` query parameter as an identity fallback.
  * Unknown query parameters on authenticated inbox requests now return a clear client error.

* **Documentation**
  * Updated A2A endpoint documentation to clarify identity verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->