### PR TITLE
ReceiptStore is the ONLY genuinely cross-thread SQLite connection in the repo and it holds ZERO locks while doing multi-statement writes

### DIFF
--- a/changelog.d/tsk-bsbwmb-receipt-thread-invariant.md
+++ b/changelog.d/tsk-bsbwmb-receipt-thread-invariant.md
@@ -1,0 +1,2 @@
+### Fixed
+- `ReceiptStore` now opens its SQLite connection with the default `check_same_thread=True` instead of `check_same_thread=False`. All production callers create and use the connection on the single `_ServiceLoop` service-loop thread, so the default is correct and SQLite now enforces the single-thread invariant for us. A genuine cross-thread use raises `sqlite3.ProgrammingError` instead of silently corrupting data.

--- a/taosmd/receipts.py
+++ b/taosmd/receipts.py
@@ -48,11 +48,10 @@ class ReceiptStore:
     All methods are async so callers can ``await`` them uniformly; the body
     runs synchronously against a single SQLite connection. The connection is
     opened through ``taosmd._db.connect`` (WAL journal mode, 5000 ms busy
-    timeout) with ``check_same_thread=False`` so it stays usable from whichever
-    thread drives the event loop -- the async methods here are not guaranteed
-    to run on the creating thread, so ``check_same_thread=False`` is required
-    to avoid a thread-affinity crash, and routing through ``_db.connect`` is
-    required to get WAL and the busy timeout.
+    timeout). Under the ``_ServiceLoop`` design every store connection is
+    created and used on the single service-loop thread, so the default
+    ``check_same_thread=True`` is correct and SQLite enforces the invariant
+    for us.
     """
 
     def __init__(self, db_path: str) -> None:
@@ -60,7 +59,7 @@ class ReceiptStore:
         self._conn: sqlite3.Connection | None = None
 
     async def init(self) -> None:
-        self._conn = _db.connect(self._db_path, check_same_thread=False)
+        self._conn = _db.connect(self._db_path)
         self._conn.row_factory = sqlite3.Row
         _db.run_schema(self._conn, SCHEMA)
         self._conn.commit()

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 import threading
 import urllib.error
 import urllib.request
@@ -253,20 +254,23 @@ def test_receipt_store_uses_wal_and_busy_timeout(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Thread-affinity: connection must stay usable across threads
+# Thread-affinity: connection must reject cross-thread use
 # ---------------------------------------------------------------------------
 
-def test_receipt_store_usable_from_non_creating_thread():
-    """check_same_thread=False keeps the connection usable cross-thread.
+def test_receipt_store_cross_thread_raises():
+    """check_same_thread=True (the default) means a worker-thread write raises.
 
-    ReceiptStore's async methods may be driven by any event loop or thread, so
-    the connection must not demand thread affinity (the default for
-    ``sqlite3.connect``). This pins that behaviour so a naive swap back to the
-    default does not turn the concurrency fix into a thread-affinity crash.
+    ReceiptStore uses the default check_same_thread=True because all
+    production callers touch it only from the _ServiceLoop thread. A
+    worker thread that tries to write through a connection created on the
+    main thread must raise sqlite3.ProgrammingError, not silently
+    corrupt data.
     """
     import tempfile
     with tempfile.TemporaryDirectory() as tmp:
-        db_path = str(Path(tmp) / "a2a-receipts.db")
+        data_dir = Path(tmp) / "receipt-test-data"
+        data_dir.mkdir()
+        db_path = str(data_dir / "a2a-receipts.db")
         store = receipts.ReceiptStore(db_path=db_path)
         asyncio.run(store.init())  # connection created on the main thread
         outcome: dict = {}
@@ -274,17 +278,18 @@ def test_receipt_store_usable_from_non_creating_thread():
         def worker() -> None:
             try:
                 asyncio.run(store.record_delivered(1, "alice", 100.0))
-                got = asyncio.run(store.get_receipt(1, "alice"))
-                outcome["ok"] = got
+                outcome["ok"] = True
+            except sqlite3.ProgrammingError as exc:
+                outcome["error"] = exc
             except Exception as exc:  # noqa: BLE001
-                outcome["err"] = repr(exc)
+                outcome["other"] = repr(exc)
 
         t = threading.Thread(target=worker)
         t.start()
         t.join()
         try:
