### PR TITLE
Four GET /a2a/* handlers have no unknown-param test in either direction: inbox, inbox/unhandled, thread_messages, list_members

### DIFF
--- a/changelog.d/tsk-ppys26-a2a-strict-params-coverage.md
+++ b/changelog.d/tsk-ppys26-a2a-strict-params-coverage.md
@@ -1,0 +1,3 @@
+### Added
+
+- Strict-param 400 tests for `GET /a2a/inbox`, `GET /a2a/inbox/unhandled`, `GET /a2a/threads/{thread}/messages` (blank-value case), and `GET /a2a/threads/{thread}/members`, covering both empty-valued (`?bogus=`) and non-empty (`?bogus=x`) unknown query parameters.

--- a/tests/test_a2a_kinds_strict_params.py
+++ b/tests/test_a2a_kinds_strict_params.py
@@ -341,6 +341,38 @@ def test_http_a2a_thread_messages_unknown_param_returns_400(live_server):
     assert "bogus" in body["error"]
 
 
+def test_http_a2a_inbox_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/inbox?consumer=agentA&bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_inbox_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/inbox?consumer=agentA&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_inbox_unhandled_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/inbox/unhandled?consumer=agentA&bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_inbox_unhandled_blank_unknown_param_returns_400(live_server):
+    status, body = _get(f"{live_server}/a2a/inbox/unhandled?consumer=agentA&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_list_members_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/threads",
+          {"thread": "list-members-test", "participants": ["agentA"], "agent": "agentA"})
+    status, body = _get(f"{live_server}/a2a/threads/list-members-test/members?bogus=1")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
 def test_http_a2a_channels_unknown_param_returns_400(live_server):
     status, body = _get(f"{live_server}/a2a/channels?bogus=1")
     assert status == 400, body
@@ -672,6 +704,22 @@ def test_http_a2a_census_blank_unknown_param_returns_400(live_server):
 
 def test_http_a2a_members_blank_unknown_param_returns_400(live_server):
     status, body = _get(f"{live_server}/a2a/members?channel=general&bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_thread_messages_blank_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/send",
+          {"from": "agentA", "body": "msg", "thread": "blank-tm-test"})
+    status, body = _get(f"{live_server}/a2a/threads/blank-tm-test/messages?bogus=")
+    assert status == 400, body
+    assert "bogus" in body["error"]
+
+
+def test_http_a2a_list_members_blank_unknown_param_returns_400(live_server):
+    _post(f"{live_server}/a2a/threads",
+          {"thread": "blank-list-members-test", "participants": ["agentA"], "agent": "agentA"})
+    status, body = _get(f"{live_server}/a2a/threads/blank-list-members-test/members?bogus=")
     assert status == 400, body
     assert "bogus" in body["error"]
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Four GET /a2a/* handlers have no unknown-param test in either direction: inbox, inbox/unhandled, thread_messages, list_members

Autonomous build of board card tsk-ppys26.

Adds 7 tests covering all four previously untested GET /a2a/* handlers
with both empty-valued (?bogus=) and non-empty (?bogus=x) unknown query
parameters, matching the shape of the existing strict-params suite.

Handlers and line numbers:
- _handle_a2a_inbox (http_server.py:1919): 2 new tests
- _handle_a2a_inbox_unhandled (http_server.py:2006): 2 new tests
- _handle_a2a_thread_messages (http_server.py:2109): 1 new blank test
- _handle_a2a_list_members (http_server.py:2152): 2 new tests

Proof (validator neutered by line number, positive controls pass):
- inbox line 1919 commented: FAILED 2, passed 50
- inbox/unhandled line 2006 commented: FAILED 2, passed 50
- thread_messages line 2109 commented: FAILED 2, passed 50
- list_members line 2152 commented: FAILED 2, passed 50

Files:
 .../tsk-ppys26-a2a-strict-params-coverage.md       |  3 ++
 tests/test_a2a_kinds_strict_params.py              | 48 ++++++++++++++++++++++
 2 files changed, 51 insertions(+)