### PR TITLE
Re-land POST /a2a/import with issuer pinning on the import auth path (supersedes blocked PR #412)

### DIFF
--- a/changelog.d/tsk-bdj4fv-a2a-import.md
+++ b/changelog.d/tsk-bdj4fv-a2a-import.md
@@ -1,0 +1,7 @@
+### Added
+
+- `POST /a2a/import` for idempotent batch import of external chat envelopes onto the A2A bus, with issuer-pinned registry auth, batch length cap, and import dedup.
+
+### Fixed
+
+- `/a2a/import` auth path now routes through `_registry_verifier.authorize()` so the token issuer is pinned, matching `/a2a/send` and `/a2a/mentions` on every check.

--- a/taosmd/archive.py
+++ b/taosmd/archive.py
@@ -91,7 +91,15 @@ CREATE TABLE IF NOT EXISTS a2a_alarm_state (
 CREATE INDEX IF NOT EXISTS idx_a2a_alarm_state_key_fp ON a2a_alarm_state(alarm_key, fingerprint);
 """
 
-INDEX_SCHEMA = INDEX_SCHEMA + A2A_ALARM_STATE_SCHEMA
+A2A_IMPORT_DEDUP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS a2a_import_dedup (
+    key TEXT PRIMARY KEY,
+    row_id INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_a2a_import_dedup_key ON a2a_import_dedup(key);
+"""
+
+INDEX_SCHEMA = INDEX_SCHEMA + A2A_ALARM_STATE_SCHEMA + A2A_IMPORT_DEDUP_SCHEMA
 
 
 class ArchiveStore:
@@ -200,6 +208,22 @@ class ArchiveStore:
             (now, alarm_key),
         )
         self._conn.commit()
+
+    async def record_import_dedup(self, key: str, row_id: int) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO a2a_import_dedup (key, row_id) VALUES (?, ?)",
+            (key, row_id),
+        )
+        self._conn.commit()
+
+    async def get_import_dedup(self, key: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT key, row_id FROM a2a_import_dedup WHERE key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"key": row[0], "row_id": row[1]}
 
     # ------------------------------------------------------------------
     # Recording

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -499,6 +499,7 @@ gating read endpoints on membership are tracked separately.
 | Method | Path | Parameters | Response |
 |--------|------|------------|----------|
 | `POST` | `/a2a/send` | body JSON `{"from", "body", "thread"?, "reply_to"?}` | `{"id", "from", "thread", "reply_to"}` |
+| `POST` | `/a2a/import` | body JSON `{"envelopes": [{"from", "body", "thread"?, "reply_to"?, "kind"?}]}` | `{"imported", "deduped", "total"}`; idempotent batch import with issuer-pinned auth |
 | `GET`  | `/a2a/messages` | `?thread=&since=&limit=&fields=&format=` | `{"messages": [...]}`; `fields=id,sender,body` projects each message down to those keys; `format=ndjson` emits one message per line (`application/x-ndjson`) |
 
 `limit` on `GET /a2a/messages` is bounded below as well as parsed. A negative

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -249,6 +249,7 @@ DEFAULT_PORT = 7900
 _A2A_REF_KINDS = frozenset({"doc", "report", "spec", "log"})
 _A2A_MAX_REFS = 8
 _A2A_MAX_MESSAGE_BYTES = 64 * 1024  # 64 KB total (body+refs+blocks)
+_A2A_MAX_IMPORT_BATCH = 100
 _A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "system"})
 
 # Cursor pagination limits for /a2a/threads/{thread}/messages.
@@ -1095,6 +1096,8 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     self._handle_pending_resolve()
                 elif method == "POST" and path == "/a2a/send":
                     self._handle_a2a_send()
+                elif method == "POST" and path == "/a2a/import":
+                    self._handle_a2a_import()
                 elif method == "GET" and path == "/a2a/channels":
                     self._handle_a2a_channels(query)
                 elif method == "GET" and path == "/a2a/census":
