### PR TITLE
The /a2a/inbox docs omit exclude_acked_by, and every auth test builds its verifier with expected_iss=None so the issuer pin production sets is unexercised

### DIFF
--- a/changelog.d/tsk-uz6ggr-a2a-issuer-pin.md
+++ b/changelog.d/tsk-uz6ggr-a2a-issuer-pin.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- A2A auth tests now pin the registry issuer in their verifier construction,
+  exercising the production `expected_iss=registry_auth.REGISTRY_ISS` check
+  instead of passing `expected_iss=None`. Wrong-issuer tokens are rejected with
+  401 on all four inbox-family endpoints, and a production-path test confirms
+  the pin is enforced when the verifier is built by `_make_handler` rather than
+  injected.
+
+### Docs
+
+- `GET /a2a/inbox` parameter list in `taosmd/http_server.py` and
+  `taosmd/docs/a2a-comms.md` now includes `exclude_acked_by`, with a description
+  of what it does (omits messages already acked by the named principal).

--- a/taosmd/docs/a2a-comms.md
+++ b/taosmd/docs/a2a-comms.md
@@ -511,7 +511,7 @@ because SQLite treats `LIMIT -1` as unbounded, so a cap written as
 | `GET`  | `/a2a/stream` | `?thread=&since=` | SSE stream (`text/event-stream`) |
 | `GET`  | `/a2a/channels` | — | `{"channels": [...]}` |
 | `GET`  | `/a2a/members` | `?channel=<name>` | `{"members": [...]}` |
-| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=` | `{"messages": [...]}` |
+| `GET`  | `/a2a/inbox` | `?consumer=&limit=&include_kinds=&exclude_acked_by=` | `{"messages": [...]}`; `exclude_acked_by` omits messages already acked by the named principal so the caller's result set is limited to messages that still need attention |
 | `POST` | `/a2a/inbox/advance` | body JSON `{"to_id": int}` | `{"ok": true}` (principal derived from the verified registry token `sub`; no standalone `?consumer=` fallback) |
 | `POST` | `/a2a/ack` | body JSON `{"message_id": int}` | `{"id", "acked_by", "ok"}` (principal derived from the verified registry token `sub`; no standalone `?consumer=` fallback) |
 | `GET`  | `/a2a/inbox/unhandled` | `?consumer=&limit=` | `{"messages": [...]}` |

--- a/taosmd/http_server.py
+++ b/taosmd/http_server.py
@@ -107,7 +107,7 @@ Endpoints
                             ``blocks``: optional list of arbitrary objects (no schema validation); when present, ``body`` must be non-empty
 ``GET  /a2a/messages``     ``?thread=&since=&limit=&fields=&format=``  -> ``{"messages": [...]}`` (``fields=id,sender,body`` projects keys; ``format=ndjson`` emits one message per line; ``since`` is an epoch timestamp in seconds, not a message id; values below 1e9 return 400)
 ``GET  /a2a/mentions``    ``?since=&limit=&reader=``                  -> ``{"messages": [...]}`` (requires registry auth; ``reader`` is derived from the verified token ``sub``, or supplied as a query parameter when no verifier is configured)
-``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter)
+``GET  /a2a/inbox``       ``?consumer=&limit=&include_kinds=&exclude_acked_by=``         -> ``{"messages": [...]}`` (``consumer`` is derived from the verified token ``sub`` when registry auth is configured; otherwise required as a query parameter; ``exclude_acked_by`` omits messages whose ``acked_by`` list contains the named principal)
 ``POST /a2a/inbox/advance`` ``{"to_id": int}``                           -> ``{"ok": true}`` (principal derived from the verified token ``sub``)
 ``POST /a2a/ack``          ``{"message_id": int}``                      -> ``{"id", "acked_by", "ok"}`` (``by`` derived from the verified token ``sub``)
 ``GET  /a2a/inbox/unhandled`` ``?consumer=&limit=``                     -> ``{"messages": [...]}`` (composed query: mentions past cursor minus acks)

--- a/tests/test_a2a_inbox_auth.py
+++ b/tests/test_a2a_inbox_auth.py
@@ -9,6 +9,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import threading
 import urllib.error
@@ -49,7 +50,7 @@ REG_PRIV_PEM, REG_PUB_PEM = _keypair()
 OTHER_PRIV_PEM, _OTHER_PUB_PEM = _keypair()
 
 
-def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=None):
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=registry_auth.REGISTRY_ISS):
     claims = {"sub": sub}
     if iss is not None:
         claims["iss"] = iss
@@ -104,10 +105,55 @@ def authed_server(tmp_path, monkeypatch):
         return json.dumps([])
 
     verifier = registry_auth.verifier_from_url(
-        "http://reg.test", opener=fake_opener, expected_iss=None,
+        "http://reg.test", opener=fake_opener, expected_iss=registry_auth.REGISTRY_ISS,
     )
     httpd = http_server.make_server(
         "127.0.0.1", 0, data_dir=str(data_dir), verifier=verifier,
+    )
+    httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
+    host, port = httpd.server_address[:2]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+        httpd.service_loop.close()
+
+
+@pytest.fixture
+def production_pinned_server(tmp_path, monkeypatch):
+    """Server that builds its registry verifier via the production code path.
+
+    No verifier is injected; ``registry_url`` is set in config so
+    ``_make_handler`` constructs the verifier itself, pinning the issuer to
+    ``registry_auth.REGISTRY_ISS`` exactly as production does.
+    """
+    data_dir = tmp_path / "taosmd-prod-pin"
+    data_dir.mkdir()
+    monkeypatch.setattr(taosmd_api, "_stores_cache", {})
+    cfg.set_a2a_auth_enforce(True, str(data_dir))
+    cfg.set_registry_url("http://reg.test", data_dir=str(data_dir))
+
+    real_urlopen = urllib.request.urlopen
+
+    def _fake_urlopen(req, timeout=None):
+        if hasattr(req, "full_url"):
+            url = req.full_url
+        else:
+            url = req
+        if url.endswith(registry_auth.PUBKEY_PATH):
+            return io.BytesIO(json.dumps({"pubkey": REG_PUB_PEM}).encode())
+        if url.endswith(registry_auth.REVOKED_PATH):
+            return io.BytesIO(b"[]")
+        return real_urlopen(req, timeout=timeout)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    httpd = http_server.make_server(
+        "127.0.0.1", 0, data_dir=str(data_dir),
     )
     httpd.service_loop.run(taosmd_api._ensure_stores(str(data_dir)))
     host, port = httpd.server_address[:2]
@@ -309,3 +355,33 @@ def test_inbox_unhandled_unknown_param_is_rejected(authed_server):
     token = _make_token("agent-1")
     status, _ = _get(f"{authed_server}/a2a/inbox/unhandled?foo=bar", token=token)
     assert status == 400
+
+
+def test_inbox_with_wrong_issuer_is_rejected(authed_server):
+    token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _get(f"{authed_server}/a2a/inbox", token=token)
+    assert status == 401
+
+
+def test_inbox_advance_with_wrong_issuer_is_rejected(authed_server):
+    token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _post(f"{authed_server}/a2a/inbox/advance", {"to_id": 5}, token=token)
+    assert status == 401
+
+
+def test_ack_with_wrong_issuer_is_rejected(authed_server):
+    token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _post(f"{authed_server}/a2a/ack", {"message_id": 1}, token=token)
+    assert status == 401
+
+
+def test_inbox_unhandled_with_wrong_issuer_is_rejected(authed_server):
+    token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _get(f"{authed_server}/a2a/inbox/unhandled", token=token)
+    assert status == 401
+
+
+def test_inbox_with_wrong_issuer_via_production_verifier_is_rejected(production_pinned_server):
+    token = _make_token("agent-1", iss="wrong-issuer")
+    status, _ = _get(f"{production_pinned_server}/a2a/inbox", token=token)
+    assert status == 401

--- a/tests/test_a2a_remote_forwarding.py
+++ b/tests/test_a2a_remote_forwarding.py
@@ -60,8 +60,8 @@ def _keypair():
 REG_PRIV_PEM, REG_PUB_PEM = _keypair()
 
 
-def _make_token(sub, priv_pem=REG_PRIV_PEM):
-    return pyjwt.encode({"sub": sub}, priv_pem, algorithm="EdDSA")
+def _make_token(sub, priv_pem=REG_PRIV_PEM, iss=registry_auth.REGISTRY_ISS):
+    return pyjwt.encode({"sub": sub, "iss": iss}, priv_pem, algorithm="EdDSA")
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +102,7 @@ def authed_live_server(tmp_path, monkeypatch):
         return json.dumps([])
 
     verifier = registry_auth.verifier_from_url(
-        "http://reg.test", opener=fake_opener, expected_iss=None,
+        "http://reg.test", opener=fake_opener, expected_iss=registry_auth.REGISTRY_ISS,
     )
 
     # Pre-seed via local service layer before the server starts, then clear


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): The /a2a/inbox docs omit exclude_acked_by, and every auth test builds its verifier with expected_iss=None so the issuer pin production sets is unexercised

Autonomous build of board card tsk-uz6ggr.

ITEM 1: Added exclude_acked_by to GET /a2a/inbox parameter lists in
taosmd/http_server.py module docstring and taosmd/docs/a2a-comms.md, with
a description of what it does (omits messages already acked by the named
principal).

ITEM 2: Both A2A auth test files now build their registry verifier with
expected_iss=registry_auth.REGISTRY_ISS instead of expected_iss=None, so
the issuer pin is exercised. Added wrong-issuer rejection tests for all
four inbox-family endpoints, plus a production-path test that builds the
verifier via _make_handler (no verifier injected) to prove the pin is
pinned. Removing the expected_iss argument from the production verifier
construction causes the production-path test to fail with 200 instead of
401.

I read the resulting prose back against the handler and confirmed every
parameter listed is real and every real parameter is listed.

RED-FIRST proof: with the production pin removed (expected_iss=None),
test_inbox_with_wrong_issuer_via_production_verifier_is_rejected fails:

```
FAILED tests/test_a2a_inbox_auth.py::test_inbox_with_wrong_issuer_via_production_verifier_is_rejected
assert 200 == 401
1 failed, 11 passed in 3.98s
```

After restoring the pin, all 31 tests pass.

Files:
 changelog.d/tsk-uz6ggr-a2a-issuer-pin.md | 14 ++++++
 taosmd/docs/a2a-comms.md                 |  2 +-
 taosmd/http_server.py                    |  2 +-
 tests/test_a2a_inbox_auth.py             | 80 +++++++++++++++++++++++++++++++-
 tests/test_a2a_remote_forwarding.py      |  6 +--
 5 files changed, 97 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * A2A authentication now rejects tokens issued by an unexpected issuer across inbox-related endpoints.

* **Documentation**
  * Documented the `exclude_acked_by` parameter for `GET /a2a/inbox`, including that it excludes messages already acknowledged by the specified principal.

* **Tests**
  * Added coverage confirming issuer validation in both direct and production authentication paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->