-            assert "err" not in outcome, outcome.get("err")
-            assert outcome["ok"]["delivered_at"] == 100.0
+            assert "error" in outcome, f"expected ProgrammingError, got {outcome}"
+            assert outcome.get("ok") is not True
         finally:
             asyncio.run(store.close())
 

--- a/tests/test_receipts_thread_affinity.py
+++ b/tests/test_receipts_thread_affinity.py
@@ -1,27 +1,28 @@
 """Thread-affinity pin for ReceiptStore.
 
-ReceiptStore is opened through ``_db.connect(..., check_same_thread=False)``
-because its async methods may be driven from any thread (the event loop is not
-guaranteed to run on the creating thread). These tests fail with
-``sqlite3.ProgrammingError: SQLite objects created in a thread can only be
-used in that same thread`` if ``check_same_thread=False`` is dropped from the
-connect call -- i.e. they are RED without that flag.
+ReceiptStore is opened through ``_db.connect`` with the default
+``check_same_thread=True`` because all production callers touch it only from
+the ``_ServiceLoop`` service-loop thread. These tests verify that a genuine
+cross-thread use raises ``sqlite3.ProgrammingError`` rather than silently
+corrupting data, and that same-thread use continues to work.
 """
 
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import threading
 
 from taosmd import receipts
 
 
-def test_receipt_store_usable_from_non_creating_thread(tmp_path):
-    """A connection created on one thread must work on another.
+def test_receipt_store_cross_thread_raises(tmp_path):
+    """A connection created on one thread must raise when used on another.
 
-    RED without ``check_same_thread=False`` on the connect call: the worker
-    thread's write raises ``ProgrammingError``. With the flag the write
-    succeeds and the row is readable from the same worker thread.
+    ReceiptStore uses ``check_same_thread=True`` (the default) so SQLite
+    enforces single-thread access. A worker thread that tries to write
+    through a connection created on the main thread must raise
+    ``ProgrammingError``, not silently corrupt data.
     """
     db_path = str(tmp_path / "receipts.db")
     store = receipts.ReceiptStore(db_path=db_path)
@@ -31,14 +32,16 @@ def test_receipt_store_usable_from_non_creating_thread(tmp_path):
     def worker() -> None:
         try:
             asyncio.run(store.record_delivered(1, "alice", 100.0))
-            outcome["receipt"] = asyncio.run(store.get_receipt(1, "alice"))
+            outcome["ok"] = True
+        except sqlite3.ProgrammingError as exc:
+            outcome["error"] = exc
         except Exception as exc:  # noqa: BLE001
-            outcome["error"] = repr(exc)
+            outcome["other"] = repr(exc)
 
     t = threading.Thread(target=worker)
     t.start()
     t.join()
     asyncio.run(store.close())
 
-    assert "error" not in outcome, outcome.get("error")
-    assert outcome["receipt"]["delivered_at"] == 100.0
+    assert "error" in outcome, f"expected ProgrammingError, got {outcome}"
+    assert outcome.get("ok") is not True


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): ReceiptStore is the ONLY genuinely cross-thread SQLite connection in the repo and it holds ZERO locks while doing multi-statement writes

Autonomous build of board card tsk-bsbwmb.

Chose option (b): drop check_same_thread=False. The runtime thread-identity
probe showed zero cross-thread use on the standalone serve path, and
ReceiptStore is created and used only on the _ServiceLoop thread via
runner.run(). All 15 other SQLite store connections already use the default
check_same_thread=True. SQLite now enforces the single-thread invariant
automatically: a genuine cross-thread use raises ProgrammingError instead
of silently corrupting data.

RED-FIRST proof:

```
FAILED tests/test_receipts_thread_affinity.py::test_receipt_store_cross_thread_raises - AssertionError: expected ProgrammingError, got {'ok': True}
```

```
tests/test_receipts_thread_affinity.py::test_receipt_store_cross_thread_raises PASSED
```

Full suite: 2005 passed, 12 skipped, 1 failed (pre-existing
test_resume_arm_time.py unrelated to this change).

Files:
 changelog.d/tsk-bsbwmb-receipt-thread-invariant.md |  2 ++
 taosmd/receipts.py                                 | 11 ++++----
 tests/test_receipts.py                             | 31 +++++++++++---------
 tests/test_receipts_thread_affinity.py             | 33 ++++++++++++----------
 4 files changed, 43 insertions(+), 34 deletions(-)