@@ -1788,6 +1791,38 @@ def _make_handler(data_dir, runner: _ServiceLoop, verifier=None,
                     alarm_key=alarm_key, alarm_fingerprint=alarm_fingerprint,
                     data_dir=data_dir,
                 )
+            )
+            self._send_json(200, result)
+
+        def _handle_a2a_import(self) -> None:
+            body = self._read_json_body()
+            envelopes = body.get("envelopes")
+            if not isinstance(envelopes, list):
+                raise _BadRequest("'envelopes' (list) is required")
+            if len(envelopes) > _A2A_MAX_IMPORT_BATCH:
+                raise _BadRequest(
+                    f"'envelopes' must have at most {_A2A_MAX_IMPORT_BATCH} items"
+                )
+            if _registry_verifier is not None:
+                auth = self.headers.get("Authorization", "")
+                token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+                if not token:
+                    self._send_json(401, {"error": "registry auth: Bearer token required"})
+                    return
+                try:
+                    from . import registry_auth as _ra  # noqa: PLC0415
+                    import jwt as _jwt  # noqa: PLC0415
+                    unverified = _jwt.decode(token, options={"verify_signature": False})
+                    raw_sub = unverified.get("sub", "") or ""
+                except Exception:  # noqa: BLE001
+                    raw_sub = ""
+                try:
+                    _registry_verifier.authorize(token, raw_sub)
+                except _ra.AuthError as exc:
+                    self._send_json(403, {"error": f"registry auth: {exc}"})
+                    return
+            result = runner.run(
+                service.a2a_import(envelopes, data_dir=data_dir)
             )
             self._send_json(200, result)
 
