### PR TITLE
Two suite tests fail under host load, which silently corrupts the count-comparison the merge protocol depends on

### DIFF
--- a/changelog.d/tsk-5wdkh4-sqlite-busy-timeout.md
+++ b/changelog.d/tsk-5wdkh4-sqlite-busy-timeout.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `taosmd/_db.py` raises `BUSY_TIMEOUT_MS` from 5000 to 30000, giving SQLite
+  connections a longer window to wait out `database is locked` contention before
+  raising. This prevents `test_concurrent_first_init_is_deterministic` from
+  flaking under host load when multiple fork workers race first-time schema init
+  on the same fresh database.

--- a/taosmd/_db.py
+++ b/taosmd/_db.py
@@ -28,7 +28,7 @@ from typing import Union
 
 # Allow a contended connection to block-and-retry for this many milliseconds
 # before raising ``sqlite3.OperationalError: database is locked``.
-BUSY_TIMEOUT_MS = 5000
+BUSY_TIMEOUT_MS = 30000
 
 # Number of attempts (the first plus retries) ``run_schema`` makes when the
 # schema DDL hits a transient ``SQLITE_BUSY`` / ``database is locked`` error.

--- a/tests/test_http_server_registry_auth.py
+++ b/tests/test_http_server_registry_auth.py
@@ -41,7 +41,7 @@ def _keypair():
 PRIV_PEM, PUB_PEM = _keypair()
 
 
-def _post_send(base_url, from_, body, token=None):
+def _post_send(base_url, from_, body, token=None, timeout=30):
     payload = json.dumps({"from": from_, "body": body}).encode()
     headers = {"Content-Type": "application/json"}
     if token:
@@ -49,7 +49,7 @@ def _post_send(base_url, from_, body, token=None):
     req = urllib.request.Request(base_url + "/a2a/send", data=payload,
                                  headers=headers, method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status, json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read().decode() or "{}")
@@ -253,7 +253,7 @@ def _make_token(sub, project_id=None, iss=None):
     return pyjwt.encode(claims, PRIV_PEM, algorithm="EdDSA")
 
 
-def _post_json(base_url, path, payload, token=None):
+def _post_json(base_url, path, payload, token=None, timeout=30):
     data = json.dumps(payload).encode()
     headers = {"Content-Type": "application/json"}
     if token:
@@ -261,19 +261,19 @@ def _post_json(base_url, path, payload, token=None):
     req = urllib.request.Request(base_url + path, data=data,
                                  headers=headers, method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status, json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read().decode() or "{}")
 
 
-def _get_json(base_url, path, token=None):
+def _get_json(base_url, path, token=None, timeout=30):
     headers = {}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(base_url + path, headers=headers, method="GET")
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status, json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read().decode() or "{}")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Two suite tests fail under host load, which silently corrupts the count-comparison the merge protocol depends on

Autonomous build of board card tsk-5wdkh4.

- Raise _db.BUSY_TIMEOUT_MS from 5000 to 30000 so concurrent first-time
  SQLite schema init waits long enough under host load instead of raising
  database is locked mid-test.
- Bump the default timeout in the HTTP test helpers from 5s to 30s so
  test_no_token_ingest_is_unchanged does not TimeoutError when the
  spawned server's qmd-embed fallback ingest is slowed by load.

Both fixes are verified green under 4 CPU-bound worker artificial load,
with the full test_http_server_registry_auth.py and test_db_run_schema.py
files as positive controls in the same run.

Files:
 changelog.d/tsk-5wdkh4-sqlite-busy-timeout.md |  7 +++++++
 taosmd/_db.py                                 |  2 +-
 tests/test_http_server_registry_auth.py       | 12 ++++++------
 3 files changed, 14 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced intermittent SQLite “database is locked” errors during concurrent database initialization by allowing connections more time to wait.
  - Improved reliability of HTTP operations that may require longer than five seconds to complete by supporting a 30-second timeout in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->