@@ -2851,7 +2886,7 @@ def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, data_dir=None) -> 
     print("Endpoints: GET /health, GET /version, POST /ingest, POST /ingest/batch, GET|POST /search, "
           "GET /projects, GET /shelves, "
           "GET /pending, POST /pending/resolve, "
-          "POST /a2a/send, GET /a2a/messages, GET /a2a/mentions, GET /a2a/stream, "
+          "POST /a2a/send, POST /a2a/import, GET /a2a/messages, GET /a2a/mentions, GET /a2a/stream, "
           "GET /a2a/channels, GET /a2a/members, "
           "POST /tasks, GET /tasks, GET /tasks/ready, GET /tasks/prime, "
           "GET /tasks/edges, "

--- a/taosmd/service.py
+++ b/taosmd/service.py
@@ -407,6 +407,9 @@ async def fetch_by_ref(ref: dict, *, agent: str, data_dir=None) -> dict:
 
 _A2A_KINDS = frozenset({"chat", "alarm", "ack", "digest", "receipt", "review", "system"})
 _A2A_ALARM_MIN_INTERVAL = 5.0
+_A2A_MAX_REFS = 8
+_A2A_MAX_MESSAGE_BYTES = 64 * 1024
+_A2A_MAX_IMPORT_BATCH = 100
 
 
 async def a2a_send(
@@ -541,6 +544,89 @@ async def a2a_send(
             recipient=recipient,
         )
     return receipt
+
+
+async def a2a_import(
+    envelopes: list[dict],
+    *,
+    data_dir=None,
+) -> dict:
+    """Idempotent batch import of external chat envelopes onto the A2A bus.
+
+    Each envelope is validated against the same field rules as
+    :func:`a2a_send` (``from``, ``body``, ``thread``, ``kind``, ``refs``,
+    ``blocks``, ``reply_to``, ``recipient``).  Duplicates are suppressed
+    via the import dedup table: a crash between the archive write and the
+    dedup record yields a duplicate, never a loss.
+
+    Returns ``{"imported": N, "deduped": M, "total": T}`` where ``T`` is
+    the number of envelopes in the batch.
+    """
+    if not isinstance(envelopes, list):
+        raise ValueError("'envelopes' (list) is required")
+    if len(envelopes) > _A2A_MAX_IMPORT_BATCH:
+        raise ValueError(f"'envelopes' must have at most {_A2A_MAX_IMPORT_BATCH} items")
+    imported = 0
+    deduped = 0
+    stores = await _api._ensure_stores(data_dir)
+    archive = stores["archive"]
+    for envelope in envelopes:
+        if not isinstance(envelope, dict):
+            raise ValueError("each envelope must be an object")
+        from_ = envelope.get("from")
+        body = envelope.get("body")
+        thread = envelope.get("thread", "general") or "general"
+        reply_to = envelope.get("reply_to")
+        refs = envelope.get("refs")
+        blocks = envelope.get("blocks")
+        kind = envelope.get("kind", "chat")
+        if kind is None:
+            kind = "chat"
+        recipient = envelope.get("recipient")
+        if not isinstance(from_, str) or not from_:
+            raise ValueError("'from' (non-empty string) is required in each envelope")
+        if not isinstance(body, str) or not body:
+            raise ValueError("'body' (non-empty string) is required in each envelope")
+        if not isinstance(thread, str) or not thread:
+            raise ValueError("'thread' (non-empty string) is required in each envelope")
+        if kind not in _A2A_KINDS:
+            raise ValueError(
+                f"'kind' must be one of {sorted(_A2A_KINDS)}; got {kind!r}"
+            )
+        if refs is not None:
+            if not isinstance(refs, list):
+                raise ValueError("'refs' must be a list")
+            if len(refs) > _A2A_MAX_REFS:
+                raise ValueError(f"'refs' must have at most {_A2A_MAX_REFS} items")
+        if blocks is not None and not isinstance(blocks, list):
+            raise ValueError("'blocks' must be a list")
+        serialized = json.dumps(
+            {"from": from_, "body": body, "thread": thread, "reply_to": reply_to, "refs": refs, "blocks": blocks, "kind": kind, "recipient": recipient}
+        )
+        if len(serialized.encode("utf-8")) > _A2A_MAX_MESSAGE_BYTES:
+            raise ValueError("envelope exceeds 64KB limit")
+        key = hashlib.sha256(serialized.encode()).hexdigest()
+        existing = await archive.get_import_dedup(key)
+        if existing is not None:
+            deduped += 1
+            continue
+        data = {"from": from_, "body": body, "thread": thread, "reply_to": reply_to, "kind": kind}
+        if recipient is not None:
+            data["recipient"] = recipient
+        if refs is not None:
+            data["refs"] = refs
+        if blocks is not None:
+            data["blocks"] = blocks
+        row_id = await archive.record(
+            event_type=EVENT_A2A,
+            data=data,
+            agent_name=from_,
+            app_id=thread,
+            summary=body[:200],
+        )
+        await archive.record_import_dedup(key, row_id)
+        imported += 1
+    return {"imported": imported, "deduped": deduped, "total": len(envelopes)}
 
 
 async def a2a_feed(
@@ -2166,7 +2252,7 @@ async def a2a_remove_member(
 
 
 __all__ = ["ingest", "search", "pending_list", "pending_resolve", "reconcile", "stats",
-           "supersede", "fetch_by_ref", "a2a_send", "a2a_feed", "a2a_channels", "a2a_sender_census",
+           "supersede", "fetch_by_ref", "a2a_send", "a2a_import", "a2a_feed", "a2a_channels", "a2a_sender_census",
            "a2a_members", "a2a_threads", "a2a_thread_messages",
            "a2a_mentions_feed", "a2a_migrate_kinds", "a2a_alarms_clear", "can_read",
            "a2a_inbox", "a2a_inbox_advance", "a2a_inbox_unhandled",

--- a/tests/test_a2a_import.py
+++ b/tests/test_a2a_import.py
@@ -1,0 +1,601 @@
+"""Tests for POST /a2a/import: issuer-pinned auth, parity with /a2a/send, idempotency, and batch cap.
+
+Covers all acceptance criteria from tsk-bdj4fv:
+1. Auth parity: /a2a/import performs the same checks as /a2a/send on every branch.
+2. Issuer pinning: a token from the wrong issuer is rejected with 403 and nothing is written.
+3. Idempotency: re-importing the same batch yields no duplicates.
+4. Batch cap: the number of envelopes per batch is bounded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import urllib.request
+
+import pytest
+
+from taosmd import api as taosmd_api
+from taosmd import http_server, service
+from taosmd.registry_auth import REGISTRY_ISS
+
+pytest.importorskip("jwt")
+pytest.importorskip("cryptography")
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _patch_embedder(stores: dict) -> None:
+    vmem = stores["vector"]
+
+    async def _fake_embed(text: str, task: str = "search_document") -> list[float]:
+        h = hash(text) & 0xFFFFFFFF
+        return [((h >> (i * 4)) & 0xFF) / 255.0 for i in range(8)]
+
+    vmem.embed = _fake_embed  # type: ignore[assignment]
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "taosmd-import"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    yield data_dir
+    for stores in list(taosmd_api._stores_cache.values()):
+        for store in (stores.get("archive"), stores.get("vector"), stores.get("kg")):
+            if store and hasattr(store, "close"):
+                try:
+                    asyncio.run(store.close())
+                except Exception:
+                    pass
+
+
+def _setup_stores(data_dir):
+    stores = asyncio.run(taosmd_api._ensure_stores(str(data_dir)))
+    _patch_embedder(stores)
+    return stores
+
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+PRIV_PEM, PUB_PEM = _keypair()
+
+
+def _make_token(sub, project_id=None, iss=None):
+    claims = {"sub": sub}
+    if project_id is not None:
+        claims["project_id"] = project_id
+    if iss is not None:
+        claims["iss"] = iss
+    return pyjwt.encode(claims, PRIV_PEM, algorithm="EdDSA")
+
+
+def _post(url: str, payload, token=None) -> tuple[int, dict]:
+    data = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get(url: str, token=None) -> tuple[int, dict]:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _count_a2a_events_via_http(base: str, thread: str) -> int:
+    status, body = _get(f"{base}/a2a/messages?thread={thread}")
+    if status != 200:
+        return -1
+    return len(body.get("messages", []))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def authed_server(tmp_path, monkeypatch):
+    """Live server built with a registry verifier in enforce mode, issuer pinned."""
+    data_dir = tmp_path / "taosmd-import-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    from taosmd import config as cfg
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    revoked: set[str] = set()
+
+    def fake_opener(url, token=None):
+        if url.endswith("pubkey"):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith("revoked"):
+            return json.dumps(list(revoked))
+        return json.dumps([])
+
+    from taosmd import registry_auth
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=REGISTRY_ISS,
+    )
+    httpd = http_server.make_server("127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier)
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}", data_dir, revoked
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def authed_server_with_grants(tmp_path, monkeypatch):
+    """Live server with verifier, grants verifier, and issuer pinning."""
+    data_dir = tmp_path / "taosmd-import-grants-http"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+
+    from taosmd import config as cfg
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+
+    grants: list[dict] = []
+
+    def fake_opener(url, token=None):
+        if url.endswith("pubkey"):
+            return json.dumps({"pubkey": PUB_PEM})
+        if url.endswith("revoked"):
+            return json.dumps([])
+        if url.endswith("grants"):
+            return json.dumps({"grants": grants})
+        return json.dumps([])
+
+    def fake_grants_opener(url, token=None):
+        if url.endswith("grants"):
+            return json.dumps({"grants": grants})
+        return json.dumps([])
+
+    from taosmd import registry_auth
+    verifier = registry_auth.verifier_from_url(
+        "http://reg.test", opener=fake_opener, expected_iss=REGISTRY_ISS,
+    )
+    grants_verifier = registry_auth.grants_verifier_from_url(
+        "http://reg.test", opener=fake_grants_opener,
+    )
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
+        verifier=verifier, grants_verifier=grants_verifier,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://{host}:{port}", data_dir, grants
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+        httpd.service_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests
+# ---------------------------------------------------------------------------
+
+def test_a2a_import_service_roundtrip(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    result = asyncio.run(service.a2a_import(
+        [
+            {"from": "agentA", "body": "hello import", "thread": "t1"},
+        ],
+        data_dir=dd,
+    ))
+    assert result == {"imported": 1, "deduped": 0, "total": 1}
+
+    msgs = asyncio.run(service.a2a_feed(thread="t1", data_dir=dd))
+    assert len(msgs) == 1
+    assert msgs[0]["body"] == "hello import"
+
+
+def test_a2a_import_service_idempotent(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+
+    envelopes = [{"from": "agentA", "body": "idempotent", "thread": "t1"}]
+    r1 = asyncio.run(service.a2a_import(envelopes, data_dir=dd))
+    assert r1["imported"] == 1
+    r2 = asyncio.run(service.a2a_import(envelopes, data_dir=dd))
+    assert r2["imported"] == 0
+    assert r2["deduped"] == 1
+
+    msgs = asyncio.run(service.a2a_feed(thread="t1", data_dir=dd))
+    assert len(msgs) == 1
+
+
+def test_a2a_import_service_validates_batch_type(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="list"):
+        asyncio.run(service.a2a_import("not-a-list", data_dir=str(isolated_data_dir)))
+
+
+def test_a2a_import_service_validates_envelope_type(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    with pytest.raises(ValueError, match="object"):
+        asyncio.run(service.a2a_import(
+            ["not-an-object"], data_dir=str(isolated_data_dir)
+        ))
+
+
+def test_a2a_import_service_rejects_batch_too_large(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+    envelopes = [
+        {"from": f"a{i}", "body": f"msg{i}", "thread": "t1"}
+        for i in range(http_server._A2A_MAX_IMPORT_BATCH + 1)
+    ]
+    with pytest.raises(ValueError, match="at most"):
+        asyncio.run(service.a2a_import(envelopes, data_dir=dd))
+
+
+def test_a2a_import_service_accepts_batch_at_boundary(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+    envelopes = [
+        {"from": f"a{i}", "body": f"msg{i}", "thread": "t1"}
+        for i in range(http_server._A2A_MAX_IMPORT_BATCH)
+    ]
+    result = asyncio.run(service.a2a_import(envelopes, data_dir=dd))
+    assert result["imported"] == http_server._A2A_MAX_IMPORT_BATCH
+    assert result["total"] == http_server._A2A_MAX_IMPORT_BATCH
+
+
+def test_a2a_import_service_dedup_gate_has_teeth(isolated_data_dir):
+    _setup_stores(isolated_data_dir)
+    dd = str(isolated_data_dir)
+    envelope = {"from": "agentA", "body": "teeth", "thread": "t1"}
+
+    asyncio.run(service.a2a_import([envelope], data_dir=dd))
+    stores = asyncio.run(taosmd_api._ensure_stores(dd))
+    archive = stores["archive"]
+    original_get = archive.get_import_dedup
+    async def _stub_get(key):
+        return None
+    archive.get_import_dedup = _stub_get  # type: ignore[assignment]
+    try:
+        result = asyncio.run(service.a2a_import([envelope], data_dir=dd))
+    finally:
+        archive.get_import_dedup = original_get  # type: ignore[assignment]
+    assert result["imported"] == 1
+    assert result["deduped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: auth parity with /a2a/send
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_no_token_refuses_and_nothing_written(authed_server):
+    base, data_dir, _ = authed_server
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "secret", "thread": "t1"},
+    ]})
+    assert s == 401, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_malformed_token_refuses_and_nothing_written(authed_server):
+    base, data_dir, _ = authed_server
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "secret", "thread": "t1"},
+    ]}, token="not-a-jwt-at-all")
+    assert s == 403, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_bad_signature_refuses_and_nothing_written(authed_server):
+    base, data_dir, _ = authed_server
+    bad_priv = Ed25519PrivateKey.generate()
+    bad_token = pyjwt.encode({"sub": "agentA", "iss": REGISTRY_ISS}, bad_priv, algorithm="EdDSA")
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "secret", "thread": "t1"},
+    ]}, token=bad_token)
+    assert s == 403, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_revoked_token_refuses_and_nothing_written(authed_server):
+    base, data_dir, revoked = authed_server
+    revoked.add("agentA")
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "secret", "thread": "t1"},
+    ]}, token=token)
+    assert s == 403, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_wrong_issuer_refuses_and_nothing_written(authed_server):
+    base, data_dir, _ = authed_server
+    wrong_iss_token = _make_token("agentA", iss="wrong-issuer")
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "secret", "thread": "t1"},
+    ]}, token=wrong_iss_token)
+    assert s == 403, body
+    assert "iss" in json.dumps(body).lower() or "registry auth" in json.dumps(body).lower()
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_valid_token_accepts_and_writes(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "hello import", "thread": "t1"},
+    ]}, token=token)
+    assert s == 200, body
+    assert body["imported"] == 1
+    assert body["total"] == 1
+    status, msgs_body = _get(f"{base}/a2a/messages?thread=t1")
+    assert status == 200, msgs_body
+    assert any(m["body"] == "hello import" for m in msgs_body.get("messages", []))
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: parity with /a2a/send for every branch
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_send_and_import_share_auth_gate(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "send", "thread": "t1"}, token=token)
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "import", "thread": "t1"},
+    ]}, token=token)
+    assert s_send == 200
+    assert s_import == 200
+
+
+def test_http_a2a_import_parity_no_token(authed_server):
+    base, data_dir, _ = authed_server
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "x", "thread": "t1"})
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1"},
+    ]})
+    assert s_send == s_import == 401
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_parity_malformed_token(authed_server):
+    base, data_dir, _ = authed_server
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "x", "thread": "t1"}, token="bad")
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1"},
+    ]}, token="bad")
+    assert s_send == s_import == 403
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_parity_bad_signature(authed_server):
+    base, data_dir, _ = authed_server
+    bad_priv = Ed25519PrivateKey.generate()
+    bad_token = pyjwt.encode({"sub": "agentA", "iss": REGISTRY_ISS}, bad_priv, algorithm="EdDSA")
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "x", "thread": "t1"}, token=bad_token)
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1"},
+    ]}, token=bad_token)
+    assert s_send == s_import == 403
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_parity_revoked(authed_server):
+    base, data_dir, revoked = authed_server
+    revoked.add("agentA")
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "x", "thread": "t1"}, token=token)
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1"},
+    ]}, token=token)
+    assert s_send == s_import == 403
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_parity_wrong_issuer(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss="wrong-issuer")
+    s_send, _ = _post(f"{base}/a2a/send", {"from": "agentA", "body": "x", "thread": "t1"}, token=token)
+    s_import, _ = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1"},
+    ]}, token=token)
+    assert s_send == s_import == 403
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_parity_valid_token(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s_send, r_send = _post(f"{base}/a2a/send", {"from": "agentA", "body": "send-ok", "thread": "t1"}, token=token)
+    s_import, r_import = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "import-ok", "thread": "t1"},
+    ]}, token=token)
+    assert s_send == 200
+    assert s_import == 200
+    assert r_send["id"] > 0
+    assert r_import["imported"] == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: batch cap
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_batch_too_large_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    envelopes = [
+        {"from": f"a{i}", "body": f"m{i}", "thread": "t1"}
+        for i in range(http_server._A2A_MAX_IMPORT_BATCH + 1)
+    ]
+    s, body = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_batch_at_boundary_accepted(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    envelopes = [
+        {"from": f"a{i}", "body": f"m{i}", "thread": "t1"}
+        for i in range(http_server._A2A_MAX_IMPORT_BATCH)
+    ]
+    s, body = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s == 200, body
+    assert body["imported"] == http_server._A2A_MAX_IMPORT_BATCH
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: idempotency
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_idempotent(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    envelopes = [{"from": "agentA", "body": "once", "thread": "t1"}]
+
+    s1, b1 = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s1 == 200
+    assert b1["imported"] == 1
+
+    s2, b2 = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s2 == 200
+    assert b2["imported"] == 0
+    assert b2["deduped"] == 1
+
+    assert _count_a2a_events_via_http(base, "t1") == 1
+
+
+def test_http_a2a_import_partial_idempotent(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    envelopes = [
+        {"from": "agentA", "body": "first", "thread": "t1"},
+        {"from": "agentA", "body": "second", "thread": "t1"},
+    ]
+
+    s1, b1 = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s1 == 200
+    assert b1["imported"] == 2
+
+    s2, b2 = _post(f"{base}/a2a/import", {"envelopes": envelopes}, token=token)
+    assert s2 == 200
+    assert b2["deduped"] == 2
+    assert b2["imported"] == 0
+
+    assert _count_a2a_events_via_http(base, "t1") == 2
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: envelope validation
+# ---------------------------------------------------------------------------
+
+def test_http_a2a_import_missing_envelopes_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {}, token=token)
+    assert s == 400, body
+
+
+def test_http_a2a_import_envelope_missing_from_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"body": "no-from", "thread": "t1"},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_envelope_missing_body_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "thread": "t1"},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_bad_kind_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1", "kind": "invalid"},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_refs_too_many_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1", "refs": [{"kind": "doc"}] * 9},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_blocks_not_list_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": "x", "thread": "t1", "blocks": "not-a-list"},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0
+
+
+def test_http_a2a_import_message_too_large_returns_400(authed_server):
+    base, data_dir, _ = authed_server
+    token = _make_token("agentA", iss=REGISTRY_ISS)
+    big_body = "x" * (64 * 1024)
+    s, body = _post(f"{base}/a2a/import", {"envelopes": [
+        {"from": "agentA", "body": big_body, "thread": "t1"},
+    ]}, token=token)
+    assert s == 400, body
+    assert _count_a2a_events_via_http(base, "t1") == 0


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Re-land POST /a2a/import with issuer pinning on the import auth path (supersedes blocked PR #412)

Autonomous build of board card tsk-bdj4fv.

- Add POST /a2a/import endpoint for idempotent batch import of external
  chat envelopes onto the A2A bus.
- Fix DEFECT 1: the import auth path now routes through
  _registry_verifier.authorize() so the token issuer is pinned, matching
  /a2a/send and /a2a/mentions on every check.
- Add a2a_import service function with at-least-once write order
  (archive.record() then record_import_dedup).
- Cap batch length at _A2A_MAX_IMPORT_BATCH = 100 envelopes per batch.
- Add comprehensive auth parity tests for all 6 branches plus idempotency
  and batch cap tests.
- Add changelog fragment and update a2a-comms.md.

Red-first proof (wrong-issuer arm, issuer check disabled):

```text
FAILED tests/test_a2a_import.py::test_http_a2a_import_wrong_issuer_refuses_and_nothing_written - AssertionError
FAILED tests/test_a2a_import.py::test_http_a2a_import_parity_wrong_issuer - AssertionError
2 failed, 29 deselected in 1.27s
```

Green after fix:

```text
2 passed, 29 deselected in 1.25s
```

Files:
 changelog.d/tsk-bdj4fv-a2a-import.md |   7 +
 taosmd/archive.py                    |  26 +-
 taosmd/docs/a2a-comms.md             |   1 +
 taosmd/http_server.py                |  37 ++-
 taosmd/service.py                    |  88 ++++-
 tests/test_a2a_import.py             | 601 +++++++++++++++++++++++++++++++++++
 6 files changed, 757 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `POST /a2a/import` endpoint for importing batches of A2A envelopes.
  - Supports idempotent imports with duplicate detection and imported/deduplicated result counts.
  - Enforces envelope, message-size, reference, and batch-size limits.
  - Supports issuer-pinned registry authentication when configured.

- **Documentation**
  - Documented the import endpoint, request format, authentication, limits, and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->